### PR TITLE
Scripts: ZSH support

### DIFF
--- a/scripts/setup/autoenv.sh
+++ b/scripts/setup/autoenv.sh
@@ -12,12 +12,12 @@ SETUP_DIR=$(readlink -f "${SETUP_DIR}")
 #####################################################
 
 # script needs to run sourced
-if [ "$0" == "$BASH_SOURCE" ]; then
+if [[ "$0" == "$BASH_SOURCE" ]]; then
   echo "ERROR: script is not sourced"
   exit 1
 fi
 
-if [ ! -z "${HOLBA_SKIP_AUTOENV}" ]; then
+if [[ ! -z "${HOLBA_SKIP_AUTOENV}" ]]; then
   echo "INFO: skipping autoenv.sh"
   return 0
 fi
@@ -33,8 +33,8 @@ if [ -z "${HOLBA_DIR}" ]; then
   HOLBA_DIR=$(readlink -f "${HOLBA_DIR}")
 fi
 
-if [ ! -d "${HOLBA_DIR}/scripts/setup" ]; then
-  echo "ERROR: HOLBA_DIR not found"
+if [[ ! -d "${HOLBA_DIR}/scripts/setup" ]]; then
+  echo "ERROR: HOLBA_DIR not found (tried $HOLBA_DIR)"
   return 2
 fi
 
@@ -58,12 +58,12 @@ function print_export_msg() {
 ####### HOLBA_OPT_DIR
 
 # the parameter to this script has precedence
-if [ ! -z "${OPT_DIR_PARAM}" ]; then
+if [[ ! -z "${OPT_DIR_PARAM}" ]]; then
   print_export_msg "Exporting HOLBA_OPT_DIR (parameter)"
   export HOLBA_OPT_DIR=$(readlink -f "${OPT_DIR_PARAM}")
 else
   # if there is no parameter, and no environment variable
-  if [ -z "${HOLBA_OPT_DIR}" ]; then
+  if [[ -z "${HOLBA_OPT_DIR}" ]]; then
     # take opt in HOLBA_DIR
     print_export_msg "Exporting HOLBA_OPT_DIR (default in HolBA)"
     export HOLBA_OPT_DIR="${HOLBA_DIR}/opt"
@@ -76,7 +76,7 @@ echo
 ####### HOLBA_HOLMAKE
 
 # make Holmake available
-if [ -z "${HOLBA_HOLMAKE}" ]; then
+if [[ -z "${HOLBA_HOLMAKE}" ]]; then
   HOL4_DIR=${HOLBA_OPT_DIR}/hol_k12_holba
   print_export_msg "Exporting HOLBA_HOLMAKE"
   export HOLBA_HOLMAKE=${HOL4_DIR}/bin/Holmake
@@ -95,15 +95,15 @@ echo
 ## SECONDARY: PYTHONPATH, LD_LIBRARY_PATH,
 ##            HOL4_Z3_EXECUTABLE, HOL4_Z3_WRAPPED_EXECUTABLE
 
-if [ -z "${HOLBA_Z3_DIR}" ]; then
+if [[ -z "${HOLBA_Z3_DIR}" ]]; then
   Z3_DIR=${HOLBA_OPT_DIR}/z3-4.8.4.d6df51951f4c
-  if [ -d "${Z3_DIR}/bin/python" ]; then
+  if [[ -d "${Z3_DIR}/bin/python" ]]; then
     print_export_msg "Exporting HOLBA_Z3_DIR"
     export HOLBA_Z3_DIR=${Z3_DIR}
   else
     # try the folder name for the version compiled from source
     Z3_DIR=${HOLBA_OPT_DIR}/z3_4.8.4
-    if [ -d "${Z3_DIR}/bin/python" ]; then
+    if [[ -d "${Z3_DIR}/bin/python" ]]; then
       print_export_msg "Exporting HOLBA_Z3_DIR"
       export HOLBA_Z3_DIR=${Z3_DIR}
     fi
@@ -112,7 +112,7 @@ fi
 echo "Using HOLBA_Z3_DIR=${HOLBA_Z3_DIR}"
 
 # if HOLBA_Z3_DIR has been found, export secondary variables
-if [ ! -z "${HOLBA_Z3_DIR}" ]; then
+if [[ ! -z "${HOLBA_Z3_DIR}" ]]; then
     print_export_msg "Exporting HOLBA_Z3_DIR's secondaries"
     export PYTHONPATH=${HOLBA_Z3_DIR}/bin/python
     export LD_LIBRARY_PATH=${HOLBA_Z3_DIR}/bin:$LD_LIBRARY_PATH
@@ -129,9 +129,9 @@ echo
 
 ####### HOLBA_EMBEXP_DIR
 
-if [ -z "${HOLBA_EMBEXP_DIR}" ]; then
+if [[ -z "${HOLBA_EMBEXP_DIR}" ]]; then
   EMBEXP_DIR=${HOLBA_OPT_DIR}/embexp
-  if [ -d "${EMBEXP_DIR}/EmbExp-ProgPlatform" ]; then
+  if [[ -d "${EMBEXP_DIR}/EmbExp-ProgPlatform" ]]; then
     print_export_msg "Exporting HOLBA_EMBEXP_DIR"
     export HOLBA_EMBEXP_DIR=${EMBEXP_DIR}
   fi
@@ -143,9 +143,9 @@ echo
 
 ####### HOLBA_GCC_ARM8_CROSS
 
-if [ -z "${HOLBA_GCC_ARM8_CROSS}" ]; then
+if [[ -z "${HOLBA_GCC_ARM8_CROSS}" ]]; then
   CROSS="${HOLBA_OPT_DIR}/gcc-arm8-8.2-2018.08-aarch64-elf/bin/aarch64-elf-"
-  if [ -f "${CROSS}gcc" ]; then
+  if [[ -f "${CROSS}gcc" ]]; then
     print_export_msg "HOLBA_GCC_ARM8_CROSS"
     export HOLBA_GCC_ARM8_CROSS=${CROSS}
   fi
@@ -157,7 +157,7 @@ echo
 
 ####### HOLBA_SCAMV_LOGS
 
-if [ -z "${HOLBA_SCAMV_LOGS}" ]; then
+if [[ -z "${HOLBA_SCAMV_LOGS}" ]]; then
   LOGS_DIR=${HOLBA_DIR}/logs
   print_export_msg "Exporting HOLBA_SCAMV_LOGS"
   export HOLBA_SCAMV_LOGS=${LOGS_DIR}

--- a/scripts/setup/install_embexp.sh
+++ b/scripts/setup/install_embexp.sh
@@ -26,7 +26,7 @@ EMBEXP_DIR=${HOLBA_OPT_DIR}/embexp
 
 
 # if the output directory exists, we already have a embexp in the cache
-if [ -d "${EMBEXP_DIR}" ]; then
+if [[ -d "${EMBEXP_DIR}" ]]; then
   echo "embexp is already available in the cache, exiting."
   exit 0
 else

--- a/scripts/setup/install_gcc_arm8.sh
+++ b/scripts/setup/install_gcc_arm8.sh
@@ -32,7 +32,7 @@ GCC_DIR=${HOLBA_OPT_DIR}/gcc-arm8-8.2-2018.08-aarch64-elf
 
 
 # if the output directory exists, we already have a gcc in the cache
-if [ -d "${GCC_DIR}" ]; then
+if [[ -d "${GCC_DIR}" ]]; then
   echo "gcc_arm8 is already available in the cache, exiting."
   exit 0
 else

--- a/scripts/setup/install_hol4.sh
+++ b/scripts/setup/install_hol4.sh
@@ -20,7 +20,7 @@ source "${SETUP_DIR}/autoenv.sh" "${OPT_DIR_PARAM}"
 POLY_VERSION="v5.7.1"
 
 # if poly version is specified in the environment, use this
-if [ ! -z "${HOLBA_POLYML_VERSION}" ]; then
+if [[ ! -z "${HOLBA_POLYML_VERSION}" ]]; then
   POLY_VERSION=${HOLBA_POLYML_VERSION}
 fi
 
@@ -39,12 +39,12 @@ HOL4_DIR=${HOLBA_OPT_DIR}/hol_k12_holba
 
 
 # if HOL does exist, check if it is up-to-date and remove it in case it is not
-if [ -d "${HOL4_DIR}" ]; then
+if [[ -d "${HOL4_DIR}" ]]; then
   cd "${HOL4_DIR}"
   git fetch origin
 
   # does the remote branch exist locally?
-  if [ ! `git branch --all --list origin/${GIT_BRANCH}` ]; then
+  if [[ ! `git branch --all --list origin/${GIT_BRANCH}` ]]; then
     echo "the cached HOL4 version seems to be on another branch, deleting it now"
     # delete the stale HOL4 build
     cd "${HOLBA_OPT_DIR}"
@@ -53,7 +53,7 @@ if [ -d "${HOL4_DIR}" ]; then
     # is there a difference between the current and the remote branch?
     GIT_DIFF=$(git diff)
     GIT_DIFF_REMOTE=$(git diff HEAD remotes/origin/${GIT_BRANCH})
-    if [ "${GIT_DIFF}${GIT_DIFF_REMOTE}" ]; then
+    if [[ "${GIT_DIFF}${GIT_DIFF_REMOTE}" ]]; then
       echo "the cached HOL4 version has differences, deleting it now"
       # delete the stale HOL4 build
       cd "${HOLBA_OPT_DIR}"
@@ -67,7 +67,7 @@ cd "${HOLBA_OPT_DIR}"
 
 
 # if HOL does not exist already, clone and build it
-if [ ! -d "${HOL4_DIR}" ]; then
+if [[ ! -d "${HOL4_DIR}" ]]; then
   # clone the specified HOL4 branch only
   git clone -b ${GIT_BRANCH} --single-branch ${GIT_URL} "${HOL4_DIR}"
   cd "${HOL4_DIR}"

--- a/scripts/setup/install_mk_env.sh
+++ b/scripts/setup/install_mk_env.sh
@@ -17,7 +17,7 @@ source "${SETUP_DIR}/autoenv.sh"
 
 # set output file param if it is unset
 OUTPUT_FILE=${OUTPUT_FILE_PARAM}
-if [ -z "${OUTPUT_FILE}" ]; then
+if [[ -z "${OUTPUT_FILE}" ]]; then
   OUTPUT_FILE=${HOLBA_OPT_DIR}/env.sh
 fi
 echo "Output file: ${OUTPUT_FILE}"
@@ -41,7 +41,7 @@ OUTPUT="#!/usr/bin/env bash\n"
 for var in "${vararr[@]}"
 do
   var_val=$(printenv ${var} | cat)
-  if [ ! -z "${var_val}" ]; then
+  if [[ ! -z "${var_val}" ]]; then
     printf -v var_pad %${PAD_LEN}.${PAD_LEN}s "${var}"
     OUTPUT="${OUTPUT}\nexport ${var_pad}=${var_val}"
     echo "Exporting ${var}"

--- a/scripts/setup/install_poly.sh
+++ b/scripts/setup/install_poly.sh
@@ -22,7 +22,7 @@ POLY_BASE="https://github.com/polyml/polyml"
 POLY_VERSION="v5.7.1"
 
 # if poly version is specified in the environment, use this
-if [ ! -z "${HOLBA_POLYML_VERSION}" ]; then
+if [[ ! -z "${HOLBA_POLYML_VERSION}" ]]; then
   POLY_VERSION=${HOLBA_POLYML_VERSION}
 fi
 
@@ -38,7 +38,7 @@ POLY_DIR_SRC=${HOLBA_OPT_DIR}/polyml_${POLY_VERSION}_src
 
 
 # if the output directory exists, we already have a polyml in the cache
-if [ -d "${POLY_DIR}" ]; then
+if [[ -d "${POLY_DIR}" ]]; then
   echo "polyml is already available in the cache, exiting."
   exit 0
 else

--- a/scripts/setup/install_z3.sh
+++ b/scripts/setup/install_z3.sh
@@ -32,7 +32,7 @@ Z3_DIR=${HOLBA_OPT_DIR}/z3-4.8.4.d6df51951f4c
 
 
 # if the output directory exists, we already have a z3 in the cache
-if [ -d "${Z3_DIR}" ]; then
+if [[ -d "${Z3_DIR}" ]]; then
   echo "z3 is already available in the cache, exiting."
   exit 0
 else

--- a/scripts/setup/install_z3_src.sh
+++ b/scripts/setup/install_z3_src.sh
@@ -35,7 +35,7 @@ Z3_DIR_SRC=${HOLBA_OPT_DIR}/z3_${Z3_VERSION}_src
 
 
 # if the output directory exists, we already have a z3 in the cache
-if [ -d "${Z3_DIR}" ]; then
+if [[ -d "${Z3_DIR}" ]]; then
   echo "z3 is already available in the cache, exiting."
   exit 0
 else


### PR DESCRIPTION
=> `scripts/: fix for ZSH (use [[ ]] instead of [ ])`

Doesn't work with `sh`, but it's simpler and safer: https://serverfault.com/a/52050
The initial goal was to fix this: https://unix.stackexchange.com/questions/255480/why-does-behave-differently-inside-in-zsh-and-bash

=> `autoenv.sh: fix sourcing with ZSH`

`BASH_SOURCE` doesn't exist in ZSH. This is a problem when sourcing `autoenv.sh` in ZSH. Fix as suggested [here](https://stackoverflow.com/a/54755784).

----
Follows #43, since it cannot be reopened because of force-push.