### PR TITLE
Add simplification library in bir-support

### DIFF
--- a/src/theory/bir-support/HolBASimps.sig
+++ b/src/theory/bir-support/HolBASimps.sig
@@ -3,9 +3,9 @@ sig
    include Abbrev
 
    (* Rewrite rules to determine statements of a program *)
-   val stmts_of_prog_ss : simpLib.ssfrag;
+   val STMTS_OF_PROG_ss : simpLib.ssfrag;
 
    (* Rewrite rules to determine variables of a program *)
-   val vars_of_prog_ss : simpLib.ssfrag;
+   val VARS_OF_PROG_ss : simpLib.ssfrag;
 
 end

--- a/src/theory/bir-support/HolBASimps.sig
+++ b/src/theory/bir-support/HolBASimps.sig
@@ -1,0 +1,11 @@
+signature HolBASimps =
+sig
+   include Abbrev
+
+   (* Rewrite rules to determine statements of a program *)
+   val stmts_of_prog_ss : simpLib.ssfrag;
+
+   (* Rewrite rules to determine variables of a program *)
+   val vars_of_prog_ss : simpLib.ssfrag;
+
+end

--- a/src/theory/bir-support/HolBASimps.sml
+++ b/src/theory/bir-support/HolBASimps.sml
@@ -19,8 +19,8 @@ val aux_thms = [LIST_TO_SET, combinTheory.K_THM];
 val pred_set_thms = [IMAGE_INSERT, IMAGE_EMPTY, BIGUNION_INSERT, BIGUNION_EMPTY, UNION_EMPTY, INSERT_UNION_EQ];
 
 
-val stmts_of_prog_ss = rewrites (bir_TYPES_thms@bir_stmts_of_prog_thms@aux_thms@pred_set_thms);
-val vars_of_prog_ss = rewrites (bir_TYPES_thms@[bir_vars_of_program_ALT_DEF]@bir_vars_of_exp_thms@
+val STMTS_OF_PROG_ss = rewrites (bir_TYPES_thms@bir_stmts_of_prog_thms@aux_thms@pred_set_thms);
+val VARS_OF_PROG_ss = rewrites (bir_TYPES_thms@[bir_vars_of_program_ALT_DEF]@bir_vars_of_exp_thms@
                                 bir_vars_of_stmt_thms@bir_stmts_of_prog_thms@aux_thms@pred_set_thms);
 
 

--- a/src/theory/bir-support/HolBASimps.sml
+++ b/src/theory/bir-support/HolBASimps.sml
@@ -1,0 +1,27 @@
+structure HolBASimps :> HolBASimps =
+struct
+
+open HolKernel boolLib liteLib simpLib Parse bossLib;
+
+open bir_typing_progTheory;
+open bir_typing_expTheory;
+open HolBACoreSimps;
+
+open listTheory;
+open pred_setTheory;
+
+
+val bir_vars_of_exp_thms = [bir_vars_of_exp_def, bir_vars_of_label_exp_def]
+val bir_vars_of_stmt_thms = [bir_vars_of_stmt_def, bir_vars_of_stmtE_def, bir_vars_of_stmtB_def];
+val bir_stmts_of_prog_thms = [bir_stmts_of_prog_def, bir_stmts_of_block_def];
+
+val aux_thms = [LIST_TO_SET, combinTheory.K_THM];
+val pred_set_thms = [IMAGE_INSERT, IMAGE_EMPTY, BIGUNION_INSERT, BIGUNION_EMPTY, UNION_EMPTY, INSERT_UNION_EQ];
+
+
+val stmts_of_prog_ss = rewrites (bir_TYPES_thms@bir_stmts_of_prog_thms@aux_thms@pred_set_thms);
+val vars_of_prog_ss = rewrites (bir_TYPES_thms@[bir_vars_of_program_ALT_DEF]@bir_vars_of_exp_thms@
+                                bir_vars_of_stmt_thms@bir_stmts_of_prog_thms@aux_thms@pred_set_thms);
+
+
+end

--- a/src/theory/bir-support/selftest.sml
+++ b/src/theory/bir-support/selftest.sml
@@ -54,7 +54,7 @@ val progvars_expected = ``
   {BVar "R0" (BType_Imm Bit64);
    BVar "Mem" (BType_Mem Bit64 Bit8)}``;
 
-val progvars_val = (rhs o concl o ((SIMP_CONV (pure_ss++vars_of_prog_ss) []) THENC EVAL)) ``bir_vars_of_program ^prog``;
+val progvars_val = (rhs o concl o ((SIMP_CONV (pure_ss++VARS_OF_PROG_ss) []) THENC EVAL)) ``bir_vars_of_program ^prog``;
 
 val _ = if progvars_expected = progvars_val then () else
         raise Fail "Incorrect result for variables of program.";

--- a/src/theory/bir-support/selftest.sml
+++ b/src/theory/bir-support/selftest.sml
@@ -5,7 +5,59 @@ open bir_bool_expSyntax;
 open bir_exp_substitutionsSyntax;
 open bir_extra_expsSyntax;
 open bir_interval_expSyntax;
+open HolBASimps;
 
 val _ = print "HolBA bir-support files successfully loaded.\n";
+
+
+val _ = print "Testing HolBASimps - vars_of_program.\n";
+
+val prog = ``
+       BirProgram [
+         <|bb_label :=
+             BL_Label "entry";
+           bb_statements :=
+             [BStmt_Assign (BVar "Mem" (BType_Mem Bit64 Bit8))
+                           (BExp_Store (BExp_Den (BVar "Mem" (BType_Mem Bit64 Bit8)))
+                                       (BExp_Const (Imm64 25w))
+                                       BEnd_LittleEndian
+                                       (BExp_Const (Imm64 26w)));
+	      BStmt_Assign (BVar "Mem" (BType_Mem Bit64 Bit8))
+                           (BExp_Store (BExp_Den (BVar "Mem" (BType_Mem Bit64 Bit8)))
+                                       (BExp_Const (Imm64 25w))
+                                       BEnd_LittleEndian
+                                       (BExp_Const (Imm64 25w)))];
+           bb_last_statement :=
+             BStmt_Jmp (BLE_Label (BL_Address (Imm32 0x102w)))|>;
+
+         <|bb_label :=
+             BL_Address (Imm32 0x102w);
+           bb_statements :=
+             [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
+                           (BExp_Cast BIExp_UnsignedCast
+                                      (BExp_Load (BExp_Den (BVar "Mem" (BType_Mem Bit64 Bit8)))
+                                                 (BExp_Const (Imm64 24w))
+                                                 BEnd_LittleEndian
+                                                 Bit32)
+                                      Bit64)];
+           bb_last_statement :=
+             BStmt_Jmp (BLE_Label (BL_Address (Imm32 0x200w))) |>;
+
+         <|bb_label :=
+             BL_Address (Imm32 0x200w);
+           bb_statements := [];
+           bb_last_statement :=
+             BStmt_Halt (BExp_Const (Imm32 1w)) |>
+       ]``;
+
+val progvars_expected = ``
+  {BVar "R0" (BType_Imm Bit64);
+   BVar "Mem" (BType_Mem Bit64 Bit8)}``;
+
+val progvars_val = (rhs o concl o ((SIMP_CONV (pure_ss++vars_of_prog_ss) []) THENC EVAL)) ``bir_vars_of_program ^prog``;
+
+val _ = if progvars_expected = progvars_val then () else
+        raise Fail "Incorrect result for variables of program.";
+
 
 val _ = Process.exit Process.success;

--- a/src/theory/bir/HolBACoreSimps.sig
+++ b/src/theory/bir/HolBACoreSimps.sig
@@ -2,6 +2,9 @@ signature HolBACoreSimps =
 sig
    include Abbrev
 
+   (* a list over rewrite theorems for all HolBA BIR types *)
+   val bir_TYPES_thms : thm list;
+
    (* Rewrite rules for all the types defined as part of the HolBIR formalisation. *)
    val bir_TYPES_ss : simpLib.ssfrag;
 

--- a/src/theory/bir/HolBACoreSimps.sml
+++ b/src/theory/bir/HolBACoreSimps.sml
@@ -39,7 +39,9 @@ val bir_list_of_types = [
 ];
 
 
-val bir_TYPES_ss = rewrites (flatten (map type_rws bir_list_of_types))
+val bir_TYPES_thms = (flatten (map type_rws bir_list_of_types));
+
+val bir_TYPES_ss = rewrites bir_TYPES_thms;
 
 val bir_SIMPLE_REWRS_imm = rewrites [
   type_of_bir_imm_def,


### PR DESCRIPTION
Now we can simplify to get a set of variables of a program by using:

```
open HolBASimps;
val prog = ``BirProgram ...``
val t = SIMP_CONV (pure_ss++vars_of_prog_ss) [] ``bir_vars_of_program ^prog``;
```