### PR TITLE
Tiny fix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Software versions
 
 - HOL4 commit: `d0a474d1d1cba7c32acb6056a6288c44c2f1a75b`
-- PolyML (e.g. standard Ubuntu) 5.6
+- PolyML (e.g. current polyml version packaged for Ubuntu, 5.7.1)
 
 
 # How to compile
@@ -35,12 +35,11 @@ Follow these instructions whenever you merge to master:
 
 ### `dev` branch
 
-* `dev` is the branch where every feature is available, but no necessarily
-  finalized:
-  * Can cheat
-  * Code can be commented out
-  * **Holmake must work**
-  * bug-fixes are ok
+`dev` is the branch where every feature is available, but not necessarily finalized:
+  - Can cheat
+  - Code can be commented out
+  - **Holmake must work**
+  - bug-fixes are ok
 
 However, **no development happens on this branch**, but rather on separate
 feature branches.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Software versions
 
 - HOL4 commit: `d0a474d1d1cba7c32acb6056a6288c44c2f1a75b`
-- PolyML (e.g. current polyml version packaged for Ubuntu, 5.7.1)
+- Poly/ML (e.g. current Poly/ML version packaged for Ubuntu, 5.7.1)
 
 
 # How to compile
 
 * First, run `make [main|examples|benchmarks|...]` in the root directory,
   according to your needs.
-* Then, go in the directory you want to use and run `{HOLDIR}/bin/Holmake`.
+* Then, go into the directory you want to use and run `{HOLDIR}/bin/Holmake`.
 * If one of the previous steps fails, try to clean your Git working directory by
   `make cleanslate` in the project root directory. **Be careful though**, this
   command is quite dangerous as it can easily eat your files (`Holmakefile`s are


### PR DESCRIPTION
I don't think anyone is using Poly/ML 5.6 at this point, and it is also not the standard package available in contemporary Ubuntu versions. It would not be advisable to redirect people to this version, since it can cause Holmake utilizing multiple cores to randomly fail. Therefore I suggest the following slight update to the README.

(if you want to check your Poly/ML version, do `poly -v`)