### PR TITLE
Made terminology more consistent in bir_exp_equivScript.sml

### DIFF
--- a/src/theory/bir-support/bir_exp_equivScript.sml
+++ b/src/theory/bir-support/bir_exp_equivScript.sml
@@ -63,7 +63,7 @@ EQ_TAC >| [
 );
 
 (* A BIR disjunction implies the equivalent HOL disjunction. *)
-val bir_disj_impl = store_thm("bir_disj_impl",
+val bir_or_impl = store_thm("bir_or_impl",
   ``!env ex1 ex2.
       ((bir_eval_exp (BExp_BinExp BIExp_Or ex1 ex2) env =
         bir_val_true) ==>
@@ -131,7 +131,7 @@ IMP_RES_TAC bir_bool_values >> (
 
 (* If the BIR negation of a value evaluates to BIR True, then said
  * value itself must evaluate to BIR False. *)
-val bir_neg_val_true = store_thm("bir_neg_val_true",
+val bir_not_val_true = store_thm("bir_not_val_true",
   ``!env ex.
       (bir_eval_exp (BExp_UnaryExp BIExp_Not ex) env =
         bir_val_true) <=>
@@ -175,7 +175,7 @@ blastLib.FULL_BBLAST_TAC
 
 (* BIR disjunction is equivalent to HOL disjunction provided the
  * variables are initialised and the subexpressions are Boolean. *)
-val bir_disj_equiv = store_thm("bir_disj_equiv",
+val bir_or_equiv = store_thm("bir_or_equiv",
   ``!env ex1 ex2.
     bir_is_bool_exp_env env ex1 ==>
     bir_is_bool_exp_env env ex2 ==>
@@ -240,7 +240,7 @@ val bir_impl_equiv = store_thm("bir_impl_equiv",
     )
   ``,
 
-METIS_TAC [bir_disj_equiv, bir_not_equiv, bir_is_bool_exp_env_def,
+METIS_TAC [bir_or_equiv, bir_not_equiv, bir_is_bool_exp_env_def,
            bir_is_bool_exp_not,
            bir_vars_init_not]
 );

--- a/src/theory/tools/wp/bir_wpScript.sml
+++ b/src/theory/tools/wp/bir_wpScript.sml
@@ -246,7 +246,7 @@ PAT_X_ASSUM ``bir_is_bool_exp_env s.bst_environ ex``
               (HO_MATCH_MP bir_bool_values thm)
             ) >>
 REV_FULL_SIMP_TAC std_ss [] >>
-FULL_SIMP_TAC std_ss [bir_neg_val_true, bir_exec_stmtB_def,
+FULL_SIMP_TAC std_ss [bir_not_val_true, bir_exec_stmtB_def,
                       bir_exec_stmt_assume_def,
                       bir_dest_bool_val_TF, bir_val_TF_dist] >>
 Cases_on `s` >> Cases_on `s'` >>


### PR DESCRIPTION
What the title says, purely janitorial work. This might resolve some lingering unclarity from #49 .