### PR TITLE
WP: wps_id_prefix + BL_Label support + dependencies fix +  MemEq&imp in bir_expLib

### DIFF
--- a/src/examples/aes/wp-test.sml
+++ b/src/examples/aes/wp-test.sml
@@ -35,7 +35,7 @@ val lbl_list = (gen_lbl_list o snd o dest_eq o concl) aes_wps1_def;
 val wp_def_list = aes_post_def::(List.map
       (fn lbl_str =>
       let
-        val (_, (def_thm, _)) = hd (DB.find ("bir_wp_comp_wps_iter_step2_wp_" ^ lbl_str));
+        val (_, (def_thm, _)) = hd (DB.find (bir_wpLib.wps_id_prefix ^ lbl_str));
       in def_thm end
       ) (tl (List.rev lbl_list)));
 
@@ -69,7 +69,7 @@ val (lbl_last, wp_last) = (dest_pair o snd o dest_fupdate) wps1;
 fun eval_through [] thm = [thm]
   | eval_through (lbl_str::lbls) thm_in =
       let
-        val (_, (def_thm, _)) = hd (DB.find ("bir_wp_comp_wps_iter_step2_wp_" ^ lbl_str));
+        val (_, (def_thm, _)) = hd (DB.find (bir_wpLib.wps_id_prefix ^ lbl_str));
         val thm = REWRITE_RULE [thm_in] def_thm;
         val thm_evald = (EVAL o snd o dest_eq o concl) thm;
         val thm_new = (TRANS thm thm_evald);
@@ -84,7 +84,7 @@ val lbl_list_todo = List.take ((tl (List.rev lbl_list)), 70);
 val wp_w_subst1 =
   let
     val lbl_str = List.last lbl_list_todo;
-    val (_, (def_thm, _)) = hd (DB.find ("bir_wp_comp_wps_iter_step2_wp_" ^ lbl_str));
+    val (_, (def_thm, _)) = hd (DB.find (bir_wpLib.wps_id_prefix ^ lbl_str));
   in
     (snd o dest_eq o concl) (computeLib.RESTR_EVAL_CONV [``bir_exp_subst1``] ((fst o dest_eq o concl) def_thm))
   end;

--- a/src/examples/aes/wp/aesM0SimpWpScript.sml
+++ b/src/examples/aes/wp/aesM0SimpWpScript.sml
@@ -35,7 +35,7 @@ val i = if take_all then
 
 val lbl_str = List.nth (lbl_list, (List.length lbl_list) - 2 - i + 1);
 
-val def_thm = lookup_def ("bir_wp_comp_wps_iter_step2_wp_" ^ lbl_str);
+val def_thm = lookup_def (bir_wpLib.wps_id_prefix ^ lbl_str);
 val def_const = (fst o dest_eq o concl) def_thm;
 
 

--- a/src/examples/aes/wp/aesSimpWpScript.sml
+++ b/src/examples/aes/wp/aesSimpWpScript.sml
@@ -35,7 +35,7 @@ val i = if take_all then
 
 val lbl_str = List.nth (lbl_list, (List.length lbl_list) - 2 - i + 1);
 
-val def_thm = lookup_def ("bir_wp_comp_wps_iter_step2_wp_" ^ lbl_str);
+val def_thm = lookup_def (bir_wpLib.wps_id_prefix ^ lbl_str);
 val def_const = (fst o dest_eq o concl) def_thm;
 
 

--- a/src/libs/bir_expLib.sml
+++ b/src/libs/bir_expLib.sml
@@ -106,6 +106,13 @@ struct
           ((xf "(") cf (ef exp1) cf (xf " ") cf (xf bpredopstr) cf (xf " ") cf (ef exp2) cf (xf ")"))
         end
 
+      else if is_BExp_MemEq exp then
+        let
+          val (exp1, exp2) = (dest_BExp_MemEq) exp;
+        in
+          ((xf "(") cf (ef exp1) cf (xf " = ") cf (ef exp2) cf (xf ")"))
+        end
+
       else if is_BExp_IfThenElse exp then
         let
           val (expc, expt, expf) = (dest_BExp_IfThenElse) exp;

--- a/src/libs/bir_expLib.sml
+++ b/src/libs/bir_expLib.sml
@@ -1,92 +1,66 @@
 structure bir_expLib =
 struct
 
+  local
+
   open HolKernel boolLib liteLib simpLib Parse bossLib;
 
   open bir_expSyntax bir_immSyntax bir_envSyntax bir_exp_immSyntax bir_exp_memSyntax;
+  open bir_bool_expSyntax;
 
+  val ERR = Feedback.mk_HOL_ERR "bir_expLib";
 
+  in
 
+  fun castt_to_string castt =
+    if is_BIExp_LowCast castt then "CL"
+    else if is_BIExp_HighCast castt then "CH"
+    else if is_BIExp_SignedCast castt then "CS"
+    else if is_BIExp_UnsignedCast castt then "CU"
+    else raise ERR "castt_to_string"
+      ("don't know how to print BIR cast-type: " ^ (term_to_string castt));
 
-  fun castt_to_string castt = if is_BIExp_LowCast castt then
-                                   "CL"
-                              else if is_BIExp_HighCast castt then
-                                   "CH"
-                              else if is_BIExp_SignedCast castt then
-                                   "CS"
-                              else if is_BIExp_UnsignedCast castt then
-                                   "CU"
-                              else
-                                   raise (ERR "castt_to_string" "don't know how to print BIR casttype")
-                              ;
+  fun bop_to_string bop =
+    if is_BIExp_And bop then "&"
+    else if is_BIExp_Or bop then "|"
+    else if is_BIExp_Xor bop then "^"
+    else if is_BIExp_Plus bop then "+"
+    else if is_BIExp_Minus bop then "-"
+    else if is_BIExp_Mult bop then "*"
+    else if is_BIExp_Div bop then "/"
+    else if is_BIExp_SignedDiv bop then "s/"
+    else if is_BIExp_Mod bop then "%"
+    else if is_BIExp_SignedMod bop then "s<<"
+    else if is_BIExp_LeftShift bop then "<<"
+    else if is_BIExp_RightShift bop then ">>"
+    else if is_BIExp_SignedRightShift bop then "s>>"
+    else raise ERR "bop_to_string"
+      ("don't know how to print BIR bin-op: " ^ (term_to_string bop));
 
-  fun bop_to_string bop = if is_BIExp_And bop then
-                               "&"
-                          else if is_BIExp_Or bop then
-                               "|"
-                          else if is_BIExp_Xor bop then
-                               "^"
-                          else if is_BIExp_Plus bop then
-                               "+"
-                          else if is_BIExp_Minus bop then
-                               "-"
-                          else if is_BIExp_Mult bop then
-                               "*"
-                          else if is_BIExp_Div bop then
-                               "/"
-                          else if is_BIExp_SignedDiv bop then
-                               "s/"
-                          else if is_BIExp_Mod bop then
-                               "%"
-                          else if is_BIExp_SignedMod bop then
-                               "s<<"
-                          else if is_BIExp_LeftShift bop then
-                               "<<"
-                          else if is_BIExp_RightShift bop then
-                               ">>"
-                          else if is_BIExp_SignedRightShift bop then
-                               "s>>"
-                          else
-                               raise (ERR "bop_to_string" "don't know how to print BIR binop")
-                          ;
+  fun bpredop_to_string bpredop =
+    if is_BIExp_Equal bpredop then "=="
+    else if is_BIExp_NotEqual bpredop then "<>"
+    else if is_BIExp_LessThan bpredop then "<"
+    else if is_BIExp_SignedLessThan bpredop then "s<"
+    else if is_BIExp_LessOrEqual bpredop then "<="
+    else if is_BIExp_SignedLessOrEqual bpredop then "s<="
+    else raise ERR "bpredop_to_string"
+      ("don't know how to print BIR bin-pred-op: " ^ (term_to_string bpredop));
 
-  fun bpredop_to_string bpredop = if is_BIExp_Equal bpredop then
-                                       "=="
-                                  else if is_BIExp_NotEqual bpredop then
-                                       "<>"
-                                  else if is_BIExp_LessThan bpredop then
-                                       "<"
-                                  else if is_BIExp_SignedLessThan bpredop then
-                                       "s<"
-                                  else if is_BIExp_LessOrEqual bpredop then
-                                       "<="
-                                  else if is_BIExp_SignedLessOrEqual bpredop then
-                                       "s<="
-                                  else
-                                       raise (ERR "bpredop_to_string" "don't know how to print BIR binpredop")
-                                  ;
+  fun uop_to_string uop =
+    if is_BIExp_ChangeSign uop then "-"
+    else if is_BIExp_Not uop then "!"
+    else if is_BIExp_CLZ uop then "($CLZ)"
+    else if is_BIExp_CLS uop then "($CLS)"
+    else raise ERR "uop_to_string"
+      ("don't know how to print BIR unary-op: " ^ (term_to_string uop));
 
-  fun uop_to_string uop = if is_BIExp_ChangeSign uop then
-                               "-"
-                          else if is_BIExp_Not uop then
-                               "!"
-                          else if is_BIExp_CLZ uop then
-                               "($CLZ)"
-                          else if is_BIExp_CLS uop then
-                               "($CLS)"
-                          else
-                               raise (ERR "uop_to_string" "don't know how to print BIR unaryop")
-                          ;
-
-  fun endi_to_string endi = if is_BEnd_BigEndian endi then
-                                 "B"
-                            else if is_BEnd_LittleEndian endi then
-                                 "L"
-                            else if is_BEnd_NoEndian endi then
-                                 "N"
-                            else
-                                 raise (ERR "endi_to_string" "don't know how to print endianness")
-                            ;
+  fun endi_to_string endi =
+    if is_BEnd_BigEndian endi then "B"
+    else if is_BEnd_LittleEndian endi then "L"
+    else if is_BEnd_NoEndian endi then "N"
+    else raise ERR "endi_to_string"
+      ("don't know how to print endianness: " ^ (term_to_string endi));
 
   fun bir_exp_to_x xf cf exp =
     let
@@ -156,8 +130,15 @@ struct
           ((xf "(") cf (ef expm) cf (xf ":") cf (xf endistr) cf (xf "[") cf (ef expad) cf (xf "] = ") cf (ef expv) cf (xf ")"))
         end
 
+      else if is_bir_exp_imp exp then
+        let
+          val (bir_lhs, bir_rhs) = dest_bir_exp_imp exp
+        in
+          ((xf "(") cf (ef bir_lhs) cf (xf "==>") cf (ef bir_rhs) cf (xf ")"))
+        end
+
       else
-        raise (ERR "bir_exp_to_x" "don't know BIR expression")
+        raise (ERR "bir_exp_to_x" ("don't know BIR expression: '" ^ term_to_string exp ^ "'"))
 
     end;
 
@@ -254,7 +235,7 @@ val _ = bir_exp_pretty_print exp;
           (bir_exp_vars_in_exp expm) @ (bir_exp_vars_in_exp expad) @ (bir_exp_vars_in_exp expv)
         end
       else
-        raise (ERR "bir_exp_vars_in_exp" "don't know BIR expression")
+        raise (ERR "bir_exp_vars_in_exp" ("don't know BIR expression: '" ^ term_to_string exp ^ "'"))
       ;
 
   fun bir_exp_dist_vars_in_exp exp =
@@ -264,6 +245,6 @@ val _ = bir_exp_pretty_print exp;
       List.foldr (fn (var, vl) => if List.exists (fn x => x = var) vl then vl else var::vl) [] vars
     end;
 
-
+  end (* local *)
 
 end

--- a/src/tools/cfg/bir_cfgLib.sml
+++ b/src/tools/cfg/bir_cfgLib.sml
@@ -1,6 +1,15 @@
 structure bir_cfgLib =
 struct
 
+local
+
+open HolKernel Parse boolLib bossLib;
+open bir_programSyntax;
+
+val ERR = Feedback.mk_HOL_ERR "bir_cfgLib";
+
+in
+
 (*
 =================================================================
               translate to edge by node list
@@ -431,6 +440,6 @@ bir_show_graph_inout true nodes g
 
 *)
 
+end (* local *)
 
-end
-
+end (* bir_cfgLib *)

--- a/src/tools/cfg/bir_cfgVizLib.sml
+++ b/src/tools/cfg/bir_cfgVizLib.sml
@@ -1,12 +1,18 @@
 structure bir_cfgVizLib =
 struct
 
-open HolKernel Parse;
+local
+
+open HolKernel Parse boolLib bossLib;
+open bir_programSyntax;
 open bir_immSyntax;
 open graphVizLib;
 open bir_cfgLib;
+open listSyntax;
 
 val ERR = mk_HOL_ERR "bir_cfgVizLib"
+
+in
 
 (*---------------------------------------------------------------------------*)
 
@@ -147,5 +153,7 @@ fun bir_show_graph_from_prog prog path =
   in
     bir_show_graph_inout_all simplified (blocks, in_idxs, out_idxs)
   end;
+
+end (* local *)
 
 end (* bir_cfgVizLib *)

--- a/src/tools/cfg/graphVizLib.sml
+++ b/src/tools/cfg/graphVizLib.sml
@@ -1,6 +1,13 @@
 structure graphVizLib =
 struct
 
+local
+
+open HolKernel Parse boolLib bossLib;
+
+val ERR = mk_HOL_ERR "graphVizLib";
+
+in
 
 (*
  ----------------------------------------
@@ -233,6 +240,6 @@ val _ = writeToFile dot_str (file ^ ".dot");
 val _ = convertAndView file;
 *)
 
+end (* local *)
 
-end
-
+end (* graphVizLib *)

--- a/src/tools/lifter/bir_lifter_simple_interfaceLib.sml
+++ b/src/tools/lifter/bir_lifter_simple_interfaceLib.sml
@@ -1,3 +1,10 @@
+structure bir_lifter_simple_interfaceLib =
+struct
+
+local
+
+open bir_expSyntax bir_immSyntax bir_envSyntax bir_exp_immSyntax bir_exp_memSyntax;
+open bir_bool_expSyntax;
 
 open bir_inst_liftingLib;
 open gcc_supportLib;
@@ -5,11 +12,7 @@ open gcc_supportLib;
 open listSyntax;
 open bir_expLib;
 
-
-structure bir_lifter_simple_interfaceLib =
-struct
-
-
+in (* local *)
 
 val log = ref TextIO.stdOut;
 
@@ -541,8 +544,6 @@ val arch_str = "m0";
 val thm_prog = lift_inst arch_str (Arbnum.fromInt 0xCFEE) ("4770");
 *)
 
-
-
+end (* local *)
 
 end
-

--- a/src/tools/lifter/gcc_supportLib.sml
+++ b/src/tools/lifter/gcc_supportLib.sml
@@ -1,15 +1,16 @@
-open HolKernel boolLib liteLib;
-open bir_inst_liftingLibTypes
-
 structure gcc_supportLib :> gcc_supportLib =
 struct
+
+  local
+
+  open HolKernel boolLib liteLib;
+  open bir_inst_liftingLibTypes
+
+  val ERR = mk_HOL_ERR "gcc_supportLib"
 
   (*******************)
   (* Auxiliary stuff *)
   (*******************)
-
-  val ERR = mk_HOL_ERR "gcc_supportLib"
-
 
   fun list_split_pred_aux acc p [] = fail ()
     | list_split_pred_aux acc p (x::xs) =
@@ -28,6 +29,7 @@ struct
     val input = read_it [] before TextIO.closeIn instream
   in input end;
 
+  in (* local *)
 
   (*******************)
   (* File Operations *)
@@ -282,4 +284,6 @@ in
   (l, r)
 end
 
-end
+end (* local *)
+
+end (* gcc_supportLib *)

--- a/src/tools/wp/bir_wpLib.sml
+++ b/src/tools/wp/bir_wpLib.sml
@@ -1,36 +1,40 @@
-open HolKernel boolLib liteLib simpLib Parse bossLib;
-
-open bir_wpTheory;
-
-open bir_programTheory;
-open bir_program_blocksTheory;
-open bir_program_terminationTheory;
-open bir_typing_progTheory;
-open bir_envTheory;
-open bir_exp_substitutionsTheory;
-open bir_bool_expTheory;
-open bir_auxiliaryTheory;
-open bir_valuesTheory;
-open bir_expTheory;
-open bir_program_env_orderTheory;
-open bir_extra_expsTheory;
-
-open bir_expLib;
-open finite_mapSyntax;
-open pairSyntax;
-
-open bir_wp_simpTheory;
-
-load "pairLib";
-
-
 structure bir_wpLib =
 struct
 
-val wps_id_prefix = "bir_wp_comp_wps_iter_step2_wp_"
+  local
 
-(* establish wps_bool_sound_thm for an initial analysis context (program, post, ls, wps) *)
-fun bir_wp_init_wps_bool_sound_thm (program, post, ls) wps defs =
+  open HolKernel Parse boolLib bossLib liteLib simpLib;
+
+  open bir_wpTheory;
+
+  open bir_programTheory;
+  open bir_program_blocksTheory;
+  open bir_program_terminationTheory;
+  open bir_typing_progTheory;
+  open bir_envTheory;
+  open bir_exp_substitutionsTheory;
+  open bir_bool_expTheory;
+  open bir_auxiliaryTheory;
+  open bir_valuesTheory;
+  open bir_expTheory;
+  open bir_program_env_orderTheory;
+  open bir_extra_expsTheory;
+  open bir_immSyntax;
+
+  open bir_expLib;
+  open finite_mapSyntax;
+  open pairSyntax;
+
+  open bir_wp_simpTheory;
+
+  val ERR = Feedback.mk_HOL_ERR "bir_wpLib";
+
+  in (* local *)
+
+  val wps_id_prefix = "bir_wp_comp_wps_iter_step2_wp_"
+
+  (* establish wps_bool_sound_thm for an initial analysis context (program, post, ls, wps) *)
+  fun bir_wp_init_wps_bool_sound_thm (program, post, ls) wps defs =
       let
         fun REPEAT_MAX n tac =
           if n > 0 then ((tac THEN (REPEAT_MAX (n - 1) tac)) ORELSE ALL_TAC)
@@ -39,7 +43,7 @@ fun bir_wp_init_wps_bool_sound_thm (program, post, ls) wps defs =
           REWRITE_TAC ([bir_bool_wps_map_def]@defs) >>
           REPEAT_MAX 20 (
               REWRITE_TAC [finite_mapTheory.FEVERY_FUPDATE, finite_mapTheory.DRESTRICT_FEMPTY, finite_mapTheory.FEVERY_FEMPTY] >>
-              SIMP_TAC (srw_ss()) [bir_is_bool_exp_def,type_of_bir_exp_def, bir_var_type_def, type_of_bir_imm_def, 
+              SIMP_TAC (srw_ss()) [bir_is_bool_exp_def,type_of_bir_exp_def, bir_var_type_def, type_of_bir_imm_def,
         		           bir_type_is_Imm_def, BType_Bool_def]
             )
           );
@@ -56,8 +60,8 @@ fun bir_wp_init_wps_bool_sound_thm (program, post, ls) wps defs =
 
 
 
-(* initial_thm_for_prog_post_ls *)
-fun bir_wp_comp_wps_iter_step0_init reusable_thm (program, post, ls) defs =
+  (* initial_thm_for_prog_post_ls *)
+  fun bir_wp_comp_wps_iter_step0_init reusable_thm (program, post, ls) defs =
     let
         val var_l = ``l:(bir_label_t)``;
         val var_wps = ``wps:(bir_label_t |-> bir_exp_t)``;
@@ -65,7 +69,7 @@ fun bir_wp_comp_wps_iter_step0_init reusable_thm (program, post, ls) defs =
         val thm = SPECL [program, var_l, ls, post, var_wps, var_wps1] reusable_thm;
 
         val post_bool_conv = [
-		       bir_is_bool_exp_def,type_of_bir_exp_def, bir_var_type_def, type_of_bir_imm_def, 
+		       bir_is_bool_exp_def,type_of_bir_exp_def, bir_var_type_def, type_of_bir_imm_def,
 		       bir_type_is_Imm_def, BType_Bool_def];
         val prog_typed_conv = [
 			    bir_is_well_typed_program_def,bir_is_well_typed_block_def,bir_is_well_typed_stmtE_def,
@@ -103,8 +107,8 @@ fun bir_wp_comp_wps_iter_step0_init reusable_thm (program, post, ls) defs =
 	thm
     end;
 
-(* include current label in reasoning *)
-fun bir_wp_comp_wps_iter_step1 label prog_thm (program, post, ls) defs =
+  (* include current label in reasoning *)
+  fun bir_wp_comp_wps_iter_step1 label prog_thm (program, post, ls) defs =
     let
         val var_wps = ``wps:(bir_label_t |-> bir_exp_t)``;
         val var_wps1 = ``wps':(bir_label_t |-> bir_exp_t)``;
@@ -129,43 +133,64 @@ fun bir_wp_comp_wps_iter_step1 label prog_thm (program, post, ls) defs =
     end;
 
 
-fun extract_new_wp fmterm = (snd o dest_pair o snd o dest_fupdate) fmterm;
-val lbl_strip_comment = (snd o dest_comb o concl o EVAL);
+  fun extract_new_wp fmterm = (snd o dest_pair o snd o dest_fupdate) fmterm;
+  val lbl_strip_comment = (snd o dest_comb o concl o EVAL);
 
-val bir_wp_comp_wps_iter_step2_defs = ref ([]:thm list);
-val bir_wp_comp_wps_iter_step2_consts = ref ([]:term list);
-val bir_wp_comp_wps_iter_step2_cntr = ref 0;
+  val bir_wp_comp_wps_iter_step2_defs = ref ([]:thm list);
+  val bir_wp_comp_wps_iter_step2_consts = ref ([]:term list);
+  val bir_wp_comp_wps_iter_step2_cntr = ref 0;
 
-(* produce wps1 and reestablish bool_sound_thm for this one *)
-fun bir_wp_comp_wps_iter_step2 (wps, wps_bool_sound_thm) prog_l_thm ((program, post, ls), (label)) defs =
+  (* produce wps1 and reestablish bool_sound_thm for this one *)
+  fun bir_wp_comp_wps_iter_step2 (wps, wps_bool_sound_thm) prog_l_thm ((program, post, ls), (label)) defs =
     let
-(*
+        (*
         val wps_id_idx = !bir_wp_comp_wps_iter_step2_cntr;
         val _ = (bir_wp_comp_wps_iter_step2_cntr := (!bir_wp_comp_wps_iter_step2_cntr) + 1);
         val wps_id_suffix = Int.toString wps_id_idx;
-*)
-        val wps_id_suffix = (term_to_string o snd o gen_dest_Imm o dest_BL_Address o lbl_strip_comment) label;
+        *)
+
+        (*-------------------------------------------------------------------
+         * Replaces invalid identifier characters by '_', to conform to
+         * Lexis.ok_identifier.
+         *-------------------------------------------------------------------*)
+        fun escape_non_alphanum c = if Char.isAlphaNum c then String.str c else "_";
+        fun to_ident name = String.translate escape_non_alphanum name;
+
+        (* Generate a string suffix from the label. *)
+        val striped_label = lbl_strip_comment label;
+        val wps_id_suffix =
+          if (is_BL_Address striped_label)
+            then (term_to_string o snd o gen_dest_Imm o dest_BL_Address) striped_label
+            else (stringSyntax.fromHOLstring o dest_BL_Label) striped_label;
+        val wps_id_suffix = to_ident wps_id_suffix;
 
         val var_wps1 = ``wps':(bir_label_t |-> bir_exp_t)``;
         val thm = SPECL [wps, var_wps1] prog_l_thm;
 
-(* this took a while, it should not have been?! *)
-	val thm = MP thm wps_bool_sound_thm;
+        (* this took a while, it should not have been?! *)
+        val thm = MP thm wps_bool_sound_thm;
 
-(* this takes a bit, not anymore? *)
+        (* this takes a bit, not anymore? *)
         val wps_eval_restrict_consts = !bir_wp_comp_wps_iter_step2_consts;
-        val wps1_thm = computeLib.RESTR_EVAL_CONV wps_eval_restrict_consts (list_mk_comb (``bir_wp_exec_of_block:'a bir_program_t ->
-  bir_label_t ->
-  (bir_label_t -> bool) ->
-  bir_exp_t ->
-  (bir_label_t |-> bir_exp_t) -> (bir_label_t |-> bir_exp_t) option``, [program, label, ls, post, wps]));
-        val wps1_thm = SIMP_RULE pure_ss [GSYM bir_exp_subst1_def, GSYM bir_exp_and_def] wps1_thm; (* normalize *)
-	val wps1 = (snd o dest_comb o snd o dest_eq o concl) wps1_thm;
+        val wps1_thm = computeLib.RESTR_EVAL_CONV wps_eval_restrict_consts
+          (list_mk_comb
+            (``bir_wp_exec_of_block:'a bir_program_t ->
+                                    bir_label_t ->
+                                    (bir_label_t -> bool) ->
+                                    bir_exp_t ->
+                                    (bir_label_t |-> bir_exp_t) ->
+                                    (bir_label_t |-> bir_exp_t) option``,
+            [program, label, ls, post, wps]));
+
+        (* normalize *)
+        val wps1_thm = SIMP_RULE pure_ss [GSYM bir_exp_subst1_def, GSYM bir_exp_and_def] wps1_thm;
+	      val wps1 = (snd o dest_comb o snd o dest_eq o concl) wps1_thm;
+
         val new_wp_id = wps_id_prefix ^ wps_id_suffix;
         val new_wp_id_var = mk_var (new_wp_id, ``:bir_exp_t``);
         val new_wp_def = Define `^new_wp_id_var = ^(extract_new_wp wps1)`;
-	(*
-	val current_theory_s = current_theory();
+	      (*
+	      val current_theory_s = current_theory();
         val new_wp_id_const = mk_const (new_wp_id, ``:bir_exp_t``);
         *)
         val new_wp_id_const = (fst o dest_eq o concl) new_wp_def;
@@ -175,21 +200,19 @@ fun bir_wp_comp_wps_iter_step2 (wps, wps_bool_sound_thm) prog_l_thm ((program, p
         val wps1 = (snd o dest_comb o snd o dest_eq o concl) wps1_thm;
 
         val thm = SPEC wps1 (GEN var_wps1 thm);
-	val wps1_bool_sound_thm = MP thm wps1_thm;
+	      val wps1_bool_sound_thm = MP thm wps1_thm;
     in
-	(wps1, wps1_bool_sound_thm)
+	      (wps1, wps1_bool_sound_thm)
     end;
 
 
+  (*
+  (* helper for simple traversal in recursive procedure *)
+  fun is_lbl_in_wps wps label =
+      (optionSyntax.is_some o snd o dest_eq o concl o EVAL) ``FLOOKUP ^wps ^label``;
+  *)
 
-
-(*
-(* helper for simple traversal in recursive procedure *)
-fun is_lbl_in_wps wps label =
-    (optionSyntax.is_some o snd o dest_eq o concl o EVAL) ``FLOOKUP ^wps ^label``;
-*)
-
-fun cmp_label lbla lblb =
+  fun cmp_label lbla lblb =
       let
         val lbla1 = lbl_strip_comment lbla;
         val lblb1 = lbl_strip_comment lblb;
@@ -197,10 +220,10 @@ fun cmp_label lbla lblb =
         term_eq lbla1 lblb1
       end;
 
-(*EVAL ``BL_Address_HC b hc``*)
+  (*EVAL ``BL_Address_HC b hc``*)
 
 
-fun bir_wp_fmap_to_dom_list fmap =
+  fun bir_wp_fmap_to_dom_list fmap =
       if is_fempty fmap then [] else
       let
         val (fmap1, kv) = dest_fupdate fmap;
@@ -209,7 +232,7 @@ fun bir_wp_fmap_to_dom_list fmap =
         (k)::(List.filter (fn k1 => not (cmp_label k1 k)) (bir_wp_fmap_to_dom_list fmap1))
       end;
 
-fun bir_wp_init_rec_proc_jobs prog_term wps_term =
+  fun bir_wp_init_rec_proc_jobs prog_term wps_term =
       let
         val wpsdom = bir_wp_fmap_to_dom_list wps_term;
         val blocks = (snd o dest_BirProgram_list) prog_term;
@@ -223,95 +246,92 @@ fun bir_wp_init_rec_proc_jobs prog_term wps_term =
         (wpsdom, blstodo)
       end;
 
-(* recursive procedure for traversing the control flow graph *)
-fun bir_wp_comp_wps prog_thm ((wps, wps_bool_sound_thm), (wpsdom, blstodo)) (program, post, ls) defs =
+  (* recursive procedure for traversing the control flow graph *)
+  fun bir_wp_comp_wps prog_thm ((wps, wps_bool_sound_thm), (wpsdom, blstodo)) (program, post, ls) defs =
     let
-	val block = List.find (fn block =>
-	      let
-                  val (label, _, end_statement) = dest_bir_block block;
-		  (*val label = (snd o dest_eq o concl o EVAL) label;*)
-                  fun is_lbl_in_wps lbl = List.exists (fn el => cmp_label el lbl) wpsdom;
-	      in
-                  (*(not (is_lbl_in_wps wps label))
-                  andalso*)
-		  (not (is_BStmt_Halt end_statement))
+      val block =
+        List.find
+          (fn block =>
+            let
+              val (label, _, end_statement) = dest_bir_block block;
+              fun is_lbl_in_wps lbl = List.exists (fn el => cmp_label el lbl) wpsdom;
+            in
+              if (is_BStmt_Halt end_statement)
+                then false else
+              if (is_BStmt_Jmp end_statement)
+                then
+                  ((is_lbl_in_wps o dest_BLE_Label o dest_BStmt_Jmp) end_statement)
+              else
+              if (is_BStmt_CJmp end_statement)
+                then
+                  ((is_lbl_in_wps o dest_BLE_Label o #2 o dest_BStmt_CJmp) end_statement)
                   andalso
-                  (
-                    ((is_BStmt_Jmp end_statement) andalso (
-		      (is_lbl_in_wps o dest_BLE_Label o dest_BStmt_Jmp) end_statement
-                    ))
-                  orelse
-		    ((is_BStmt_CJmp end_statement) andalso (
-		      (((is_lbl_in_wps o dest_BLE_Label o #2 o dest_BStmt_CJmp) end_statement) andalso ((is_lbl_in_wps o dest_BLE_Label o #3 o dest_BStmt_CJmp) end_statement))
-                    ))
-                  )
-	      end)
-            blstodo
+                  ((is_lbl_in_wps o dest_BLE_Label o #3 o dest_BStmt_CJmp) end_statement)
+              else
+                raise ERR "bir_wp_comp_wps" "unhandled end_statement type."
+            end)
+          blstodo
     in
-      case block of 
-          SOME (bl) => 
-                let
-                  val (label, _, _) = dest_bir_block bl;
+      case block of
+        SOME (bl) =>
+          let
+            val (label, _, _) = dest_bir_block bl;
+            val wpsdom1 = label::wpsdom;
 
-                  val _ = if (!debug_trace > 1) then
-                            print ("\n\r\nstarting with block: " ^ (term_to_string label) ^ "\r\n")
-                          else
-                            ()
-                          ;
+            val _ = if (!debug_trace > 1)
+              then print ("\n\r\nstarting with block: " ^ (term_to_string label) ^ "\r\n")
+              else ();
 
-                  val time_start = Time.now ();
+            val time_start = Time.now ();
 
-                  val prog_l_thm = bir_wp_comp_wps_iter_step1 label prog_thm (program, post, ls) defs;
-                  val (wps1, wps1_bool_sound_thm) = bir_wp_comp_wps_iter_step2 (wps, wps_bool_sound_thm) prog_l_thm ((program, post, ls), (label)) defs;
-                  val blstodo1 = List.filter (fn block =>
-                        let
-                          val (label_el, _, _) = dest_bir_block block;
-                        in
-                          not (cmp_label label label_el)
-                        end) blstodo;
-                  val wpsdom1 = label::wpsdom;
+            val prog_l_thm =
+              bir_wp_comp_wps_iter_step1 label prog_thm (program, post, ls) defs;
+            val (wps1, wps1_bool_sound_thm) =
+              bir_wp_comp_wps_iter_step2
+                (wps, wps_bool_sound_thm)
+                prog_l_thm
+                ((program, post, ls), (label))
+                defs;
 
-                  val _ = if (!debug_trace > 2) then
-                            let
-                              val wp_exp_term = (snd o dest_comb o concl o EVAL) ``(FAPPLY ^wps1 ^label)``;
-                              val _ = bir_exp_pretty_print wp_exp_term;
-                            in
-                              ()
-                            end
-                          else
-                            ()
-                          ;
+            (* Remove label from blstodo *)
+            val blstodo1 =
+              List.filter
+                (fn block =>
+                  let
+                    val (label_el, _, _) = dest_bir_block block;
+                  in
+                    not (cmp_label label label_el)
+                  end) blstodo;
 
-                  val _ = if (!debug_trace > 1) then
-                            print ("it took " ^ (LargeInt.toString (Time.toSeconds ((Time.now ()) - time_start))) ^ "s\r\n")
-                          else
-                            ()
-                          ;
+            val _ = if (!debug_trace > 2) orelse true
+              then let
+                  val _ = print "label: ";
+                  val _ = print_term label;
+                  val _ = print "\n";
+                  val wp_exp_term = (snd o dest_comb o concl o EVAL) ``(FAPPLY ^wps1 ^label)``;
+                  val _ = bir_exp_pretty_print wp_exp_term;
+                in () end else ();
 
-                  val _ = if (!debug_trace > 0) then
-                            print ("remaining = " ^ (Int.toString (List.length blstodo1)) ^ "  \r")
-                          else
-                            ()
-                          ;
-                in
-                  (* recursive call with new wps tuple *)
-                  (*(wps1, wps1_bool_sound_thm)*)
-                  bir_wp_comp_wps prog_thm ((wps1, wps1_bool_sound_thm), (wpsdom1, blstodo1)) (program, post, ls) defs
-                end
-        | _ => let
-                 val _ = if (!debug_trace > 0) then
-                           print ("\n")
-                         else
-                           ()
-                         ;
-               in
-                 (wps, wps_bool_sound_thm)
-               end
+            val _ = if (!debug_trace > 1)
+              then let
+                val time_as_sec = (Time.toSeconds ((Time.now ()) - time_start));
+                val time_str = LargeInt.toString time_as_sec;
+                val _ = print ("it took " ^ time_str ^ "s\r\n");
+              in () end else ();
+
+            val _ = if (!debug_trace > 0)
+              then print ("remaining labels = " ^ (Int.toString (List.length blstodo1)) ^ "  \r")
+              else ();
+          in
+            (* recursive call with new wps tuple (which is (wps1, wps1_bool_sound_thm)) *)
+            bir_wp_comp_wps prog_thm ((wps1, wps1_bool_sound_thm), (wpsdom1, blstodo1)) (program, post, ls) defs
+          end
+        | NONE =>
+          let
+            val _ = if (!debug_trace > 0) then print "\n" else ();
+          in (wps, wps_bool_sound_thm) end
     end;
 
+  end (* local *)
 
-
-
-
-
-end
+end (* bir_wpLib *)

--- a/src/tools/wp/bir_wpLib.sml
+++ b/src/tools/wp/bir_wpLib.sml
@@ -27,6 +27,8 @@ load "pairLib";
 structure bir_wpLib =
 struct
 
+val wps_id_prefix = "bir_wp_comp_wps_iter_step2_wp_"
+
 (* establish wps_bool_sound_thm for an initial analysis context (program, post, ls, wps) *)
 fun bir_wp_init_wps_bool_sound_thm (program, post, ls) wps defs =
       let
@@ -159,7 +161,7 @@ fun bir_wp_comp_wps_iter_step2 (wps, wps_bool_sound_thm) prog_l_thm ((program, p
   (bir_label_t |-> bir_exp_t) -> (bir_label_t |-> bir_exp_t) option``, [program, label, ls, post, wps]));
         val wps1_thm = SIMP_RULE pure_ss [GSYM bir_exp_subst1_def, GSYM bir_exp_and_def] wps1_thm; (* normalize *)
 	val wps1 = (snd o dest_comb o snd o dest_eq o concl) wps1_thm;
-        val new_wp_id = "bir_wp_comp_wps_iter_step2_wp_" ^ wps_id_suffix;
+        val new_wp_id = wps_id_prefix ^ wps_id_suffix;
         val new_wp_id_var = mk_var (new_wp_id, ``:bir_exp_t``);
         val new_wp_def = Define `^new_wp_id_var = ^(extract_new_wp wps1)`;
 	(*

--- a/src/tools/wp/bir_wpLib.sml
+++ b/src/tools/wp/bir_wpLib.sml
@@ -140,6 +140,25 @@ struct
   val bir_wp_comp_wps_iter_step2_consts = ref ([]:term list);
   val bir_wp_comp_wps_iter_step2_cntr = ref 0;
 
+  (* Generates a string suffix from the label. *)
+  fun label_to_wps_id_suffix label =
+    let
+      (*-------------------------------------------------------------------
+       * Replaces invalid identifier characters by '_', to conform to
+       * Lexis.ok_identifier.
+       *-------------------------------------------------------------------*)
+      fun escape_non_alphanum c = if Char.isAlphaNum c then String.str c else "_";
+      fun to_ident name = String.translate escape_non_alphanum name;
+
+      val striped_label = lbl_strip_comment label;
+      val wps_id_suffix =
+        if (is_BL_Address striped_label)
+          then (term_to_string o snd o gen_dest_Imm o dest_BL_Address) striped_label
+          else (stringSyntax.fromHOLstring o dest_BL_Label) striped_label;
+    in
+      to_ident wps_id_suffix
+    end;
+
   (* produce wps1 and reestablish bool_sound_thm for this one *)
   fun bir_wp_comp_wps_iter_step2 (wps, wps_bool_sound_thm) prog_l_thm ((program, post, ls), (label)) defs =
     let
@@ -149,20 +168,8 @@ struct
         val wps_id_suffix = Int.toString wps_id_idx;
         *)
 
-        (*-------------------------------------------------------------------
-         * Replaces invalid identifier characters by '_', to conform to
-         * Lexis.ok_identifier.
-         *-------------------------------------------------------------------*)
-        fun escape_non_alphanum c = if Char.isAlphaNum c then String.str c else "_";
-        fun to_ident name = String.translate escape_non_alphanum name;
-
         (* Generate a string suffix from the label. *)
-        val striped_label = lbl_strip_comment label;
-        val wps_id_suffix =
-          if (is_BL_Address striped_label)
-            then (term_to_string o snd o gen_dest_Imm o dest_BL_Address) striped_label
-            else (stringSyntax.fromHOLstring o dest_BL_Label) striped_label;
-        val wps_id_suffix = to_ident wps_id_suffix;
+        val wps_id_suffix = label_to_wps_id_suffix label;
 
         val var_wps1 = ``wps':(bir_label_t |-> bir_exp_t)``;
         val thm = SPECL [wps, var_wps1] prog_l_thm;

--- a/src/tools/wp/bir_wpScript.sml
+++ b/src/tools/wp/bir_wpScript.sml
@@ -1,17 +1,17 @@
+open HolKernel Parse boolLib bossLib;
+
 (* From core BIR: *)
 open bir_programTheory bir_typing_progTheory bir_envTheory
      bir_auxiliaryTheory bir_valuesTheory bir_expTheory
-     bir_exp_immTheory;
+     bir_exp_immTheory bir_typing_expTheory bir_immTheory;
 
-(* From BIR core-props: *)
+(* From BIR theories: *)
 open bir_program_blocksTheory bir_program_terminationTheory
      bir_program_valid_stateTheory bir_exp_substitutionsTheory
      bir_bool_expTheory bir_program_env_orderTheory
      bir_program_multistep_propsTheory;
 
 open HolBACoreSimps;
-
-load "pairLib";
 
 val _ = new_theory "bir_wp";
 

--- a/src/tools/wp/bir_wp_expLib.sml
+++ b/src/tools/wp/bir_wp_expLib.sml
@@ -55,7 +55,7 @@ struct
     end;
 
   fun gen_lbl_list wps1_term =
-    List.map (term_to_string o snd o gen_dest_Imm o dest_BL_Address) (bir_wp_fmap_to_dom_list wps1_term);
+    List.map bir_wpLib.label_to_wps_id_suffix (bir_wp_fmap_to_dom_list wps1_term);
 
   end (* local *)
 

--- a/src/tools/wp/bir_wp_expLib.sml
+++ b/src/tools/wp/bir_wp_expLib.sml
@@ -1,55 +1,62 @@
-open HolKernel Parse;
-
-open bir_wpTheory bir_wpLib;
-
-open listSyntax;
-
-open bir_expLib;
-
-open bir_wp_simpLib;
-
-
-
 structure bir_wp_expLib =
 struct
 
+  local
 
-fun get_nth_last_label prog_term n =
-      let
-        val (block_list, block_type) = (dest_list o dest_BirProgram) prog_term;
-        val nth_last_block = List.nth (List.rev block_list, n)
-      in
-        (snd o dest_comb o concl o EVAL) ``(^nth_last_block).bb_label``
-      end;
+  open HolKernel Parse boolLib bossLib;
+  open listSyntax;
 
-(* create subproblem for debugging and analysis *)
-fun get_subprog_with_n_last prog_term n =
-      let
-        val (block_list, block_type) = (dest_list o dest_BirProgram) prog_term;
-        val n_last_blocks = List.drop (block_list, (List.length block_list) - n)
-      in
-        mk_BirProgram (mk_list (n_last_blocks, block_type))
-      end;
+  open bir_expLib;
+  open bir_expSyntax;
+  open bir_immSyntax;
+  open bir_envSyntax;
+  open bir_exp_immSyntax;
+  open bir_exp_memSyntax;
+  open bir_bool_expSyntax;
+  open bir_programSyntax;
 
-fun get_subprog_drop_n_at_end prog_term n =
-      let
-        val (block_list, block_type) = (dest_list o dest_BirProgram) prog_term;
-        val n_last_blocks = List.rev (List.drop (List.rev block_list, n))
-      in
-        mk_BirProgram (mk_list (n_last_blocks, block_type))
-      end;
+  open bir_wpTheory bir_wpLib;
+  open bir_wp_simpLib;
 
-fun get_prog_length prog_term =
-      let
-        val (block_list, block_type) = (dest_list o dest_BirProgram) prog_term;
-      in
-        List.length block_list
-      end;
+  val ERR = Feedback.mk_HOL_ERR "bir_wp_expLib";
 
+  in
 
-fun gen_lbl_list wps1_term =
-  List.map (term_to_string o snd o gen_dest_Imm o dest_BL_Address) (bir_wp_fmap_to_dom_list wps1_term);
+  fun get_nth_last_label prog_term n =
+    let
+      val (block_list, block_type) = (dest_list o dest_BirProgram) prog_term;
+      val nth_last_block = List.nth (List.rev block_list, n)
+    in
+      (snd o dest_comb o concl o EVAL) ``(^nth_last_block).bb_label``
+    end;
 
+  (* create subproblem for debugging and analysis *)
+  fun get_subprog_with_n_last prog_term n =
+    let
+      val (block_list, block_type) = (dest_list o dest_BirProgram) prog_term;
+      val n_last_blocks = List.drop (block_list, (List.length block_list) - n)
+    in
+      mk_BirProgram (mk_list (n_last_blocks, block_type))
+    end;
 
+  fun get_subprog_drop_n_at_end prog_term n =
+    let
+      val (block_list, block_type) = (dest_list o dest_BirProgram) prog_term;
+      val n_last_blocks = List.rev (List.drop (List.rev block_list, n))
+    in
+      mk_BirProgram (mk_list (n_last_blocks, block_type))
+    end;
 
-end
+  fun get_prog_length prog_term =
+    let
+      val (block_list, block_type) = (dest_list o dest_BirProgram) prog_term;
+    in
+      List.length block_list
+    end;
+
+  fun gen_lbl_list wps1_term =
+    List.map (term_to_string o snd o gen_dest_Imm o dest_BL_Address) (bir_wp_fmap_to_dom_list wps1_term);
+
+  end (* local *)
+
+end (* bir_wp_expLib *)

--- a/src/tools/wp/bir_wp_simpLib.sml
+++ b/src/tools/wp/bir_wp_simpLib.sml
@@ -1,30 +1,31 @@
-open HolKernel boolLib liteLib simpLib Parse bossLib;
-
-open bir_wpTheory;
-
-open bir_programTheory;
-open bir_program_blocksTheory;
-open bir_program_terminationTheory;
-open bir_typing_progTheory;
-open bir_envTheory;
-open bir_exp_substitutionsTheory bir_exp_substitutionsSyntax;
-open bir_bool_expTheory bir_bool_expSyntax;
-open bir_auxiliaryTheory;
-open bir_valuesTheory;
-open bir_expTheory;
-open bir_program_env_orderTheory;
-
-open bir_expLib;
-open finite_mapSyntax;
-open pairSyntax;
-
-open bir_wp_simpTheory;
-
-load "pairLib";
-
-
 structure bir_wp_simpLib =
 struct
+
+  local
+
+  open HolKernel boolLib liteLib simpLib Parse bossLib;
+
+  open bir_wpTheory;
+
+  open bir_programTheory;
+  open bir_program_blocksTheory;
+  open bir_program_terminationTheory;
+  open bir_typing_progTheory;
+  open bir_envTheory bir_envSyntax;
+  open bir_exp_substitutionsTheory bir_exp_substitutionsSyntax;
+  open bir_bool_expTheory bir_bool_expSyntax;
+  open bir_auxiliaryTheory;
+  open bir_valuesTheory bir_valuesSyntax;
+  open bir_expTheory bir_expSyntax;
+  open bir_program_env_orderTheory;
+
+  open bir_expLib;
+  open finite_mapSyntax;
+  open pairSyntax;
+
+  open bir_wp_simpTheory;
+
+  in (* local *)
 
   fun syntax_fns n d m = HolKernel.syntax_fns {n = n, dest = d, make = m} "bir_wp_simp"
   val syntax_fns2 = syntax_fns 2 HolKernel.dest_binop HolKernel.mk_binop;
@@ -1152,5 +1153,6 @@ val goalterm = (snd o dest_eq o concl) simp_thm;
 *)
 
 
-end
+end (* local *)
 
+end (* bir_wp_simpLib *)

--- a/src/tools/wp/bir_wp_simpLib.sml
+++ b/src/tools/wp/bir_wp_simpLib.sml
@@ -196,7 +196,7 @@ struct
     | preproc_vars acc (lbl_str::lbl_list) =
         let
           val _ = print ((Int.toString (length acc)) ^ "        \r");
-          val def_thm = lookup_def ("bir_wp_comp_wps_iter_step2_wp_" ^ lbl_str);
+          val def_thm = lookup_def (bir_wpLib.wps_id_prefix ^ lbl_str);
 (*
           val vars_def_var_id = "bir_wp_comp_wps_iter_step2_wp_" ^ lbl_str ^ "_vars";
           val vars_def_var = mk_var (vars_def_var_id, ``:bir_var_t -> bool``);

--- a/src/tools/wp/bir_wp_simpScript.sml
+++ b/src/tools/wp/bir_wp_simpScript.sml
@@ -1,3 +1,5 @@
+open HolKernel Parse boolLib bossLib;
+
 open bir_programTheory;
 open bir_program_blocksTheory;
 open bir_program_terminationTheory;
@@ -9,11 +11,11 @@ open bir_auxiliaryTheory;
 open bir_valuesTheory;
 open bir_expTheory;
 open bir_program_env_orderTheory;
+open bir_immTheory;
+open bir_typing_expTheory;
 
 open bir_exp_congruencesTheory;
 open bir_exp_tautologiesTheory;
-
-load "pairLib";
 
 val _ = new_theory "bir_wp_simp";
 


### PR DESCRIPTION
`src/libs/bir_expLib.sml` line 4 is the reason why I had to "fix" a lot of `open`s.

Also, I strangely had to revert this: https://github.com/kth-step/HolBA/commit/3f1b4ae5ae996126bc48b44438304dc4477c04a3 (in 199e398) in order to get `tools/wp/examples/*` working.

Examples in `tools/wp/examples` and `examples/aes` are all working.