### PR TITLE
SMT SAT model: SAT NONE when no model is given

### DIFF
--- a/src/libs/Z3_SAT_modelLib.sml
+++ b/src/libs/Z3_SAT_modelLib.sml
@@ -107,7 +107,10 @@ struct
           end
         val model = parse_tm_list instream [];
       in
-        SAT (SOME model)
+        if model = [] then
+          SAT NONE
+        else
+          SAT (SOME model)
       end
     | _ => raise ERR "is_sat_stream" "Malformed Z3 output: first line not recognized"
 


### PR DESCRIPTION
Returns `SAT NONE` if the Python wrapper fails to serialize terms but still says "sat"