### PR TITLE
Changing memory representation from a function to a finite map (and add BExp_MemConst)

### DIFF
--- a/src/core/bir_expSyntax.sig
+++ b/src/core/bir_expSyntax.sig
@@ -14,6 +14,7 @@ sig
    val BExp_MemEq_tm        : term;
    val BExp_Cast_tm         : term;
    val BExp_Const_tm        : term;
+   val BExp_MemConst_tm     : term;
    val BExp_Den_tm          : term;
    val BExp_IfThenElse_tm   : term;
    val BExp_Load_tm         : term;
@@ -25,6 +26,7 @@ sig
    val dest_BExp_MemEq      : term -> term * term;
    val dest_BExp_Cast       : term -> term * term * term;
    val dest_BExp_Const      : term -> term;
+   val dest_BExp_MemConst   : term -> term * term * term;
    val dest_BExp_Den        : term -> term;
    val dest_BExp_IfThenElse : term -> term * term * term;
    val dest_BExp_Load       : term -> term * term * term * term;
@@ -36,6 +38,7 @@ sig
    val is_BExp_MemEq        : term -> bool;
    val is_BExp_Cast         : term -> bool;
    val is_BExp_Const        : term -> bool;
+   val is_BExp_MemConst     : term -> bool;
    val is_BExp_Den          : term -> bool;
    val is_BExp_IfThenElse   : term -> bool;
    val is_BExp_Load         : term -> bool;
@@ -47,6 +50,7 @@ sig
    val mk_BExp_MemEq        : term * term -> term;
    val mk_BExp_Cast         : term * term * term -> term;
    val mk_BExp_Const        : term -> term;
+   val mk_BExp_MemConst     : term * term * term -> term;
    val mk_BExp_Den          : term -> term;
    val mk_BExp_IfThenElse   : term * term * term -> term;
    val mk_BExp_Load         : term * term * term * term -> term;

--- a/src/core/bir_expSyntax.sml
+++ b/src/core/bir_expSyntax.sml
@@ -29,6 +29,7 @@ val syntax_fns4 = syntax_fns 4 HolKernel.dest_quadop HolKernel.mk_quadop;
 val bir_exp_t_ty = mk_type ("bir_exp_t", []);
 
 val (BExp_Const_tm, mk_BExp_Const, dest_BExp_Const, is_BExp_Const) = syntax_fns1 "BExp_Const";
+val (BExp_MemConst_tm, mk_BExp_MemConst, dest_BExp_MemConst, is_BExp_MemConst) = syntax_fns3 "BExp_MemConst";
 val (BExp_Den_tm, mk_BExp_Den, dest_BExp_Den, is_BExp_Den) = syntax_fns1 "BExp_Den";
 val (BExp_Cast_tm, mk_BExp_Cast, dest_BExp_Cast, is_BExp_Cast) = syntax_fns3 "BExp_Cast";
 val (BExp_UnaryExp_tm, mk_BExp_UnaryExp, dest_BExp_UnaryExp, is_BExp_UnaryExp) = syntax_fns2 "BExp_UnaryExp";

--- a/src/core/bir_programScript.sml
+++ b/src/core/bir_programScript.sml
@@ -4,6 +4,7 @@ open bir_auxiliaryTheory bir_immTheory bir_valuesTheory;
 open bir_exp_immTheory bir_exp_memTheory bir_envTheory;
 open bir_expTheory;
 open llistTheory wordsLib;
+open finite_mapTheory;
 
 val _ = new_theory "bir_program";
 
@@ -166,7 +167,7 @@ val bir_state_init_def = Define `bir_state_init p = <|
 
 val bir_declare_initial_value_def = Define `
   (bir_declare_initial_value (BType_Imm _) = NONE) /\
-  (bir_declare_initial_value (BType_Mem at vt) = SOME (BVal_Mem at vt (K 0)))`;
+  (bir_declare_initial_value (BType_Mem at vt) = SOME (BVal_Mem at vt (FEMPTY)))`;
 
 val bir_exec_stmt_declare_def = Define `bir_exec_stmt_declare v ty (st : bir_state_t) =
    if bir_env_varname_is_bound st.bst_environ v then

--- a/src/core/bir_typing_expScript.sml
+++ b/src/core/bir_typing_expScript.sml
@@ -19,6 +19,8 @@ val bir_type_ss = rewrites (type_rws ``:bir_type_t``);
 val type_of_bir_exp_def = Define `
   (type_of_bir_exp (BExp_Const i) = SOME (BType_Imm (type_of_bir_imm i))) /\
 
+  (type_of_bir_exp (BExp_MemConst aty vty mmap) = SOME (BType_Mem aty vty)) /\
+
   (type_of_bir_exp (BExp_Den v) = SOME (bir_var_type v)) /\
 
   (type_of_bir_exp (BExp_Cast ct e rty) = (case (type_of_bir_exp e) of
@@ -121,6 +123,8 @@ Induct >> (
 val type_of_bir_exp_EQ_SOME_REWRS = store_thm ("type_of_bir_exp_EQ_SOME_REWRS",``
   (!i ty. (type_of_bir_exp (BExp_Const i) = SOME ty) <=> (ty = BType_Imm (type_of_bir_imm i))) /\
 
+  (!aty vty mmap ty. (type_of_bir_exp (BExp_MemConst aty vty mmap) = SOME ty) <=> (ty = BType_Mem aty vty)) /\
+
   (!v ty. (type_of_bir_exp (BExp_Den v) = SOME ty) <=> (ty = bir_var_type v)) /\
 
   (!ct e ty ty'. (type_of_bir_exp (BExp_Cast ct e ty') = SOME ty) <=> (
@@ -192,6 +196,8 @@ REPEAT CONJ_TAC >> (
 
 val type_of_bir_exp_EQ_NONE_REWRS = store_thm ("type_of_bir_exp_EQ_NONE_REWRS",``
   (!i. ~(type_of_bir_exp (BExp_Const i) = NONE)) /\
+
+  (!aty vty mmap. ~(type_of_bir_exp (BExp_MemConst aty vty mmap) = NONE)) /\
 
   (!v. ~(type_of_bir_exp (BExp_Den v) = NONE)) /\
 
@@ -271,6 +277,7 @@ REPEAT CONJ_TAC >> (
 
 val bir_vars_of_exp_def = Define `
   (bir_vars_of_exp (BExp_Const _) = {}) /\
+  (bir_vars_of_exp (BExp_MemConst _ _ _) = {}) /\
   (bir_vars_of_exp (BExp_Den v) = {v}) /\
   (bir_vars_of_exp (BExp_Cast _ e _) = bir_vars_of_exp e) /\
   (bir_vars_of_exp (BExp_UnaryExp _ e) = bir_vars_of_exp e) /\

--- a/src/core/bir_valuesScript.sml
+++ b/src/core/bir_valuesScript.sml
@@ -1,5 +1,6 @@
 open HolKernel Parse boolLib bossLib;
 open wordsTheory bitstringTheory listTheory pred_setTheory;
+open finite_mapTheory;
 open bir_auxiliaryTheory bir_immTheory;
 
 val _ = new_theory "bir_values";
@@ -13,7 +14,7 @@ val bir_imm_ss = rewrites ((type_rws ``:bir_imm_t``) @ (type_rws ``:bir_immtype_
 val _ = Datatype `bir_val_t =
     BVal_Unknown
   | BVal_Imm bir_imm_t
-  | BVal_Mem bir_immtype_t (*Addr-Type*) bir_immtype_t (* value-type *) (num -> num)
+  | BVal_Mem bir_immtype_t (*Addr-Type*) bir_immtype_t (* value-type *) (num |-> num)
 `;
 
 
@@ -226,7 +227,7 @@ REWRITE_TAC[bir_type_t_UNIV_SPEC, listTheory.FINITE_LIST_TO_SET]);
 
 val bir_default_value_of_type_def = Define `
   (bir_default_value_of_type (BType_Imm s) = BVal_Imm (n2bs 0 s)) /\
-  (bir_default_value_of_type (BType_Mem a_s v_s) = BVal_Mem a_s v_s (K 0))`;
+  (bir_default_value_of_type (BType_Mem a_s v_s) = BVal_Mem a_s v_s (FEMPTY))`;
 
 val bir_default_value_of_type_SPEC = store_thm ("bir_default_value_of_type_SPEC",
   ``!ty. type_of_bir_val (bir_default_value_of_type ty) = SOME ty``,

--- a/src/libs/bir_expLib.sml
+++ b/src/libs/bir_expLib.sml
@@ -70,6 +70,15 @@ struct
       if is_BExp_Const exp then
         (xf o term_to_string o snd o gen_dest_Imm o dest_BExp_Const) exp
 
+      else if is_BExp_MemConst exp then
+        let
+          val (aty, vty, mmap) = (dest_BExp_MemConst) exp;
+          val aty_str = (Int.toString o size_of_bir_immtype_t) aty;
+          val vty_str = (Int.toString o size_of_bir_immtype_t) vty;
+        in
+          ((xf "(MEM:") cf (xf aty_str) cf (xf ":") cf (xf vty_str) cf (xf (":{" ^ (term_to_string mmap) ^ "})")))
+        end
+
       else if is_BExp_Den exp then
         ((xf "_") cf ((xf o fst o dest_BVar_string o dest_BExp_Den) exp))
 
@@ -196,6 +205,8 @@ val _ = bir_exp_pretty_print exp;
 
   fun bir_exp_vars_in_exp exp =
       if is_BExp_Const exp then
+        []
+      else if is_BExp_MemConst exp then
         []
       else if is_BExp_Den exp then
         [(fst o dest_BVar_string o dest_BExp_Den) exp]

--- a/src/libs/bir_exp_to_wordsLib.sml
+++ b/src/libs/bir_exp_to_wordsLib.sml
@@ -411,7 +411,7 @@ struct
           val writes = offset_writes_up_to nsplits []
             handle e => raise wrap_exn "bir_exp_to_words::store::writes" e;
           (* Fold using mk_comb *)
-          val whole_store_tm = List.foldl (fn (update_tm, mem_tm) =>
+          val whole_store_tm = List.foldr (fn (update_tm, mem_tm) =>
             mk_comb (update_tm, mem_tm))
             mem_w writes
             handle e => raise wrap_exn "bir_exp_to_words::store::mk_comb" e;

--- a/src/libs/bir_exp_to_wordsLib.sml
+++ b/src/libs/bir_exp_to_wordsLib.sml
@@ -170,7 +170,7 @@ struct
                 val val_ty = word_ty_of_bir_immtype_t val_bir_ty
                   handle e => raise wrap_exn "bir_exp_to_words::den::mem" e
               in
-                Type `: ^addr_ty -> ^val_ty`
+                Type `: ^addr_ty |-> ^val_ty`
               end
             else
               raise Fail ("unhandled type: " ^ (term_to_string bir_type))
@@ -298,7 +298,7 @@ struct
         val w = bir_exp_to_words exp;
         *)
         (*
-         * ((addr+0) :> mem) @@ ((addr+1) :> mem) @@ ...
+         * ((addr+0) ' mem) @@ ((addr+1) ' mem) @@ ...
          *)
         let
           val (bir_mem, bir_addr, bir_endi, bir_val_ty) = dest_BExp_Load exp
@@ -321,7 +321,8 @@ struct
                 val offset = Arbnumcore.- (n, Arbnumcore.one);
                 val offset_w = mk_word (offset, size_of base_addr_w);
                 val addr = ``^base_addr_w + ^offset_w``;
-                val load_tm = ``^addr :> ^mem_w``;
+                (* this may need to be refined to: case FLOOKUP .. .. of SOME x => x | NONE => 0w *)
+                val load_tm = ``FAPPLY ^mem_w ^addr``;
               in
                 offset_reads_up_to (Arbnumcore.- (n, Arbnumcore.one)) (load_tm::acc)
               end
@@ -386,6 +387,10 @@ struct
           val write_len_num = Arbnumcore.fromInt write_len
           val write_len_ty = mk_numeric_type write_len_num
           val val_w = bir_exp_to_words bir_val
+          (*
+          val n = nsplits;
+          val acc = [];
+          *)
           fun offset_writes_up_to n acc =
             if n = Arbnumcore.zero then acc else
               let
@@ -399,7 +404,7 @@ struct
                 val high_bit_tm = mk_numeral high_bit
                 val val_tm = mk_word_extract
                   (high_bit_tm, low_bit_tm, val_w, write_len_ty)
-                val store_tm = ``(^addr_tm =+ ^val_tm)``
+                val store_tm = ``(\x. (FUPDATE x (^addr_tm, ^val_tm)))``
               in
                 offset_writes_up_to (Arbnumcore.- (n, Arbnumcore.one)) (store_tm::acc)
               end
@@ -411,7 +416,7 @@ struct
             mem_w writes
             handle e => raise wrap_exn "bir_exp_to_words::store::mk_comb" e;
         in
-          whole_store_tm
+          (snd o dest_eq o concl o (SIMP_CONV pure_ss [boolTheory.BETA_THM])) whole_store_tm
         end
       (*** WP specific terms ***)
       (* Implications *)

--- a/src/libs/bir_exp_to_wordsLib.sml
+++ b/src/libs/bir_exp_to_wordsLib.sml
@@ -148,7 +148,7 @@ struct
           handle e => raise wrap_exn "bir_exp_to_words::const" e
       (* Memory constants *)
       else if is_BExp_MemConst exp then
-        raise Fail ("unhandled: BExp_MemConst")
+        raise ERR "bir_exp_to_words" "unhandled: BExp_MemConst"
       (* Den *)
       else if is_BExp_Den exp then
         (* Manual tests

--- a/src/libs/bir_exp_to_wordsLib.sml
+++ b/src/libs/bir_exp_to_wordsLib.sml
@@ -146,6 +146,9 @@ struct
       if is_BExp_Const exp then
         (snd o gen_dest_Imm o dest_BExp_Const) exp
           handle e => raise wrap_exn "bir_exp_to_words::const" e
+      (* Memory constants *)
+      else if is_BExp_MemConst exp then
+        raise Fail ("unhandled: BExp_MemConst")
       (* Den *)
       else if is_BExp_Den exp then
         (* Manual tests

--- a/src/libs/bslSyntax.sig
+++ b/src/libs/bslSyntax.sig
@@ -313,15 +313,16 @@ sig
     (* Memory constants (BExp_MemConst: bir_exp_t)
      *
      * Notes:
-     *  - bconstmem takes an address type, a value type and a
-     *    list of key-value pairs to build up a finite map
-     *    using FUPDATE and FEMPTY. The address and value
-     *    sizes have to be supported by BIR.
+     *  - bconstmem takes an address type length, a value type
+     *    length and a list of key-value pairs to build up a
+     *    finite map using FUPDATE and FEMPTY. The address and
+     *    value sizes have to be supported by BIR.
      *
-     * bconstmem:  int -> int -> (int * int) list -> bir_exp_t
+     * bconstmemii:  int (address type) -> int (value type) ->
+                       (int * int) list -> bir_exp_t
      *)
 
-    val bconstmem: int -> int -> (int * int) list -> term
+    val bconstmemii: int -> int -> (int * int) list -> term
 
     (* Den (BExp_Den: bir_exp_t)
      *

--- a/src/libs/bslSyntax.sig
+++ b/src/libs/bslSyntax.sig
@@ -310,6 +310,19 @@ sig
     val bconstii:   int -> int -> term
     val bconstimm:  term -> term
 
+    (* Memory constants (BExp_MemConst: bir_exp_t)
+     *
+     * Notes:
+     *  - bconstmem takes an address type, a value type and a
+     *    list of key-value pairs to build up a finite map
+     *    using FUPDATE and FEMPTY. The address and value
+     *    sizes have to be supported by BIR.
+     *
+     * bconstmem:  int -> int -> (int * int) list -> bir_exp_t
+     *)
+
+    val bconstmem: int -> int -> (int * int) list -> term
+
     (* Den (BExp_Den: bir_exp_t)
      *
      * bden: bir_var_t -> bir_exp_t

--- a/src/libs/bslSyntax.sml
+++ b/src/libs/bslSyntax.sml
@@ -225,10 +225,10 @@ struct
         finite_mapSyntax.mk_fupdate (bconstmem_helper l,
           pairSyntax.mk_pair (numSyntax.term_of_int k, numSyntax.term_of_int v));
 
-  fun bconstmem al vl l =
+  fun bconstmemii al vl l =
     let
-      val aty = Term [QUOTE ("Bit" ^ (Int.toString al))];
-      val vty = Term [QUOTE ("Bit" ^ (Int.toString al))];
+      val aty = bir_immtype_t_of_size al;
+      val vty = bir_immtype_t_of_size vl;
     in
       mk_BExp_MemConst (aty, vty, bconstmem_helper l)
     end;

--- a/src/libs/bslSyntax.sml
+++ b/src/libs/bslSyntax.sml
@@ -218,6 +218,21 @@ struct
   val bconst64 = bconstii 64
   val bconst128 = bconstii 128
 
+  (* Memory constants (BExp_MemConst: bir_exp_t) *)
+  fun bconstmem_helper [] =
+        finite_mapSyntax.mk_fempty (numSyntax.num, numSyntax.num)
+    | bconstmem_helper ((k,v)::l) =
+        finite_mapSyntax.mk_fupdate (bconstmem_helper l,
+          pairSyntax.mk_pair (numSyntax.term_of_int k, numSyntax.term_of_int v));
+
+  fun bconstmem al vl l =
+    let
+      val aty = Term [QUOTE ("Bit" ^ (Int.toString al))];
+      val vty = Term [QUOTE ("Bit" ^ (Int.toString al))];
+    in
+      mk_BExp_MemConst (aty, vty, bconstmem_helper l)
+    end;
+
   (* Den (BExp_Den: bir_exp_t) *)
   val bden = mk_BExp_Den
     handle e => raise wrap_exn "bden" e

--- a/src/libs/examples/example-z3-sat-model.sml
+++ b/src/libs/examples/example-z3-sat-model.sml
@@ -1,5 +1,7 @@
 open HolKernel Parse boolLib bossLib;
 
+open finite_mapTheory;
+
 (* Load the dependencies in interactive sessions *)
 val _ = if !Globals.interactive then (
   load "../Z3_SAT_modelLib"; (* ../ *)
@@ -41,6 +43,10 @@ fun produce_sat_thm term model =
 
 (* Get a SAT model using Z3 (this function assumes that the given term is SAT) *)
 val term = ``(z + y = 2 * x) /\ ((x * x + y - 25) = z:int)``;
+(* (FUN_MAP2 (K 0w) (UNIV)) *)
+(*
+val term = ``(m2 = FUPDATE (m1: word32 |-> word8) (3w, 2w)) /\ (FAPPLY m2 3w = 2w)``;
+*)
 val model = Z3_SAT_modelLib.Z3_GET_SAT_MODEL term;
 val _ = (print "SAT model:\n"; print_model model(*; print "\n"*));
 val sat_thm = produce_sat_thm term model;

--- a/src/libs/examples/test-bir-to-word.sml
+++ b/src/libs/examples/test-bir-to-word.sml
@@ -54,11 +54,12 @@ val bir_exprs = [
         (BExp_Den (BVar "address" (BType_Imm Bit32)))
         BEnd_BigEndian
         (BExp_Const (Imm16 (42w :word16))))``,
-    ``((address :word32) + (1w :word32) =+
-          ((((15 :num) >< (8 :num)) :word16 -> word8) (42w :word16)))
-        ((address + (0w :word32) =+
-          ((((7 :num) >< (0 :num)) :word16 -> word8) (42w :word16)))
-        (memory :word32 -> word8))``),
+    ``(memory :word32 |-> word8)
+        |+ ((address :word32) + (1w :word32),
+            ((((15 :num) >< (8 :num)) :word16 -> word8) (42w :word16)))
+        |+ ((address + (0w :word32),
+            ((((7 :num) >< (0 :num)) :word16 -> word8) (42w :word16))))
+        ``),
 
   ("128-bit value load",
     ``(BExp_Load
@@ -67,35 +68,36 @@ val bir_exprs = [
         BEnd_LittleEndian
         Bit128)``,
     ``(word_concat :word8 -> 120 word -> word128 )
-        ((address :word64) + (0w :word64) :> (memory :word64 -> word8))
-        ((word_concat :word8 -> 112 word -> 120 word)
-        (address + (1w :word64) :> memory)
-        ((word_concat :word8 -> 104 word -> 112 word)
-        (address + (2w :word64) :> memory)
-        ((word_concat :word8 -> word96 -> 104 word)
-        (address + (3w :word64) :> memory)
-        ((word_concat :word8 -> 88 word -> word96)
-        (address + (4w :word64) :> memory)
-        ((word_concat :word8 -> 80 word -> 88 word)
-        (address + (5w :word64) :> memory)
-        ((word_concat :word8 -> 72 word -> 80 word)
-        (address + (6w :word64) :> memory)
-        ((word_concat :word8 -> word64 -> 72 word)
-        (address + (7w :word64) :> memory)
-        ((word_concat :word8 -> 56 word -> word64)
-        (address + (8w :word64) :> memory)
-        ((word_concat :word8 -> word48 -> 56 word)
-        (address + (9w :word64) :> memory)
-        ((word_concat :word8 -> 40 word -> word48)
-        (address + (10w :word64) :> memory)
-        ((word_concat :word8 -> word32 -> 40 word)
-        (address + (11w :word64) :> memory)
-        ((word_concat :word8 -> word24 -> word32)
-        (address + (12w :word64) :> memory)
-        ((word_concat :word8 -> word16 -> word24)
-        (address + (13w :word64) :> memory)
-        ((word_concat :word8 -> word8 -> word16) (address + (14w :word64) :> memory)
-        (address + (15w :word64) :> memory)))))))))))))))``)
+       (((memory :word64 |-> word8) ' ((address :word64) + (0w :word64))) :word8)
+     ((word_concat :word8 -> 112 word -> 120 word )
+       ((memory ' (address + (1w :word64))) :word8)
+     ((word_concat :word8 -> 104 word -> 112 word )
+       ((memory ' (address + (2w :word64))) :word8)
+     ((word_concat :word8 -> word96 -> 104 word )
+       ((memory ' (address + (3w :word64))) :word8)
+     ((word_concat :word8 -> 88 word -> word96 )
+       ((memory ' (address + (4w :word64))) :word8)
+     ((word_concat :word8 -> 80 word -> 88 word )
+       ((memory ' (address + (5w :word64))) :word8)
+     ((word_concat :word8 -> 72 word -> 80 word )
+       ((memory ' (address + (6w :word64))) :word8)
+     ((word_concat :word8 -> word64 -> 72 word )
+       ((memory ' (address + (7w :word64))) :word8)
+     ((word_concat :word8 -> 56 word -> word64 )
+       ((memory ' (address + (8w :word64))) :word8)
+     ((word_concat :word8 -> word48 -> 56 word )
+       ((memory ' (address + (9w :word64))) :word8)
+     ((word_concat :word8 -> 40 word -> word48 )
+       ((memory ' (address + (10w :word64))) :word8)
+     ((word_concat :word8 -> word32 -> 40 word )
+       ((memory ' (address + (11w :word64))) :word8)
+     ((word_concat :word8 -> word24 -> word32 )
+       ((memory ' (address + (12w :word64))) :word8)
+     ((word_concat :word8 -> word16 -> word24 )
+       ((memory ' (address + (13w :word64))) :word8)
+     ((word_concat :word8 -> word8 -> word16 )
+       ((memory ' (address + (14w :word64))) :word8)
+     ((memory ' (address + (15w :word64))) :word8)))))))))))))))``)
 ];
 
 (* Print all BIR expressions as words expressions and check that they are correct. *)

--- a/src/libs/z3_wrapper.py
+++ b/src/libs/z3_wrapper.py
@@ -127,9 +127,11 @@ def z3_to_HolTerm(exp):
             if is_store(exp):
                 return "(store %s)" % " ".join(z3_to_HolTerm(p) for p in exp.children())
             if is_const_array(exp):
-                params = " ".join(string.ascii_lowercase[:exp.num_args()])
+                if exp.num_args() != 1 and len(exp.children()) != 1:
+                    raise NotImplementedError("Not handled: special constant array: {}".format(exp))
+                #params = " ".join(string.ascii_lowercase[:exp.num_args()])
                 expr = ", ".join(z3_to_HolTerm(p) for p in exp.children())
-                return "(\\{}. ({}))".format(params, expr)
+                return "(FUN_MAP2 (K ({})) (UNIV))".format(expr)
 
     raise NotImplementedError("Not handled: {} as {}".format(type(exp), exp))
 

--- a/src/theories/bir_exp_substitutionsScript.sml
+++ b/src/theories/bir_exp_substitutionsScript.sml
@@ -28,6 +28,7 @@ REPEAT CASE_TAC);
 
 val bir_exp_subst_def = Define `
    (!s n. bir_exp_subst s (BExp_Const n) = (BExp_Const n)) /\
+   (!s aty vty mmap. bir_exp_subst s (BExp_MemConst aty vty mmap) = (BExp_MemConst aty vty mmap)) /\
    (!s v. bir_exp_subst s (BExp_Den v) = bir_exp_subst_var s v) /\
    (!s ct e ty.
       bir_exp_subst s (BExp_Cast ct e ty) =
@@ -197,6 +198,7 @@ val bir_exp_subst1_def = Define `
 
 val bir_exp_subst1_REWRS = store_thm ("bir_exp_subst1_REWRS",
 `` (!v ve n. bir_exp_subst1 v ve (BExp_Const n) = (BExp_Const n)) /\
+   (!v ve aty vty mmap. bir_exp_subst1 v ve (BExp_MemConst aty vty mmap) = (BExp_MemConst aty vty mmap)) /\
    (!v ve v'. bir_exp_subst1 v ve (BExp_Den v') = (if v = v' then ve else (BExp_Den v'))) /\
    (!v ve ct e ty.
       bir_exp_subst1 v ve (BExp_Cast ct e ty) =

--- a/src/tools/lifter/bir_exp_liftingScript.sml
+++ b/src/tools/lifter/bir_exp_liftingScript.sml
@@ -71,7 +71,8 @@ val bir_mf2mm_def = Define `
 
 
 val bir_FLOOKUP_mmap_w2n__thm = store_thm("bir_FLOOKUP_mmap_w2n__thm", ``
-  !mmap_w a. FLOOKUP (bir_mmap_w_w2n mmap_w) (a MOD dimword (:'a)) = OPTION_MAP w2n (FLOOKUP mmap_w (n2w a : 'a word))
+  !mmap_w a. FLOOKUP (bir_mmap_w_w2n mmap_w) (a MOD dimword (:'a)) =
+               OPTION_MAP w2n (FLOOKUP mmap_w (n2w a : 'a word))
 ``,
   REPEAT STRIP_TAC >>
   REWRITE_TAC [FLOOKUP_DEF] >>
@@ -108,7 +109,8 @@ val bir_FLOOKUP_mmap_w2n__thm = store_thm("bir_FLOOKUP_mmap_w2n__thm", ``
 );
 
 val bir_FLOOKUP_mmap_n2w__thm = store_thm("bir_FLOOKUP_mmap_n2w__thm", ``
-  !mmap a. FLOOKUP (bir_mmap_n2w mmap) a = OPTION_MAP n2w (FLOOKUP mmap ((w2n (a : 'a word))))
+  !mmap a. FLOOKUP (bir_mmap_n2w mmap) a =
+             OPTION_MAP n2w (FLOOKUP mmap ((w2n (a : 'a word))))
 ``,
   REPEAT STRIP_TAC >>
   REWRITE_TAC [FLOOKUP_DEF] >>
@@ -148,14 +150,16 @@ val w2n_MOD_dimword_thm = prove(``
 );
 
 val bir_FLOOKUP_mmap_w2n_thm = store_thm("bir_FLOOKUP_mmap_w2n_thm", ``
-  !mmap_w a. FLOOKUP (bir_mmap_w_w2n mmap_w) (w2n (a:'a word)) = OPTION_MAP w2n (FLOOKUP mmap_w a)
+  !mmap_w a. FLOOKUP (bir_mmap_w_w2n mmap_w) (w2n (a:'a word)) =
+               OPTION_MAP w2n (FLOOKUP mmap_w a)
 ``,
   REPEAT STRIP_TAC >>
   METIS_TAC [bir_FLOOKUP_mmap_w2n__thm, n2w_w2n, w2n_MOD_dimword_thm]
 );
 
 val bir_FLOOKUP_mmap_n2w_thm = store_thm("bir_FLOOKUP_mmap_n2w_thm", ``
-  !mmap a. FLOOKUP (bir_mmap_n2w mmap) (n2w a : 'a word) = OPTION_MAP n2w (FLOOKUP mmap (a MOD dimword (:'a)))
+  !mmap a. FLOOKUP (bir_mmap_n2w mmap) (n2w a : 'a word) =
+             OPTION_MAP n2w (FLOOKUP mmap (a MOD dimword (:'a)))
 ``,
   REPEAT STRIP_TAC >>
   REWRITE_TAC [bir_FLOOKUP_mmap_n2w__thm, w2n_n2w]
@@ -202,7 +206,8 @@ val bir_mmap_w_n2w_w2n_thm = store_thm("bir_mmap_w_n2w_w2n_thm", ``
 );
 
 val bir_load_mmap_MOD_dimword_thm = store_thm("bir_load_mmap_MOD_dimword_thm", ``
-  !mem_n a.   bir_load_mmap (bir_mmap_w_w2n (bir_mmap_n2w mem_n : 'a word |-> 'b word)) (a MOD dimword (:'a))
+  !mem_n a.   bir_load_mmap (bir_mmap_w_w2n (bir_mmap_n2w mem_n : 'a word |-> 'b word))
+                            (a MOD dimword (:'a))
             = (bir_load_mmap mem_n (a MOD dimword (:'a))) MOD dimword (:'b)
 ``,
   REPEAT STRIP_TAC >>
@@ -229,7 +234,9 @@ val bir_load_mmap_w_bir_mmap_n2w_thm = store_thm("bir_load_mmap_w_bir_mmap_n2w_t
 
 val bir_load_w2n_mf2mm_load_n2w_thm = prove (``
   !mem_n a.
-    (bir_load_mmap (bir_mmap_w_w2n (bir_mf2mm (bir_load_mmap_w (bir_mmap_n2w mem_n : 'a word |-> 'b word)))) (a MOD dimword(:'a)))
+    (bir_load_mmap (bir_mmap_w_w2n (bir_mf2mm (bir_load_mmap_w
+                      (bir_mmap_n2w mem_n : 'a word |-> 'b word))))
+                   (a MOD dimword(:'a)))
     =
     ((bir_load_mmap mem_n (a MOD dimword(:'a))) MOD dimword(:'b))
 ``,

--- a/src/tools/lifter/bir_inst_liftingScript.sml
+++ b/src/tools/lifter/bir_inst_liftingScript.sml
@@ -451,7 +451,10 @@ FULL_SIMP_TAC list_ss [bmr_rel_def] >>
   REV_FULL_SIMP_TAC (std_ss++holBACore_ss) [] >>
   REPEAT BasicProvers.VAR_EQ_TAC >>
   Q.EXISTS_TAC `mem_n'` >> ASM_REWRITE_TAC[] >>
-  Tactical.REVERSE CONJ_TAC >- METIS_TAC[bir_env_var_is_declared_ORDER] >>
+  Tactical.REVERSE CONJ_TAC >- (
+    METIS_TAC[n2w_bir_load_mmap_w2n_thm,
+              bir_env_var_is_declared_ORDER]
+  ) >>
 
   ASM_SIMP_TAC std_ss [bir_env_read_def, pairTheory.pair_case_thm,
     bir_updateB_desc_value_def]

--- a/src/tools/lifter/bir_lifter_simple_interfaceLib.sml
+++ b/src/tools/lifter/bir_lifter_simple_interfaceLib.sml
@@ -48,6 +48,7 @@ fun err_to_str disassemble_fun ((err_pc, err_inst, err_inst_desc, err_descr):bir
       val ef = bir_exp_nonstandards;
     in
       if is_BExp_Const exp then []
+      else if is_BExp_MemConst exp then []
       else if is_BExp_Den exp then []
       else if is_BExp_Cast exp then
         let
@@ -122,6 +123,7 @@ fun err_to_str disassemble_fun ((err_pc, err_inst, err_inst_desc, err_descr):bir
       val ef = bir_exp_count_bir_nodes_mod;
     in
       if is_BExp_Const exp then 1
+      else if is_BExp_MemConst exp then 1
       else if is_BExp_Den exp then 1
       else if is_BExp_Cast exp then
         let

--- a/src/tools/lifter/bir_lifting_machinesScript.sml
+++ b/src/tools/lifter/bir_lifting_machinesScript.sml
@@ -118,7 +118,7 @@ val bir_machine_lifted_mem_def = Define `bir_machine_lifted_mem (BMLM v lf) bs m
 
 ?sa sb mem_n. (bir_var_type v = BType_Mem sa sb) /\
 (bir_env_read v bs.bst_environ = BVal_Mem sa sb mem_n) /\
-(lf ms = (\a. n2w (mem_n (w2n a)))) /\
+(lf ms = (\a. n2w (bir_load_mmap mem_n (w2n a)))) /\
 (bir_env_var_is_declared bs.bst_environ (bir_temp_var T v))`;
 
 
@@ -171,7 +171,9 @@ SIMP_TAC (std_ss++bir_TYPES_ss) [bir_machine_lifted_mem_def,
   bir_env_vars_are_initialised_EMPTY,
   bir_env_var_is_initialised_def,
   bir_env_read_NEQ_UNKNOWN, type_of_bir_val_def,
-  GSYM LEFT_FORALL_IMP_THM]);
+  GSYM LEFT_FORALL_IMP_THM] >>
+REWRITE_TAC [n2w_bir_load_mmap_w2n_thm]
+);
 
 
 

--- a/src/tools/lifter/bir_lifting_machinesScript.sml
+++ b/src/tools/lifter/bir_lifting_machinesScript.sml
@@ -172,7 +172,7 @@ SIMP_TAC (std_ss++bir_TYPES_ss) [bir_machine_lifted_mem_def,
   bir_env_var_is_initialised_def,
   bir_env_read_NEQ_UNKNOWN, type_of_bir_val_def,
   GSYM LEFT_FORALL_IMP_THM] >>
-REWRITE_TAC [n2w_bir_load_mmap_w2n_thm]
+  REWRITE_TAC [n2w_bir_load_mmap_w2n_thm]
 );
 
 

--- a/src/tools/pass/bir_passificationLib.sml
+++ b/src/tools/pass/bir_passificationLib.sml
@@ -75,6 +75,8 @@ local
     (* Leaves *)
     if is_BExp_Const exp
     then exp
+    else if is_BExp_MemConst exp
+    then exp
     else if is_BExp_Den exp
     then let
            val var = dest_BExp_Den exp

--- a/src/tools/wp/bir_wpScript.sml
+++ b/src/tools/wp/bir_wpScript.sml
@@ -362,6 +362,9 @@ Induct_on `ex'` >| [
   (* Const *)
   FULL_SIMP_TAC std_ss [bir_exp_subst_def],
 
+  (* MemConst *)
+  FULL_SIMP_TAC std_ss [bir_exp_subst_def],
+
   (* Den *)
   REPEAT STRIP_TAC >>
   Cases_on `b` >> Cases_on `v` >>


### PR DESCRIPTION
This change should simplify working with execution tools, SMT solver and others as well. In fact, the memory semantics was already a finite mapping before. After this change it is just more explicit and I believe that this eases our proofs.

Please tell me what you think in general and also about the concrete changes.

PS: I also adjusted the HolSmtLib code in our HOL to work with the finite maps instead of functions. Please have a look at this as well.
[HOL for HolBA with fmap HolSmtLib](/kth-step/HOL/tree/for_holba_smtfmap)