### PR TITLE
Travis: Slack notifications and encrypt email

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 notifications:
-  email:
-    recipients:
-      - andili@kth.se
-    on_success: always
-    on_failure: always
-
+  slack:
+    secure: ECND9JC2WAYuuqjvCB5NBNikS5RgPzVqEwKN9W/Mex3J3mtYihjQdCEKXv3dtc8hXcIIvPzPWgiC4/ei82ZHW5SiPOSXBW0TKhrWHVuA8NCg3Hb9YzVqi+9lIL5gnXEZA2I57sTevoQDdu4dPMYcKy+nNWTgnNHo5XOPjITnSOG+JXfTizBg4zMWEWpvZLPIocj9Y21RjHV5YqrTWG9ve5yJyH9NYFH1TB3wfTi+hRpEEAxgtOcM0IxS2RuapE5awaRT8LtCrRYNPfjAmUvs5dE3gZ81t0BvFuxwL/I0VKg1A/wmZfFLM8Ug7tPmRTEqZ14T2Eks4ZyxmbC2Gcyei6zbdquYeDp5cUC09BOD8KPAHMha+bWRZigAJ2HLv8mIBuLiP86N/U+XysksQnx0l12HBiOoCIxjHXDgrMdDr6lyzCTbM3cN+4921lYRPBz3as8WOY7tj16AsvlY/wsQRrCMb28MReait1LckggHHIFflNhTnM0vTD/uw1EaEHslUuQVFcC44ADWVY5Z1yrYk9bH0DgySQ9JX9/ZPbS8d/a8B+ed2j9w1dJMusEV1SAkSF3z22jwxesUDXAeBWd8vd6CxZYcZQIglxwVWSAXAuYCHBRqfcC2XffGNLARSxe28G6NFGP/0Hxn9jCmf7N3HymjRPWNauqczoRD9PHfRhQ=
 
 language: c
 dist: xenial


### PR DESCRIPTION
I encrypted Andreas' email address to prevent forks to send him emails about Travis status.