### PR TITLE
Some fixes for non-'a observation types (+ 1 PP bugfix + 2 wrap_exn)

### DIFF
--- a/src/shared/bir_ppLib.sml
+++ b/src/shared/bir_ppLib.sml
@@ -48,6 +48,7 @@ struct
 
   fun hol_string_printer _ _ _ {add_string,ustyle,...} _ _ term =
     ustyle [FG Green] (add_string ("\"" ^ (stringSyntax.fromHOLstring term) ^ "\""))
+      handle e => raise term_pp_types.UserPP_Failed
 
   fun bir_immtype_t_printer _ _ _ ppfns _ _ term =
     let

--- a/src/shared/bslSyntax.sml
+++ b/src/shared/bslSyntax.sml
@@ -199,7 +199,8 @@ struct
     let
       (* Instantiate the observation type for all statements *)
       val bl_list_obs_ty = List.map
-        (fn (a, l_stmts, b) => (a, List.map (inst [alpha |-> obs_ty]) l_stmts, b))
+        (fn (a, l_stmts, b) => (a,
+          List.map (inst [mk_bir_program_t_ty alpha |-> mk_bir_program_t_ty obs_ty]) l_stmts, b))
         bl_list
       (* list of terms to term of list *)
       val list_tm = List.map

--- a/src/shared/bslSyntax.sml
+++ b/src/shared/bslSyntax.sml
@@ -196,8 +196,18 @@ struct
   val bprog = mk_BirProgram
     handle e => raise wrap_exn "bprog" e
   fun bprog_list obs_ty bl_list =
-    (curry2 mk_BirProgram_list)
-      obs_ty (List.map (uncurry3 ((curry4 mk_bir_block_list) obs_ty)) bl_list)
+    let
+      (* Instantiate the observation type for all statements *)
+      val bl_list_obs_ty = List.map
+        (fn (a, l_stmts, b) => (a, List.map (inst [alpha |-> obs_ty]) l_stmts, b))
+        bl_list
+      (* list of terms to term of list *)
+      val list_tm = List.map
+        (uncurry3 ((curry4 mk_bir_block_list) obs_ty))
+        bl_list_obs_ty
+    in
+      mk_BirProgram_list (obs_ty, list_tm)
+  end
     handle e => raise wrap_exn "bprog_list" e
 
   (****************************************************************************)

--- a/src/theory/bir/bir_programSyntax.sml
+++ b/src/theory/bir/bir_programSyntax.sml
@@ -6,6 +6,7 @@ open bir_immTheory bir_valuesTheory bir_programTheory;
 
 
 val ERR = mk_HOL_ERR "bir_programSyntax"
+val wrap_exn = Feedback.wrap_exn "bir_programSyntax"
 fun syntax_fns n d m = HolKernel.syntax_fns {n = n, dest = d, make = m} "bir_program"
 
 fun syntax_fns0 s = let val (tm, _, _, is_f) = syntax_fns 0
@@ -102,7 +103,7 @@ fun dest_bir_block tm = let
   val last_stmt = Lib.assoc "bb_last_statement" l
 in
   (lbl, stmts, last_stmt)
-end handle HOL_ERR _ => raise ERR "dest_bir_block" "";
+end handle e => raise wrap_exn "dest_bir_block" e;
 
 val is_bir_block = can dest_bir_block;
 
@@ -115,7 +116,7 @@ fun mk_bir_block (tm_lbl, tm_stmts, tm_last_stmt) = let
            ("bb_last_statement", tm_last_stmt)];
 in
   TypeBase.mk_record (ty, l)
-end handle HOL_ERR _ => raise ERR "mk_bir_block" "";
+end handle e => raise wrap_exn "mk_bir_block" e;
 
 fun dest_bir_block_list tm = let
   val (tm_lbl, tm_stmts, tm_last_stmt) = dest_bir_block tm;
@@ -123,14 +124,14 @@ fun dest_bir_block_list tm = let
   val ty'' = dest_bir_stmt_basic_t_ty ty'
 in
   (ty'', tm_lbl, l_stmts, tm_last_stmt)
-end handle HOL_ERR _ => raise ERR "dest_bir_block_list" "";
+end handle e => raise wrap_exn "dest_bir_block_list" e;
 
 fun mk_bir_block_list (ty, tm_lbl, l_stmts, tm_last_stmt) = let
   val ty' = mk_bir_stmt_basic_t_ty ty
   val tm_stmts = listSyntax.mk_list (l_stmts, ty')
 in
   mk_bir_block (tm_lbl, tm_stmts, tm_last_stmt)
-end handle HOL_ERR _ => raise ERR "mk_bir_block_list" "";
+end handle e => raise wrap_exn "mk_bir_block_list" e;
 
 
 (* bir_program_t *)
@@ -153,14 +154,14 @@ fun dest_BirProgram_list tm = let
   val (l, ty) = listSyntax.dest_list l_tm
 in
   (dest_bir_block_t_ty ty, l)
-end handle HOL_ERR _ => raise ERR "dest_BirProgram_list" "";
+end handle e => raise wrap_exn "dest_BirProgram_list" e;
 
 fun mk_BirProgram_list (ty, tms) = let
   val ty' = mk_bir_block_t_ty ty
   val l_tm = listSyntax.mk_list (tms, ty')
 in
   mk_BirProgram l_tm
-end handle HOL_ERR _ => raise ERR "mk_BirProgram_list" "";
+end handle e => raise wrap_exn "mk_BirProgram_list" e;
 
 
 (* bir_programcounter_t *)
@@ -173,7 +174,7 @@ fun dest_bir_programcounter tm = let
   val index = Lib.assoc "bpc_index" l
 in
   (lbl, index)
-end handle HOL_ERR _ => raise ERR "dest_bir_programcounter" "";
+end handle e => raise wrap_exn "dest_bir_programcounter" e;
 
 val is_bir_programcounter = can dest_bir_programcounter;
 
@@ -182,7 +183,7 @@ fun mk_bir_programcounter (tm_lbl, tm_index) = let
            ("bpc_index", tm_index)];
 in
   TypeBase.mk_record (bir_programcounter_t_ty, l)
-end handle HOL_ERR _ => raise ERR "mk_bir_programcounter" "";
+end handle e => raise wrap_exn "mk_bir_programcounter" e;
 
 
 val (bir_block_pc_tm,  mk_bir_block_pc, dest_bir_block_pc, is_bir_block_pc)  = syntax_fns1 "bir_block_pc";
@@ -232,7 +233,7 @@ fun dest_bir_state tm = let
   val status = Lib.assoc "bst_status" l
 in
   (pc, env, status)
-end handle HOL_ERR _ => raise ERR "dest_bir_state" "";
+end handle e => raise wrap_exn "dest_bir_state" e;
 
 val is_bir_state = can dest_bir_state;
 
@@ -242,7 +243,7 @@ fun mk_bir_state (pc, env, status) = let
            ("bst_status", status)];
 in
   TypeBase.mk_record (bir_state_t_ty, l)
-end handle HOL_ERR _ => raise ERR "mk_bir_state" "";
+end handle e => raise wrap_exn "mk_bir_state" e;
 
 
 val (bst_status_tm,  mk_bst_status, dest_bst_status, is_bst_status)  = syntax_fns1 "bir_state_t_bst_status";

--- a/src/tools/wp/bir_wpLib.sml
+++ b/src/tools/wp/bir_wpLib.sml
@@ -129,8 +129,8 @@ struct
       val no_declare_conv = [bir_declare_free_prog_exec_def,
                              bir_isnot_declare_stmt_def]
 
-      fun wrap_exn_ exn term message = wrap_exn ("bir_wp_comp_wps_iter_step0_init::"
-        ^ message ^ ": \n" ^ (Hol_pp.term_to_string term) ^ "\n") exn
+      fun wrap_exn_ exn term message = wrap_exn
+        (message ^ ": \n" ^ (Hol_pp.term_to_string term) ^ "\n") exn
       val concl_tm = (snd o dest_eq o concl)
 
       (* TODO: Create bir_is_bool_expSyntax for the below *)
@@ -160,7 +160,8 @@ struct
       val thm = GENL [var_l, var_wps, var_wps1] thm;
     in
       thm
-    end;
+    end
+      handle e => raise wrap_exn "bir_wp_comp_wps_iter_step0_init" e;
 
   (* Include current label in reasoning *)
   fun bir_wp_comp_wps_iter_step1 label prog_thm (program, post, ls)
@@ -302,7 +303,8 @@ struct
       val wps1_bool_sound_thm = MP thm wps1_thm
     in
       (wps1, wps1_bool_sound_thm)
-    end;
+    end
+      handle e => raise wrap_exn "bir_wp_comp_wps_iter_step2" e;
 
   (*
   (* helper for simple traversal in recursive procedure *)
@@ -331,7 +333,8 @@ struct
       (k)::(List.filter (fn k1 => not (cmp_label k1 k))
 			(bir_wp_fmap_to_dom_list fmap1)
 	   )
-    end;
+    end
+      handle e => raise wrap_exn "bir_wp_fmap_to_dom_list" e;
 
   fun bir_wp_init_rec_proc_jobs prog_term wps_term =
     let
@@ -346,7 +349,8 @@ struct
       val blstodo = List.filter blstodofilter blocks
     in
       (wpsdom, blstodo)
-    end;
+    end
+      handle e => raise wrap_exn "bir_wp_init_rec_proc_jobs" e;
 
   (* Recursive procedure for traversing the control flow graph *)
   fun bir_wp_comp_wps prog_thm ((wps, wps_bool_sound_thm),
@@ -373,8 +377,7 @@ struct
 	          ((is_lbl_in_wps o dest_BLE_Label o #3 o
                     dest_BStmt_CJmp) end_statement)
 	  else
-	    raise ERR "bir_wp_comp_wps"
-                      "unhandled end_statement type."
+	    raise ERR "bir_wp_comp_wps" "unhandled end_statement type."
 	end) blstodo
     in
       case block of
@@ -457,7 +460,8 @@ struct
           in
             (wps, wps_bool_sound_thm)
           end
-    end;
+    end
+      handle e => raise wrap_exn "bir_wp_comp_wps" e;
 
   end (* local *)
 


### PR DESCRIPTION
The commit messages should be clear enough :slightly_smiling_face: 