### PR TITLE
Obtaining the old Hoare triple from the new

### DIFF
--- a/src/theory/bir-support/bir_program_blocksScript.sml
+++ b/src/theory/bir-support/bir_program_blocksScript.sml
@@ -14,9 +14,9 @@ val _ = new_theory "bir_program_blocks";
 (* ------------------------------------------------------------------------- *)
 (* This theory tries to execute whole blocks in an easy way.
    The PC is only relevant for fetching the next instruction.
-   Moreover, basic staments can only terminate or increment the PC. Therefore
+   Moreover, basic statements can only terminate or increment the PC. Therefore
    executing blocks can be simplified by executing one instruction after the
-   other and just update the PC at the very end.                             *)
+   other and only updating the PC at the very end.                             *)
 (* ------------------------------------------------------------------------- *)
 
 
@@ -138,7 +138,7 @@ FULL_SIMP_TAC (std_ss++holBACore_ss++pairSimps.gen_beta_ss++boolSimps.LIFT_COND_
 (*  Definition of executing lists of basic staments                          *)
 (* ------------------------------------------------------------------------- *)
 
-(* First lets define executing lists of basic statements. *)
+(* First, let's define executing lists of basic statements. *)
 val bir_exec_stmtsB_def = Define `
   (bir_exec_stmtsB [] (l, c, st) = (REVERSE l, c, st)) /\
   (bir_exec_stmtsB (stmt::stmts) (l, c, st) =
@@ -315,7 +315,7 @@ FULL_SIMP_TAC (std_ss++holBACore_ss) [
 (*  Semantics of bir_exec_stmtsB                                             *)
 (* ------------------------------------------------------------------------- *)
 
-(* We can proof that the executing a list of basic statements and then
+(* We can prove that executing a list of basic statements and then
    updating the PC is the same as executing multiple steps and then updating the pc. *)
 
 val bir_exec_stmtsB_COUNTER = store_thm ("bir_exec_stmtsB_COUNTER",
@@ -720,18 +720,8 @@ ASM_SIMP_TAC std_ss [bir_exec_block_SEMANTICS_step_n]);
 (* ------------------------------------------------------------------------- *)
 
 (* We can execute our whole program just using bir_exec_block,
-   size we either terminate during execution of the next block
+   since we either terminate during execution of the next block
    or end up at the beginning of a new block.*)
-
-val bir_get_current_block_block_pc = store_thm ("bir_get_current_block_block_pc",
-  ``!p l. IS_SOME (bir_get_current_block p (bir_block_pc l)) <=>
-          MEM l (bir_labels_of_program p)``,
-
-SIMP_TAC (std_ss++holBACore_ss) [optionTheory.IS_SOME_EXISTS, bir_get_current_block_SOME,
-  bir_block_pc_def, bir_get_program_block_info_by_label_MEM] >>
-METIS_TAC[]);
-
-
 val bir_exec_stmtE_new_block_pc = store_thm ("bir_exec_stmtE_new_block_pc",
   ``!st p stmt. let st' = bir_exec_stmtE p stmt st in
                 ~(bir_state_is_terminated st') ==>

--- a/src/theory/bir-support/bir_program_blocksScript.sml
+++ b/src/theory/bir-support/bir_program_blocksScript.sml
@@ -147,6 +147,26 @@ val bir_exec_stmtsB_def = Define `
      bir_exec_stmtsB stmts (OPT_CONS fe l, SUC c, st'))`;
 
 
+val bir_exec_stmtsB_exists =
+  store_thm("bir_exec_stmtsB_exists",
+  ``!stmtsB l c st.
+      ?l' c' st'.
+        bir_exec_stmtsB stmtsB (l,c,st) = (l', c', st')``,
+
+Induct_on `stmtsB` >- (
+  FULL_SIMP_TAC std_ss [bir_exec_stmtsB_def]
+) >>
+REPEAT STRIP_TAC >>
+FULL_SIMP_TAC std_ss [bir_exec_stmtsB_def] >>
+Cases_on `bir_state_is_terminated st` >- (
+  FULL_SIMP_TAC std_ss []
+) >>
+ASSUME_TAC (SPECL [``h:'a bir_stmt_basic_t``, ``st:bir_state_t``]
+                  bir_exec_stmtB_exists) >>
+FULL_SIMP_TAC std_ss [LET_DEF]
+);
+
+
 val bir_exec_stmtsB_REWRS = store_thm ("bir_exec_stmtsB_REWRS",
   ``(!l c st. bir_exec_stmtsB [] (l, c, st) = (REVERSE l, c, st)) /\
     (!stmts l c st. bir_state_is_terminated st ==>
@@ -538,6 +558,25 @@ val bir_exec_block_def = Define `bir_exec_block (p:'a bir_program_t) (bl:'a bir_
         if (bir_state_is_terminated st'') then
           (st'' with bst_pc := (st.bst_pc with bpc_index := st.bst_pc.bpc_index + c))
         else st''))`;
+
+
+val bir_exec_block_exists =
+  store_thm("bir_exec_block_exists",
+  ``!prog bl st.
+      ?l' c' st'.
+        bir_exec_block prog bl st = (l', c', st')``,
+
+Cases_on `prog` >>
+FULL_SIMP_TAC std_ss [bir_exec_block_def] >>
+REPEAT STRIP_TAC >>
+ASSUME_TAC (SPECL [``bl.bb_statements:'a bir_stmt_basic_t list``,
+                   ``[]: 'a list``, ``0:num``, ``st:bir_state_t``]
+                  bir_exec_stmtsB_exists) >>
+FULL_SIMP_TAC std_ss [LET_DEF] >>
+Cases_on `bir_state_is_terminated st'` >> (
+  FULL_SIMP_TAC std_ss []
+)
+);
 
 
 val bir_exec_block_REWR_TERMINATED = store_thm ("bir_exec_block_REWR_TERMINATED",

--- a/src/theory/bir-support/bir_subprogramScript.sml
+++ b/src/theory/bir-support/bir_subprogramScript.sml
@@ -672,7 +672,6 @@ Q.PAT_X_ASSUM `!st'' mo'. _` (MP_TAC o Q.SPECL [`st2''`, `mo'`]) >>
 ASM_SIMP_TAC (std_ss++bir_TYPES_ss) []);
 
 
-
 val bir_state_is_terminated_step_not_valid_pc = store_thm ("bir_state_is_terminated_step_not_valid_pc",
 ``!p st. ~(bir_is_valid_pc p st.bst_pc) ==> bir_state_is_terminated (bir_exec_step_state p st)``,
 
@@ -683,6 +682,24 @@ FULL_SIMP_TAC std_ss [bir_exec_step_state_def, bir_exec_step_def] >>
 Cases_on `bir_state_is_terminated st` >> (
   FULL_SIMP_TAC (std_ss++bir_TYPES_ss) [bir_state_set_failed_def, bir_state_is_terminated_def]
 ));
+
+
+val bir_state_is_failed_step_not_valid_pc =
+  store_thm ("bir_state_is_failed_step_not_valid_pc",
+``!p st.
+  ~(bir_state_is_terminated st) ==>
+  ~(bir_is_valid_pc p st.bst_pc) ==>
+  ((bir_exec_step_state p st).bst_status = BST_Failed)``,
+
+REPEAT STRIP_TAC >>
+`~(IS_SOME (bir_get_current_statement p st.bst_pc))` by
+  (METIS_TAC [bir_get_current_statement_IS_SOME]) >>
+  FULL_SIMP_TAC std_ss [bir_exec_step_state_def,
+                        bir_exec_step_def] >>
+FULL_SIMP_TAC (std_ss++bir_TYPES_ss)
+  [bir_state_set_failed_def]
+);
+
 
 val bir_exec_infinite_steps_fun_SUBPROGRAM = store_thm ("bir_exec_infinite_steps_fun_SUBPROGRAM",
 ``!p1 p2.

--- a/src/theory/bir/bir_auxiliaryScript.sml
+++ b/src/theory/bir/bir_auxiliaryScript.sml
@@ -166,6 +166,28 @@ Cases_on `INDEX_FIND 0 P l` >> (
 ));
 
 
+val INDEX_FIND_PRE = store_thm("INDEX_FIND_PRE",
+  ``!i j P l x.
+    (0 < i) ==>
+    (INDEX_FIND i       P l = SOME (j, x)) ==>
+    (INDEX_FIND (PRE i) P l = SOME (PRE j, x))``,
+
+Induct_on `l` >- (
+  FULL_SIMP_TAC std_ss [listTheory.INDEX_FIND_def]
+) >>
+REPEAT STRIP_TAC >>
+FULL_SIMP_TAC std_ss [listTheory.INDEX_FIND_def] >>
+Cases_on `P h` >> (
+  FULL_SIMP_TAC std_ss []
+) >>
+PAT_X_ASSUM ``!i j P x. _``
+            (fn thm => ASSUME_TAC (SPEC ``(SUC i):num`` thm)) >>
+REV_FULL_SIMP_TAC std_ss [] >>
+PAT_X_ASSUM ``!j' P' x'. _`` (fn thm => IMP_RES_TAC thm) >>
+REV_FULL_SIMP_TAC std_ss [arithmeticTheory.SUC_PRE]
+);
+
+
 val SEG_SUC_LENGTH = store_thm ("SEG_SUC_LENGTH",
 ``!l n m. (n + m < LENGTH l) ==>
           (SEG (SUC n) m l = (EL m l)::SEG n (SUC m) l)``,

--- a/src/theory/bir/bir_programScript.sml
+++ b/src/theory/bir/bir_programScript.sml
@@ -228,6 +228,27 @@ val bir_exec_stmtB_state_def = Define `bir_exec_stmtB_state stmt st =
   SND (bir_exec_stmtB stmt st)`;
 
 
+val bir_exec_stmtB_exists =
+  store_thm("bir_exec_stmtB_exists",
+  ``!h st.
+      ?obs' st'.
+        bir_exec_stmtB h st = (obs', st')``,
+
+Cases_on `h` >> (
+  STRIP_TAC >>
+  FULL_SIMP_TAC std_ss [bir_exec_stmtB_def]
+) >>
+FULL_SIMP_TAC std_ss [bir_exec_stmt_observe_def] >>
+Cases_on `bir_dest_bool_val (bir_eval_exp b st.bst_environ)` >| [
+  FULL_SIMP_TAC std_ss [],
+
+  Cases_on `x` >> (
+    FULL_SIMP_TAC std_ss []
+  )
+]
+);
+
+
 val bir_exec_stmtB_state_REWRS = store_thm ("bir_exec_stmtB_state_REWRS",
 ``(!v st. (bir_exec_stmtB_state (BStmt_Declare v) st = (bir_exec_stmt_declare (bir_var_name v) (bir_var_type v) st))) /\
   (!ex st. (bir_exec_stmtB_state (BStmt_Assert ex) st = (bir_exec_stmt_assert ex st))) /\

--- a/src/theory/tools/wp/bir_htScript.sml
+++ b/src/theory/tools/wp/bir_htScript.sml
@@ -23,11 +23,8 @@ open HolBACoreSimps;
 val _ = new_theory "bir_ht";
 
 val bir_stmtB_is_not_assume_def = Define `
-  (bir_stmtB_is_not_assume (BStmt_Declare v) = T) /\
-  (bir_stmtB_is_not_assume (BStmt_Assign v ex) = T) /\
-  (bir_stmtB_is_not_assume (BStmt_Assert ex) = T) /\
   (bir_stmtB_is_not_assume (BStmt_Assume ex) = F) /\
-  (bir_stmtB_is_not_assume (BStmt_Observe ec el obf) = T)
+  (bir_stmtB_is_not_assume _ = T)
 `;
 
 val bir_stmtB_not_assume_never_assumviol =

--- a/src/theory/tools/wp/bir_htScript.sml
+++ b/src/theory/tools/wp/bir_htScript.sml
@@ -1,21 +1,25 @@
 open HolKernel Parse boolLib bossLib;
 
-(* From /core: *)
+(* Theories from theory/bir: *)
 open bir_programTheory bir_typing_progTheory bir_envTheory
      bir_auxiliaryTheory bir_valuesTheory bir_expTheory
      bir_exp_immTheory bir_typing_expTheory bir_immTheory;
 
-(* From /theories: *)
+(* Theories from theory/bir-support: *)
 open bir_program_blocksTheory bir_program_terminationTheory
      bir_program_valid_stateTheory bir_exp_substitutionsTheory
      bir_bool_expTheory bir_program_env_orderTheory
      bir_program_multistep_propsTheory bir_exp_equivTheory
      bir_subprogramTheory;
 
+(* Local theories: *)
 open bir_wpTheory;
 
+(* Simplification sets from theory/bir: *)
 open HolBACoreSimps;
 
+(* This theory contains theorems for manipulation of Hoare
+ * triples not directly related to WP propagation. *)
 val _ = new_theory "bir_ht";
 
 val bir_stmtb_is_not_assume_def = Define `
@@ -26,8 +30,8 @@ val bir_stmtb_is_not_assume_def = Define `
   (bir_stmtb_is_not_assume (BStmt_Observe ec el obf) = T)
 `;
 
-val bir_stmtb_not_assume_never_assviol =
-  store_thm("bir_stmtb_not_assume_never_assviol",
+val bir_stmtb_not_assume_never_assumviol =
+  store_thm("bir_stmtb_not_assume_never_assumviol",
   ``!stmtb st obs st'.
     bir_stmtb_is_not_assume stmtb ==>
     (st.bst_status <> BST_AssumptionViolated) ==>
@@ -130,8 +134,8 @@ Cases_on `bir_dest_bool_val (bir_eval_exp b st.bst_environ)` >| [
 ]
 );
 
-val bir_stmtsB_not_assume_never_assviol =
-  store_thm("bir_stmtsB_not_assume_never_assviol",
+val bir_stmtsB_not_assume_never_assumviol =
+  store_thm("bir_stmtsB_not_assume_never_assumviol",
   ``!stmtsB l c st l' c' st'.
     bir_stmtsB_has_no_assumes stmtsB ==>
     (st.bst_status <> BST_AssumptionViolated) ==>
@@ -156,8 +160,8 @@ Cases_on `bir_state_is_terminated st` >| [
     FULL_SIMP_TAC std_ss [bir_exec_stmtB_exists]
   ) >>
   FULL_SIMP_TAC std_ss [LET_DEF] >>
-  IMP_RES_TAC bir_stmtb_not_assume_never_assviol >>
-  PAT_X_ASSUM ``!l'' c'' st''. blah``
+  IMP_RES_TAC bir_stmtb_not_assume_never_assumviol >>
+  PAT_X_ASSUM ``!l'' c'' st''. _``
               (fn thm => ASSUME_TAC
                 (SPECL [``(OPT_CONS obs_test l): 'a list``,
                         ``(SUC c):num``,
@@ -177,8 +181,8 @@ val bir_block_has_no_assumes_def = Define `
 `;
 
 (* TODO: Move somewhere else... *)
-val bir_exec_stmtE_not_assviol =
-  store_thm("bir_exec_stmtE_not_assviol",
+val bir_exec_stmtE_not_assumviol =
+  store_thm("bir_exec_stmtE_not_assumviol",
   ``!prog stmtE st.
       (st.bst_status <> BST_AssumptionViolated) ==>
       ((bir_exec_stmtE prog stmtE st).bst_status <>
@@ -272,8 +276,8 @@ ASSUME_TAC (SPECL [``h:'a bir_stmt_basic_t``, ``st:bir_state_t``]
 FULL_SIMP_TAC std_ss [LET_DEF]
 );
 
-val bir_block_not_assume_never_assviol =
-  store_thm("bir_block_not_assume_never_assviol",
+val bir_block_not_assume_never_assumviol =
+  store_thm("bir_block_not_assume_never_assumviol",
   ``!prog bl st l' c' st'.
     bir_block_has_no_assumes bl ==>
     (st.bst_status <> BST_AssumptionViolated) ==>
@@ -283,14 +287,14 @@ val bir_block_not_assume_never_assviol =
 FULL_SIMP_TAC std_ss [bir_block_has_no_assumes_def,
                       bir_exec_block_def] >>
 REPEAT STRIP_TAC >>
-IMP_RES_TAC bir_stmtsB_not_assume_never_assviol >>
+IMP_RES_TAC bir_stmtsB_not_assume_never_assumviol >>
 subgoal `?l_test c_test st'_test.
 	   bir_exec_stmtsB bl.bb_statements ([],0,st) =
              (l_test, c_test, st'_test)` >- (
   FULL_SIMP_TAC std_ss [bir_exec_stmtsB_exists]
 ) >>
 FULL_SIMP_TAC std_ss [LET_DEF] >>
-PAT_X_ASSUM ``!st' l' l c' c. blah``
+PAT_X_ASSUM ``!st' l' l c' c. _``
 	    (fn thm => ASSUME_TAC
 	      (SPECL [``st'_test:bir_state_t``,
 		      ``l_test: 'a list``,
@@ -319,7 +323,7 @@ Cases_on `bir_state_is_terminated st'_test` >| [
     ASSUME_TAC (SPECL [``prog:'a bir_program_t``,
                        ``bl.bb_last_statement:bir_stmt_end_t``,
                        ``st'_test:bir_state_t``]
-                      bir_exec_stmtE_not_assviol
+                      bir_exec_stmtE_not_assumviol
                ) >>
     Q.ABBREV_TAC `st' = bir_exec_stmtE prog bl.bb_last_statement
                                        st'_test` >>
@@ -353,10 +357,10 @@ FULL_SIMP_TAC std_ss [listTheory.INDEX_FIND_def] >>
 Cases_on `P h` >> (
   FULL_SIMP_TAC std_ss []
 ) >>
-PAT_X_ASSUM ``!i j P x. blah``
+PAT_X_ASSUM ``!i j P x. _``
             (fn thm => ASSUME_TAC (SPEC ``(SUC i):num`` thm)) >>
 REV_FULL_SIMP_TAC std_ss [] >>
-PAT_X_ASSUM ``!j' P' x'. blah`` (fn thm => IMP_RES_TAC thm) >>
+PAT_X_ASSUM ``!j' P' x'. _`` (fn thm => IMP_RES_TAC thm) >>
 REV_FULL_SIMP_TAC std_ss [arithmeticTheory.SUC_PRE]
 );
 
@@ -396,7 +400,7 @@ Induct_on `l` >| [
 		      )
 	       ) >>
     REV_FULL_SIMP_TAC std_ss [] >>
-    PAT_X_ASSUM ``!st' bl'. blah``
+    PAT_X_ASSUM ``!st' bl'. _``
 		(fn thm => ASSUME_TAC
 		  (SPECL [``st:bir_state_t``,
 			  ``bl:'a bir_block_t``] thm)
@@ -425,8 +429,8 @@ Cases_on `bir_state_is_terminated st'` >> (
 )
 );
 
-val bir_prog_not_assume_never_assviol =
-  store_thm("bir_prog_not_assume_never_assviol",
+val bir_prog_not_assume_never_assumviol_exec_block_n =
+  store_thm("bir_prog_not_assume_never_assumviol_exec_block_n",
   ``!prog st n bl ol nstep npc st'.
     (bir_get_current_block prog st.bst_pc = SOME bl) ==>
     bir_prog_has_no_assumes prog ==>
@@ -450,14 +454,14 @@ Induct_on `n` >| [
   rename1 `st'''.bst_status = BST_AssumptionViolated` >>
   rename1 `bir_exec_block prog bl st = (l',c',st')` >>
   rename1 `st''.bst_status = BST_AssumptionViolated` >>
-  PAT_X_ASSUM ``!prog st bl ol nstep npc st'. blah``
+  PAT_X_ASSUM ``!prog st bl ol nstep npc st'. _``
           (fn thm => ASSUME_TAC (SPECL [``prog: 'a bir_program_t``,
                                         ``st':bir_state_t``] thm)
           ) >>
   IMP_RES_TAC bir_prog_to_block_no_assumes >>
-  IMP_RES_TAC bir_block_not_assume_never_assviol >>
+  IMP_RES_TAC bir_block_not_assume_never_assumviol >>
   IMP_RES_TAC bir_exec_block_n_block >>
-  PAT_X_ASSUM ``!n. blah``
+  PAT_X_ASSUM ``!n. _``
           (fn thm => ASSUME_TAC
             (SPECL [``n:num``] thm)
           ) >>
@@ -472,7 +476,7 @@ Induct_on `n` >| [
       IMP_RES_TAC bir_exec_block_new_block_pc >>
       FULL_SIMP_TAC std_ss [optionTheory.IS_SOME_EXISTS] >>
       FULL_SIMP_TAC (std_ss++holBACore_ss) [] >>
-      PAT_X_ASSUM ``(ol,nstep,npc,st'') = blah``
+      PAT_X_ASSUM ``(ol,nstep,npc,st'') = _``
 	      (fn thm => ASSUME_TAC
 		(GSYM thm)
 	      ) >>
@@ -484,7 +488,7 @@ Induct_on `n` >| [
 
       FULL_SIMP_TAC (std_ss++holBACore_ss) [] >>
       IMP_RES_TAC bir_exec_block_n_REWR_TERMINATED >>
-      PAT_X_ASSUM ``!p n. blah``
+      PAT_X_ASSUM ``!p n. _``
 	      (fn thm => ASSUME_TAC
 		(SPECL [``prog:'a bir_program_t``, ``n:num``] thm)
 	      ) >>
@@ -494,8 +498,8 @@ Induct_on `n` >| [
 ]
 );
 (* Formulated in terms of bir_exec_to_labels: *)
-val bir_prog_not_assume_never_assviol_labels =
-  store_thm("bir_prog_not_assume_never_assviol_labels",
+val bir_prog_not_assume_never_assumviol_exec_to_labels =
+  store_thm("bir_prog_not_assume_never_assumviol_exec_to_labels",
   ``!ls prog st bl ol c_st c_l st'.
     (bir_get_current_block prog st.bst_pc = SOME bl) ==>
     bir_prog_has_no_assumes prog ==>
@@ -511,7 +515,7 @@ subgoal `bir_exec_to_labels_n ls prog st 1 =
   FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_exec_to_labels_def]
 ) >>
 IMP_RES_TAC bir_exec_to_labels_n_TO_bir_exec_block_n >>
-IMP_RES_TAC bir_prog_not_assume_never_assviol
+IMP_RES_TAC bir_prog_not_assume_never_assumviol_exec_block_n
 );
 
 val bir_exec_to_labels_no_av_triple_def = Define `
@@ -549,8 +553,8 @@ FULL_SIMP_TAC (std_ss++bir_TYPES_ss)
   [bir_state_set_failed_def]
 );
 
-val bir_never_assviol_ht =
-  store_thm("bir_never_assviol_ht",
+val bir_never_assumviol_ht =
+  store_thm("bir_never_assumviol_ht",
   ``!prog l ls pre post.
     bir_prog_has_no_assumes prog ==>
     bir_exec_to_labels_triple prog l ls pre post ==>
@@ -559,7 +563,7 @@ val bir_never_assviol_ht =
 REWRITE_TAC [bir_exec_to_labels_no_av_triple_def,
              bir_exec_to_labels_triple_def] >>
 REPEAT STRIP_TAC >>
-PAT_X_ASSUM ``!s r. blah``
+PAT_X_ASSUM ``!s r. _``
             (fn thm => ASSUME_TAC
               (SPECL [``s:bir_state_t``,
                       ``r: 'a bir_execution_result_t``] thm)
@@ -578,7 +582,7 @@ Cases_on `r` >| [
       >- (
       FULL_SIMP_TAC std_ss [bir_get_current_block_def]
     ) >>
-    IMP_RES_TAC bir_prog_not_assume_never_assviol_labels >>
+    IMP_RES_TAC bir_prog_not_assume_never_assumviol_exec_to_labels >>
     cheat,
 
     FULL_SIMP_TAC (std_ss++holBACore_ss)

--- a/src/theory/tools/wp/bir_htScript.sml
+++ b/src/theory/tools/wp/bir_htScript.sml
@@ -1,0 +1,614 @@
+open HolKernel Parse boolLib bossLib;
+
+(* From /core: *)
+open bir_programTheory bir_typing_progTheory bir_envTheory
+     bir_auxiliaryTheory bir_valuesTheory bir_expTheory
+     bir_exp_immTheory bir_typing_expTheory bir_immTheory;
+
+(* From /theories: *)
+open bir_program_blocksTheory bir_program_terminationTheory
+     bir_program_valid_stateTheory bir_exp_substitutionsTheory
+     bir_bool_expTheory bir_program_env_orderTheory
+     bir_program_multistep_propsTheory bir_exp_equivTheory
+     bir_subprogramTheory;
+
+open bir_wpTheory;
+
+open HolBACoreSimps;
+
+val _ = new_theory "bir_ht";
+
+val bir_stmtb_is_not_assume_def = Define `
+  (bir_stmtb_is_not_assume (BStmt_Declare v) = T) /\
+  (bir_stmtb_is_not_assume (BStmt_Assign v ex) = T) /\
+  (bir_stmtb_is_not_assume (BStmt_Assert ex) = T) /\
+  (bir_stmtb_is_not_assume (BStmt_Assume ex) = F) /\
+  (bir_stmtb_is_not_assume (BStmt_Observe ec el obf) = T)
+`;
+
+val bir_stmtb_not_assume_never_assviol =
+  store_thm("bir_stmtb_not_assume_never_assviol",
+  ``!stmtb st obs st'.
+    bir_stmtb_is_not_assume stmtb ==>
+    (st.bst_status <> BST_AssumptionViolated) ==>
+    (bir_exec_stmtB stmtb st = (obs, st')) ==>
+    (st'.bst_status <> BST_AssumptionViolated)``,
+
+REPEAT STRIP_TAC >>
+Cases_on `stmtb` >> (
+  FULL_SIMP_TAC std_ss [bir_stmtb_is_not_assume_def,
+                        bir_exec_stmtB_def]
+) >| [
+  FULL_SIMP_TAC std_ss [bir_exec_stmt_declare_def] >>
+  Cases_on `bir_env_varname_is_bound st.bst_environ
+              (bir_var_name b)` >| [
+    FULL_SIMP_TAC std_ss [bir_state_set_failed_def] >>
+    RW_TAC std_ss [] >>
+    FULL_SIMP_TAC (std_ss++holBACore_ss) [],
+
+    FULL_SIMP_TAC std_ss [] >>
+    Cases_on `bir_env_update (bir_var_name b)
+                (bir_declare_initial_value (bir_var_type b))
+                (bir_var_type b)
+                st.bst_environ` >| [
+      FULL_SIMP_TAC std_ss [bir_state_set_failed_def] >>
+      RW_TAC std_ss [] >>
+      FULL_SIMP_TAC (std_ss++holBACore_ss) [],
+
+      FULL_SIMP_TAC std_ss [] >>
+      RW_TAC std_ss [] >>
+      FULL_SIMP_TAC (std_ss++holBACore_ss) []
+    ]
+  ],
+
+  FULL_SIMP_TAC std_ss [bir_exec_stmt_assign_def, LET_DEF] >>
+  Cases_on `bir_env_write b (bir_eval_exp b0 st.bst_environ)
+                          st.bst_environ` >| [
+    FULL_SIMP_TAC std_ss [bir_state_set_failed_def] >>
+    RW_TAC std_ss [] >>
+    FULL_SIMP_TAC (std_ss++holBACore_ss) [],
+
+    RW_TAC std_ss [] >>
+    FULL_SIMP_TAC (std_ss++holBACore_ss) []
+  ],
+
+  FULL_SIMP_TAC std_ss [bir_exec_stmt_assert_def] >>
+  Cases_on `bir_dest_bool_val (bir_eval_exp b st.bst_environ)` >| [
+    FULL_SIMP_TAC std_ss [bir_state_set_failed_def] >>
+    RW_TAC std_ss [] >>
+    FULL_SIMP_TAC (std_ss++holBACore_ss) [],
+
+    Cases_on `x` >> (
+      FULL_SIMP_TAC (std_ss++holBACore_ss) []
+    ) >>
+    RW_TAC std_ss [] >>
+    FULL_SIMP_TAC (std_ss++holBACore_ss) []
+  ],
+
+  FULL_SIMP_TAC std_ss [bir_exec_stmt_observe_def] >>
+  Cases_on `bir_dest_bool_val (bir_eval_exp b st.bst_environ)` >| [
+    FULL_SIMP_TAC std_ss [bir_state_set_failed_def] >>
+    RW_TAC std_ss [] >>
+    FULL_SIMP_TAC (std_ss++holBACore_ss) [],
+
+    Cases_on `x` >> (
+      FULL_SIMP_TAC (std_ss++holBACore_ss) []
+    )
+  ]
+]
+);
+
+val bir_stmtsB_has_no_assumes_def = Define `
+  (bir_stmtsB_has_no_assumes [] = T) /\
+  (bir_stmtsB_has_no_assumes (h::t) =
+    (bir_stmtb_is_not_assume h) /\ (bir_stmtsB_has_no_assumes t)
+  )
+`;
+
+(* TODO: Move this elsewhere... *)
+val bir_exec_stmtB_exists =
+  store_thm("bir_exec_stmtB_exists",
+  ``!h st.
+      ?obs' st'.
+        bir_exec_stmtB h st = (obs', st')``,
+
+Cases_on `h` >> (
+  STRIP_TAC >>
+  FULL_SIMP_TAC std_ss [bir_exec_stmtB_def]
+) >>
+FULL_SIMP_TAC std_ss [bir_exec_stmt_observe_def] >>
+Cases_on `bir_dest_bool_val (bir_eval_exp b st.bst_environ)` >| [
+  FULL_SIMP_TAC std_ss [],
+
+  Cases_on `x` >| [
+    FULL_SIMP_TAC std_ss [],
+
+    FULL_SIMP_TAC std_ss []
+  ]
+]
+);
+
+val bir_stmtsB_not_assume_never_assviol =
+  store_thm("bir_stmtsB_not_assume_never_assviol",
+  ``!stmtsB l c st l' c' st'.
+    bir_stmtsB_has_no_assumes stmtsB ==>
+    (st.bst_status <> BST_AssumptionViolated) ==>
+    (bir_exec_stmtsB stmtsB (l, c, st) = (l', c', st')) ==>
+    (st'.bst_status <> BST_AssumptionViolated)``,
+
+Induct_on `stmtsB` >- (
+  REPEAT STRIP_TAC >>
+  FULL_SIMP_TAC (std_ss++holBACore_ss)
+                [bir_stmtsB_has_no_assumes_def,
+                 bir_exec_stmtsB_def]
+) >>
+REPEAT STRIP_TAC >>
+FULL_SIMP_TAC std_ss [bir_stmtsB_has_no_assumes_def,
+                      bir_stmtb_is_not_assume_def,
+                      bir_exec_stmtsB_def] >>
+Cases_on `bir_state_is_terminated st` >| [
+  FULL_SIMP_TAC std_ss [],
+
+  subgoal `?obs_test st_test.
+             bir_exec_stmtB h st = (obs_test, st_test)` >- (
+    FULL_SIMP_TAC std_ss [bir_exec_stmtB_exists]
+  ) >>
+  FULL_SIMP_TAC std_ss [LET_DEF] >>
+  IMP_RES_TAC bir_stmtb_not_assume_never_assviol >>
+  PAT_X_ASSUM ``!l'' c'' st''. blah``
+              (fn thm => ASSUME_TAC
+                (SPECL [``(OPT_CONS obs_test l): 'a list``,
+                        ``(SUC c):num``,
+                        ``st_test:bir_state_t``,
+                        ``l': 'a list``,
+                        ``c':num``,
+                        ``st':bir_state_t``] thm
+                )
+              ) >>
+  REV_FULL_SIMP_TAC std_ss []
+]
+);
+
+val bir_block_has_no_assumes_def = Define `
+  bir_block_has_no_assumes block =
+    bir_stmtsB_has_no_assumes block.bb_statements
+`;
+
+(* TODO: Move somewhere else... *)
+val bir_exec_stmtE_not_assviol =
+  store_thm("bir_exec_stmtE_not_assviol",
+  ``!prog stmtE st.
+      (st.bst_status <> BST_AssumptionViolated) ==>
+      ((bir_exec_stmtE prog stmtE st).bst_status <>
+         BST_AssumptionViolated)``,
+
+REPEAT STRIP_TAC >>
+Cases_on `stmtE` >| [
+  (* Jmp *)
+  FULL_SIMP_TAC std_ss [bir_exec_stmtE_def,
+                        bir_exec_stmt_jmp_def] >>
+  Cases_on `bir_eval_label_exp b st.bst_environ` >| [
+    FULL_SIMP_TAC (std_ss++holBACore_ss)
+                  [bir_state_set_failed_def],
+
+    Cases_on `x` >| [
+      FULL_SIMP_TAC (std_ss++holBACore_ss)
+                    [bir_state_set_failed_def,
+                     bir_exec_stmt_jmp_to_label_def] >>
+      Cases_on `MEM (BL_Label s) (bir_labels_of_program prog)` >| [
+        FULL_SIMP_TAC (std_ss++holBACore_ss) [],
+
+        FULL_SIMP_TAC (std_ss++holBACore_ss) []
+      ],
+
+      FULL_SIMP_TAC (std_ss++holBACore_ss)
+                    [bir_exec_stmt_jmp_to_label_def] >>
+      Cases_on `MEM (BL_Address b')
+                    (bir_labels_of_program prog)` >| [
+        FULL_SIMP_TAC (std_ss++holBACore_ss) [],
+
+        FULL_SIMP_TAC (std_ss++holBACore_ss) []
+      ]
+    ]
+  ],
+
+  (* CJmp *)
+  FULL_SIMP_TAC std_ss [bir_exec_stmtE_def,
+                        bir_exec_stmt_cjmp_def] >>
+  Cases_on `bir_dest_bool_val (bir_eval_exp b st.bst_environ)` >- (
+    FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_state_set_failed_def]
+  ) >>
+  Cases_on `x` >> (
+    FULL_SIMP_TAC std_ss [bir_exec_stmt_jmp_def]
+  ) >>> (TACS_TO_LT [
+    Cases_on `bir_eval_label_exp b0 st.bst_environ` >- (
+      FULL_SIMP_TAC (std_ss++holBACore_ss)
+                    [bir_state_set_failed_def]
+    ),
+
+    Cases_on `bir_eval_label_exp b1 st.bst_environ` >- (
+      FULL_SIMP_TAC (std_ss++holBACore_ss)
+                    [bir_state_set_failed_def]
+    )
+  ]) >> (
+    Cases_on `x` >| [
+      FULL_SIMP_TAC (std_ss++holBACore_ss)
+                    [bir_state_set_failed_def,
+                     bir_exec_stmt_jmp_to_label_def] >>
+      Cases_on `MEM (BL_Label s) (bir_labels_of_program prog)` >| [
+        FULL_SIMP_TAC (std_ss++holBACore_ss) [],
+
+        FULL_SIMP_TAC (std_ss++holBACore_ss) []
+      ],
+
+      FULL_SIMP_TAC (std_ss++holBACore_ss)
+                    [bir_exec_stmt_jmp_to_label_def] >>
+      Cases_on `MEM (BL_Address b')
+                    (bir_labels_of_program prog)` >| [
+        FULL_SIMP_TAC (std_ss++holBACore_ss) [],
+
+        FULL_SIMP_TAC (std_ss++holBACore_ss) []
+      ]
+    ]
+  ),
+
+  (* Halt *)
+  FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_exec_stmtE_def,
+                                        bir_exec_stmt_halt_def]
+]
+);
+
+(* TODO: Move this elsewhere... *)
+val bir_exec_stmtsB_exists =
+  store_thm("bir_exec_stmtsB_exists",
+  ``!stmtsB l c st.
+      ?l' c' st'.
+        bir_exec_stmtsB stmtsB (l,c,st) = (l', c', st')``,
+
+Induct_on `stmtsB` >- (
+  FULL_SIMP_TAC std_ss [bir_exec_stmtsB_def]
+) >>
+REPEAT STRIP_TAC >>
+FULL_SIMP_TAC std_ss [bir_exec_stmtsB_def] >>
+Cases_on `bir_state_is_terminated st` >- (
+  FULL_SIMP_TAC std_ss []
+) >>
+ASSUME_TAC (SPECL [``h:'a bir_stmt_basic_t``, ``st:bir_state_t``]
+                  bir_exec_stmtB_exists) >>
+FULL_SIMP_TAC std_ss [LET_DEF]
+);
+
+val bir_block_not_assume_never_assviol =
+  store_thm("bir_block_not_assume_never_assviol",
+  ``!prog bl st l' c' st'.
+    bir_block_has_no_assumes bl ==>
+    (st.bst_status <> BST_AssumptionViolated) ==>
+    (bir_exec_block prog bl st = (l', c', st')) ==>
+    (st'.bst_status <> BST_AssumptionViolated)``,
+
+FULL_SIMP_TAC std_ss [bir_block_has_no_assumes_def,
+                      bir_exec_block_def] >>
+REPEAT STRIP_TAC >>
+IMP_RES_TAC bir_stmtsB_not_assume_never_assviol >>
+subgoal `?l_test c_test st'_test.
+	   bir_exec_stmtsB bl.bb_statements ([],0,st) =
+             (l_test, c_test, st'_test)` >- (
+  FULL_SIMP_TAC std_ss [bir_exec_stmtsB_exists]
+) >>
+FULL_SIMP_TAC std_ss [LET_DEF] >>
+PAT_X_ASSUM ``!st' l' l c' c. blah``
+	    (fn thm => ASSUME_TAC
+	      (SPECL [``st'_test:bir_state_t``,
+		      ``l_test: 'a list``,
+                      ``[]:'a list``,
+		      ``c_test:num``,
+		      ``0:num``] thm
+	      )
+	    ) >>
+REV_FULL_SIMP_TAC std_ss [] >>
+Cases_on `bir_state_is_terminated st'_test` >| [
+  Cases_on `st'_test` >>
+  Cases_on `st` >>
+  Cases_on `st'` >>
+  FULL_SIMP_TAC (std_ss++holBACore_ss)
+                [bir_state_t_fn_updates, bir_state_t_bst_status,
+                 bir_state_t_bst_pc],
+
+  FULL_SIMP_TAC (std_ss++holBACore_ss)
+                [bir_state_t_fn_updates, bir_state_t_bst_status,
+                 bir_state_t_bst_pc] >>
+  Cases_on `bir_state_is_terminated
+              (bir_exec_stmtE prog bl.bb_last_statement
+                 st'_test)` >> (
+    FULL_SIMP_TAC (std_ss++holBACore_ss) [] >>
+    Cases_on `st'` >>
+    ASSUME_TAC (SPECL [``prog:'a bir_program_t``,
+                       ``bl.bb_last_statement:bir_stmt_end_t``,
+                       ``st'_test:bir_state_t``]
+                      bir_exec_stmtE_not_assviol
+               ) >>
+    Q.ABBREV_TAC `st' = bir_exec_stmtE prog bl.bb_last_statement
+                                       st'_test` >>
+    Cases_on `st'` >>
+    REV_FULL_SIMP_TAC (std_ss++holBACore_ss)
+                      [bir_state_t_fn_updates]
+  )
+]
+);
+
+val bir_prog_has_no_assumes_def = Define `
+  (bir_prog_has_no_assumes (BirProgram []) = T) /\
+  (bir_prog_has_no_assumes (BirProgram (h::t)) =
+    (bir_block_has_no_assumes h) /\
+    (bir_prog_has_no_assumes (BirProgram t))
+  )
+`;
+
+val test_lemma_3 = store_thm("test_lemma_3",
+  ``!i j P l x.
+    (0 < i) ==>
+    (INDEX_FIND i       P l = SOME (j, x)) ==>
+    (INDEX_FIND (PRE i) P l = SOME (PRE j, x))``,
+
+Induct_on `l` >- (
+  FULL_SIMP_TAC std_ss [listTheory.INDEX_FIND_def]
+) >>
+REPEAT STRIP_TAC >>
+FULL_SIMP_TAC std_ss [listTheory.INDEX_FIND_def] >>
+Cases_on `P h` >> (
+  FULL_SIMP_TAC std_ss []
+) >>
+PAT_X_ASSUM ``!i j P x. blah``
+            (fn thm => ASSUME_TAC (SPEC ``(SUC i):num`` thm)) >>
+REV_FULL_SIMP_TAC std_ss [] >>
+PAT_X_ASSUM ``!j' P' x'. blah`` (fn thm => IMP_RES_TAC thm) >>
+REV_FULL_SIMP_TAC std_ss [arithmeticTheory.SUC_PRE]
+);
+
+val test_lemma = store_thm("test_lemma",
+  ``!prog st bl.
+    (bir_get_current_block prog st.bst_pc = SOME bl) ==>
+    bir_prog_has_no_assumes prog ==>
+    bir_block_has_no_assumes bl``,
+
+Cases_on `prog` >>
+Induct_on `l` >| [
+  FULL_SIMP_TAC std_ss [bir_get_current_block_def,
+                        bir_get_program_block_info_by_label_def,
+                        listTheory.INDEX_FIND_def],
+
+  REPEAT STRIP_TAC >>
+  FULL_SIMP_TAC std_ss [bir_prog_has_no_assumes_def,
+			bir_get_current_block_def,
+			bir_get_program_block_info_by_label_def,
+			listTheory.INDEX_FIND_def] >>
+  Cases_on `h.bb_label = st.bst_pc.bpc_label` >| [
+    FULL_SIMP_TAC std_ss [] >>
+    RW_TAC std_ss [pairTheory.SND],
+
+    FULL_SIMP_TAC std_ss [] >>
+    Cases_on `INDEX_FIND 1 (λx. x.bb_label = st.bst_pc.bpc_label)                   l` >> (
+      FULL_SIMP_TAC std_ss []
+    ) >>
+    Cases_on `x` >>
+    REV_FULL_SIMP_TAC std_ss [] >>
+    ASSUME_TAC (SPECL [``1:num``, ``q:num``,
+		       ``(\x. x.bb_label = st.bst_pc.bpc_label):('a bir_block_t) -> bool``,
+		       ``l:'a bir_block_t list``,
+		       ``bl:'a bir_block_t``]
+		      (INST_TYPE [``:'a`` |-> ``:'a bir_block_t``]
+				 test_lemma_3
+		      )
+	       ) >>
+    REV_FULL_SIMP_TAC std_ss [] >>
+    PAT_X_ASSUM ``!st' bl'. blah``
+		(fn thm => ASSUME_TAC
+		  (SPECL [``st:bir_state_t``,
+			  ``bl:'a bir_block_t``] thm)
+		) >>
+    FULL_SIMP_TAC std_ss []
+  ]
+]
+);
+
+(* TODO: Move this elsewhere... *)
+val bir_exec_block_exists =
+  store_thm("bir_exec_block_exists",
+  ``!prog bl st.
+      ?l' c' st'.
+        bir_exec_block prog bl st = (l', c', st')``,
+
+Cases_on `prog` >>
+FULL_SIMP_TAC std_ss [bir_exec_block_def] >>
+REPEAT STRIP_TAC >>
+ASSUME_TAC (SPECL [``bl.bb_statements:'a bir_stmt_basic_t list``,
+                   ``[]: 'a list``, ``0:num``, ``st:bir_state_t``]
+                  bir_exec_stmtsB_exists) >>
+FULL_SIMP_TAC std_ss [LET_DEF] >>
+Cases_on `bir_state_is_terminated st'` >> (
+  FULL_SIMP_TAC std_ss []
+)
+);
+
+val bir_prog_not_assume_never_assviol =
+  store_thm("bir_prog_not_assume_never_assviol",
+  ``!prog st n bl ol nstep npc st'.
+    (bir_get_current_block prog st.bst_pc = SOME bl) ==>
+    bir_prog_has_no_assumes prog ==>
+    (st.bst_status <> BST_AssumptionViolated) ==>
+    (bir_exec_block_n prog st n =
+       (ol, nstep, npc, st')
+    ) ==>
+    (st'.bst_status <> BST_AssumptionViolated)``,
+
+Induct_on `n` >| [
+  FULL_SIMP_TAC std_ss [bir_exec_block_n_def,
+                        bir_exec_steps_GEN_REWR_no_steps,
+                        valOf_BER_Ended_def],
+
+  REPEAT STRIP_TAC >>
+  ASSUME_TAC (SPECL [``prog:'a bir_program_t``,
+		     ``bl:'a bir_block_t``,
+		     ``st:bir_state_t``] bir_exec_block_exists) >>
+  FULL_SIMP_TAC std_ss [] >>
+  (* How to best swap variable names? *)
+  rename1 `st'''.bst_status = BST_AssumptionViolated` >>
+  rename1 `bir_exec_block prog bl st = (l',c',st')` >>
+  rename1 `st''.bst_status = BST_AssumptionViolated` >>
+  PAT_X_ASSUM ``!prog st bl ol nstep npc st'. blah``
+          (fn thm => ASSUME_TAC (SPECL [``prog: 'a bir_program_t``,
+                                        ``st':bir_state_t``] thm)
+          ) >>
+  IMP_RES_TAC test_lemma >>
+  IMP_RES_TAC bir_block_not_assume_never_assviol >>
+  IMP_RES_TAC bir_exec_block_n_block >>
+  PAT_X_ASSUM ``!n. blah``
+          (fn thm => ASSUME_TAC
+            (SPECL [``n:num``] thm)
+          ) >>
+  REV_FULL_SIMP_TAC std_ss [LET_DEF] >>
+  Cases_on `0 < c' /\
+            bir_state_COUNT_PC (F,(\pc. pc.bpc_index = 0)) st'`
+    >> (
+      FULL_SIMP_TAC std_ss [] >>
+      FULL_SIMP_TAC std_ss []
+   ) >> (
+    Cases_on `~bir_state_is_terminated st'` >| [
+      IMP_RES_TAC bir_exec_block_new_block_pc >>
+      FULL_SIMP_TAC std_ss [optionTheory.IS_SOME_EXISTS] >>
+      FULL_SIMP_TAC (std_ss++holBACore_ss) [] >>
+      PAT_X_ASSUM ``(ol,nstep,npc,st'') = blah``
+	      (fn thm => ASSUME_TAC
+		(GSYM thm)
+	      ) >>
+      (* TODO: The below finish is ugly... *)
+      Cases_on `(bir_exec_block_n prog st' n)` >>
+      Cases_on `r` >>
+      Cases_on `r'` >>
+      FULL_SIMP_TAC (std_ss++holBACore_ss) [],
+
+      FULL_SIMP_TAC (std_ss++holBACore_ss) [] >>
+      IMP_RES_TAC bir_exec_block_n_REWR_TERMINATED >>
+      PAT_X_ASSUM ``!p n. blah``
+	      (fn thm => ASSUME_TAC
+		(SPECL [``prog:'a bir_program_t``, ``n:num``] thm)
+	      ) >>
+      FULL_SIMP_TAC (std_ss++holBACore_ss) []
+    ]
+  ) 
+]
+);
+(* Formulated in terms of bir_exec_to_labels: *)
+val bir_prog_not_assume_never_assviol_labels =
+  store_thm("bir_prog_not_assume_never_assviol_labels",
+  ``!ls prog st bl ol c_st c_l st'.
+    (bir_get_current_block prog st.bst_pc = SOME bl) ==>
+    bir_prog_has_no_assumes prog ==>
+    (st.bst_status <> BST_AssumptionViolated) ==>
+    (bir_exec_to_labels ls prog st =
+       BER_Ended ol c_st c_l st'
+    ) ==>
+    (st'.bst_status <> BST_AssumptionViolated)``,
+
+REPEAT STRIP_TAC >>
+subgoal `bir_exec_to_labels_n ls prog st 1 =
+           BER_Ended ol c_st c_l st'` >- (
+  FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_exec_to_labels_def]
+) >>
+IMP_RES_TAC bir_exec_to_labels_n_TO_bir_exec_block_n >>
+IMP_RES_TAC bir_prog_not_assume_never_assviol
+);
+
+val bir_exec_to_labels_no_av_triple_def = Define `
+  bir_exec_to_labels_no_av_triple p l ls pre post =
+  !s r.
+    bir_env_vars_are_initialised s.bst_environ
+                                 (bir_vars_of_program p) ==>
+    ((s.bst_pc.bpc_index = 0) /\ (s.bst_pc.bpc_label = l)) ==>
+    (s.bst_status = BST_Running) ==>
+    bir_is_bool_exp_env s.bst_environ pre ==>
+    (bir_eval_exp pre (s.bst_environ) = bir_val_true) ==>
+    ((bir_exec_to_labels ls p s) = r) ==>
+    (?l1 c1 c2 s'.
+      (r = BER_Ended l1 c1 c2 s') /\
+      (s'.bst_status = BST_Running) /\
+      bir_is_bool_exp_env s'.bst_environ post /\
+      (bir_eval_exp post (s'.bst_environ) = bir_val_true) /\
+      ((s'.bst_pc.bpc_index = 0) /\ (s'.bst_pc.bpc_label IN ls))
+    )`;
+
+(* TODO: Move to SubprogramTheory *)
+val bir_state_is_failed_step_not_valid_pc =
+  store_thm ("bir_state_is_failed_step_not_valid_pc",
+``!p st.
+  ~(bir_state_is_terminated st) ==>
+  ~(bir_is_valid_pc p st.bst_pc) ==>
+  ((bir_exec_step_state p st).bst_status = BST_Failed)``,
+
+REPEAT STRIP_TAC >>
+`~(IS_SOME (bir_get_current_statement p st.bst_pc))` by
+  (METIS_TAC [bir_get_current_statement_IS_SOME]) >>
+  FULL_SIMP_TAC std_ss [bir_exec_step_state_def,
+                        bir_exec_step_def] >>
+FULL_SIMP_TAC (std_ss++bir_TYPES_ss)
+  [bir_state_set_failed_def]
+);
+
+val bir_never_assviol_ht =
+  store_thm("bir_never_assviol_ht",
+  ``!prog l ls pre post.
+    bir_prog_has_no_assumes prog ==>
+    bir_exec_to_labels_triple prog l ls pre post ==>
+    bir_exec_to_labels_no_av_triple prog l ls pre post``,
+
+REWRITE_TAC [bir_exec_to_labels_no_av_triple_def,
+             bir_exec_to_labels_triple_def] >>
+REPEAT STRIP_TAC >>
+PAT_X_ASSUM ``!s r. blah``
+            (fn thm => ASSUME_TAC
+              (SPECL [``s:bir_state_t``,
+                      ``r: 'a bir_execution_result_t``] thm)
+            ) >>
+Cases_on `r` >| [
+  rename1 `bir_exec_to_labels ls prog s = BER_Ended l' n n0 s'` >>
+  REV_FULL_SIMP_TAC (std_ss++holBACore_ss) [] >>
+  subgoal `s.bst_status <> BST_AssumptionViolated` >- (
+    FULL_SIMP_TAC (std_ss++holBACore_ss) [] 
+  ) >>
+  Cases_on `bir_is_valid_pc prog s.bst_pc` >| [
+    FULL_SIMP_TAC std_ss
+                  [bir_is_valid_pc_def,
+                   bir_get_program_block_info_by_label_def] >>
+    subgoal `?bl. bir_get_current_block prog s.bst_pc = SOME bl`
+      >- (
+      FULL_SIMP_TAC std_ss [bir_get_current_block_def]
+    ) >>
+    IMP_RES_TAC bir_prog_not_assume_never_assviol_labels >>
+    cheat,
+
+    FULL_SIMP_TAC (std_ss++holBACore_ss)
+                  [bir_exec_to_labels_def] >>
+    IMP_RES_TAC bir_exec_to_labels_n_TO_bir_exec_step_n >>
+    subgoal `~bir_state_is_terminated s` >- (
+      FULL_SIMP_TAC std_ss [bir_state_is_terminated_def]
+    ) >>
+    IMP_RES_TAC bir_state_is_failed_step_not_valid_pc >>
+    Cases_on `n` >| [
+      FULL_SIMP_TAC (std_ss++holBACore_ss)
+                    [bir_exec_step_n_REWR_0],
+
+      FULL_SIMP_TAC (std_ss++holBACore_ss)
+                  [bir_exec_step_n_SUC, bir_exec_step_state_def] >>
+      Cases_on `(bir_exec_step prog s)` >>
+      ASSUME_TAC (el 4 (CONJUNCTS bir_exec_step_n_REWRS)) >>
+      FULL_SIMP_TAC (std_ss++holBACore_ss)
+                    [bir_state_is_terminated_def, LET_DEF] >>
+      REV_FULL_SIMP_TAC (std_ss++holBACore_ss) []
+    ]
+  ],
+
+  REV_FULL_SIMP_TAC (std_ss++holBACore_ss) []
+]
+);
+
+val _ = export_theory();

--- a/src/theory/tools/wp/bir_htScript.sml
+++ b/src/theory/tools/wp/bir_htScript.sml
@@ -479,8 +479,7 @@ Cases_on `r` >| [
       >- (
       FULL_SIMP_TAC std_ss [bir_get_current_block_def]
     ) >>
-    IMP_RES_TAC bir_prog_not_assume_never_assumviol_exec_to_labels >>
-    cheat,
+    IMP_RES_TAC bir_prog_not_assume_never_assumviol_exec_to_labels,
 
     FULL_SIMP_TAC (std_ss++holBACore_ss)
                   [bir_exec_to_labels_def] >>

--- a/src/theory/tools/wp/bir_htScript.sml
+++ b/src/theory/tools/wp/bir_htScript.sml
@@ -35,61 +35,65 @@ val bir_stmtb_not_assume_never_assviol =
     (st'.bst_status <> BST_AssumptionViolated)``,
 
 REPEAT STRIP_TAC >>
+Cases_on `st` >>
+Cases_on `st'` >>
 Cases_on `stmtb` >> (
   FULL_SIMP_TAC std_ss [bir_stmtb_is_not_assume_def,
                         bir_exec_stmtB_def]
 ) >| [
-  FULL_SIMP_TAC std_ss [bir_exec_stmt_declare_def] >>
-  Cases_on `bir_env_varname_is_bound st.bst_environ
-              (bir_var_name b)` >| [
-    FULL_SIMP_TAC std_ss [bir_state_set_failed_def] >>
-    RW_TAC std_ss [] >>
-    FULL_SIMP_TAC (std_ss++holBACore_ss) [],
+  FULL_SIMP_TAC (std_ss++holBACore_ss)
+                [bir_exec_stmt_declare_def] >>
+  Cases_on `bir_env_varname_is_bound b0
+              (bir_var_name b'')` >| [
+    FULL_SIMP_TAC (std_ss++holBACore_ss)
+                  [bir_state_set_failed_def,
+                   bir_state_t_bst_status_fupd],
 
-    FULL_SIMP_TAC std_ss [] >>
-    Cases_on `bir_env_update (bir_var_name b)
-                (bir_declare_initial_value (bir_var_type b))
-                (bir_var_type b)
-                st.bst_environ` >| [
-      FULL_SIMP_TAC std_ss [bir_state_set_failed_def] >>
-      RW_TAC std_ss [] >>
-      FULL_SIMP_TAC (std_ss++holBACore_ss) [],
+    Cases_on `bir_env_update (bir_var_name b'')
+                (bir_declare_initial_value (bir_var_type b''))
+                (bir_var_type b'')
+                b0` >| [
+      FULL_SIMP_TAC (std_ss++holBACore_ss)
+		    [bir_state_set_failed_def,
+		     bir_state_t_bst_status_fupd],
 
-      FULL_SIMP_TAC std_ss [] >>
-      RW_TAC std_ss [] >>
-      FULL_SIMP_TAC (std_ss++holBACore_ss) []
+      FULL_SIMP_TAC (std_ss++holBACore_ss)
+		    [bir_state_set_failed_def,
+		     bir_state_t_bst_status_fupd,
+                     bir_state_t_bst_environ_fupd]
     ]
   ],
 
-  FULL_SIMP_TAC std_ss [bir_exec_stmt_assign_def, LET_DEF] >>
-  Cases_on `bir_env_write b (bir_eval_exp b0 st.bst_environ)
-                          st.bst_environ` >| [
-    FULL_SIMP_TAC std_ss [bir_state_set_failed_def] >>
-    RW_TAC std_ss [] >>
-    FULL_SIMP_TAC (std_ss++holBACore_ss) [],
+  FULL_SIMP_TAC (std_ss++holBACore_ss)
+                [bir_exec_stmt_assign_def, LET_DEF] >>
+  Cases_on `bir_env_write b'' (bir_eval_exp b0'' b0) b0` >| [
+    FULL_SIMP_TAC (std_ss++holBACore_ss)
+		  [bir_state_set_failed_def,
+		   bir_state_t_bst_status_fupd],
 
-    RW_TAC std_ss [] >>
-    FULL_SIMP_TAC (std_ss++holBACore_ss) []
+    FULL_SIMP_TAC (std_ss++holBACore_ss)
+                  [bir_state_t_bst_environ_fupd]
   ],
 
-  FULL_SIMP_TAC std_ss [bir_exec_stmt_assert_def] >>
-  Cases_on `bir_dest_bool_val (bir_eval_exp b st.bst_environ)` >| [
-    FULL_SIMP_TAC std_ss [bir_state_set_failed_def] >>
-    RW_TAC std_ss [] >>
-    FULL_SIMP_TAC (std_ss++holBACore_ss) [],
+  FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_exec_stmt_assert_def] >>
+  Cases_on `bir_dest_bool_val (bir_eval_exp b'' b0)` >| [
+    FULL_SIMP_TAC (std_ss++holBACore_ss)
+		  [bir_state_set_failed_def,
+		   bir_state_t_bst_status_fupd],
 
     Cases_on `x` >> (
-      FULL_SIMP_TAC (std_ss++holBACore_ss) []
-    ) >>
-    RW_TAC std_ss [] >>
-    FULL_SIMP_TAC (std_ss++holBACore_ss) []
+      FULL_SIMP_TAC (std_ss++holBACore_ss)
+		    [bir_state_set_failed_def,
+		     bir_state_t_bst_status_fupd]
+    )
   ],
 
-  FULL_SIMP_TAC std_ss [bir_exec_stmt_observe_def] >>
-  Cases_on `bir_dest_bool_val (bir_eval_exp b st.bst_environ)` >| [
-    FULL_SIMP_TAC std_ss [bir_state_set_failed_def] >>
-    RW_TAC std_ss [] >>
-    FULL_SIMP_TAC (std_ss++holBACore_ss) [],
+  FULL_SIMP_TAC (std_ss++holBACore_ss)
+                [bir_exec_stmt_observe_def] >>
+  Cases_on `bir_dest_bool_val (bir_eval_exp b'' b0)` >| [
+    FULL_SIMP_TAC (std_ss++holBACore_ss)
+		  [bir_state_set_failed_def,
+		   bir_state_t_bst_status_fupd],
 
     Cases_on `x` >> (
       FULL_SIMP_TAC (std_ss++holBACore_ss) []
@@ -120,11 +124,9 @@ FULL_SIMP_TAC std_ss [bir_exec_stmt_observe_def] >>
 Cases_on `bir_dest_bool_val (bir_eval_exp b st.bst_environ)` >| [
   FULL_SIMP_TAC std_ss [],
 
-  Cases_on `x` >| [
-    FULL_SIMP_TAC std_ss [],
-
+  Cases_on `x` >> (
     FULL_SIMP_TAC std_ss []
-  ]
+  )
 ]
 );
 
@@ -195,20 +197,16 @@ Cases_on `stmtE` >| [
       FULL_SIMP_TAC (std_ss++holBACore_ss)
                     [bir_state_set_failed_def,
                      bir_exec_stmt_jmp_to_label_def] >>
-      Cases_on `MEM (BL_Label s) (bir_labels_of_program prog)` >| [
-        FULL_SIMP_TAC (std_ss++holBACore_ss) [],
-
+      Cases_on `MEM (BL_Label s) (bir_labels_of_program prog)` >> (
         FULL_SIMP_TAC (std_ss++holBACore_ss) []
-      ],
+      ),
 
       FULL_SIMP_TAC (std_ss++holBACore_ss)
                     [bir_exec_stmt_jmp_to_label_def] >>
       Cases_on `MEM (BL_Address b')
-                    (bir_labels_of_program prog)` >| [
-        FULL_SIMP_TAC (std_ss++holBACore_ss) [],
-
+                    (bir_labels_of_program prog)` >> (
         FULL_SIMP_TAC (std_ss++holBACore_ss) []
-      ]
+      )
     ]
   ],
 
@@ -235,20 +233,16 @@ Cases_on `stmtE` >| [
       FULL_SIMP_TAC (std_ss++holBACore_ss)
                     [bir_state_set_failed_def,
                      bir_exec_stmt_jmp_to_label_def] >>
-      Cases_on `MEM (BL_Label s) (bir_labels_of_program prog)` >| [
-        FULL_SIMP_TAC (std_ss++holBACore_ss) [],
-
+      Cases_on `MEM (BL_Label s) (bir_labels_of_program prog)` >> (
         FULL_SIMP_TAC (std_ss++holBACore_ss) []
-      ],
+      ),
 
       FULL_SIMP_TAC (std_ss++holBACore_ss)
                     [bir_exec_stmt_jmp_to_label_def] >>
       Cases_on `MEM (BL_Address b')
-                    (bir_labels_of_program prog)` >| [
-        FULL_SIMP_TAC (std_ss++holBACore_ss) [],
-
+                    (bir_labels_of_program prog)` >> (
         FULL_SIMP_TAC (std_ss++holBACore_ss) []
-      ]
+      )
     ]
   ),
 
@@ -344,7 +338,8 @@ val bir_prog_has_no_assumes_def = Define `
   )
 `;
 
-val test_lemma_3 = store_thm("test_lemma_3",
+(* TODO: Move this elsewhere... *)
+val INDEX_FIND_PRE = store_thm("INDEX_FIND_PRE",
   ``!i j P l x.
     (0 < i) ==>
     (INDEX_FIND i       P l = SOME (j, x)) ==>
@@ -365,7 +360,7 @@ PAT_X_ASSUM ``!j' P' x'. blah`` (fn thm => IMP_RES_TAC thm) >>
 REV_FULL_SIMP_TAC std_ss [arithmeticTheory.SUC_PRE]
 );
 
-val test_lemma = store_thm("test_lemma",
+val bir_prog_to_block_no_assumes = store_thm("bir_prog_to_block_no_assumes",
   ``!prog st bl.
     (bir_get_current_block prog st.bst_pc = SOME bl) ==>
     bir_prog_has_no_assumes prog ==>
@@ -397,7 +392,7 @@ Induct_on `l` >| [
 		       ``l:'a bir_block_t list``,
 		       ``bl:'a bir_block_t``]
 		      (INST_TYPE [``:'a`` |-> ``:'a bir_block_t``]
-				 test_lemma_3
+				 INDEX_FIND_PRE
 		      )
 	       ) >>
     REV_FULL_SIMP_TAC std_ss [] >>
@@ -459,7 +454,7 @@ Induct_on `n` >| [
           (fn thm => ASSUME_TAC (SPECL [``prog: 'a bir_program_t``,
                                         ``st':bir_state_t``] thm)
           ) >>
-  IMP_RES_TAC test_lemma >>
+  IMP_RES_TAC bir_prog_to_block_no_assumes >>
   IMP_RES_TAC bir_block_not_assume_never_assviol >>
   IMP_RES_TAC bir_exec_block_n_block >>
   PAT_X_ASSUM ``!n. blah``

--- a/src/theory/tools/wp/bir_htScript.sml
+++ b/src/theory/tools/wp/bir_htScript.sml
@@ -22,18 +22,18 @@ open HolBACoreSimps;
  * triples not directly related to WP propagation. *)
 val _ = new_theory "bir_ht";
 
-val bir_stmtb_is_not_assume_def = Define `
-  (bir_stmtb_is_not_assume (BStmt_Declare v) = T) /\
-  (bir_stmtb_is_not_assume (BStmt_Assign v ex) = T) /\
-  (bir_stmtb_is_not_assume (BStmt_Assert ex) = T) /\
-  (bir_stmtb_is_not_assume (BStmt_Assume ex) = F) /\
-  (bir_stmtb_is_not_assume (BStmt_Observe ec el obf) = T)
+val bir_stmtB_is_not_assume_def = Define `
+  (bir_stmtB_is_not_assume (BStmt_Declare v) = T) /\
+  (bir_stmtB_is_not_assume (BStmt_Assign v ex) = T) /\
+  (bir_stmtB_is_not_assume (BStmt_Assert ex) = T) /\
+  (bir_stmtB_is_not_assume (BStmt_Assume ex) = F) /\
+  (bir_stmtB_is_not_assume (BStmt_Observe ec el obf) = T)
 `;
 
-val bir_stmtb_not_assume_never_assumviol =
-  store_thm("bir_stmtb_not_assume_never_assumviol",
+val bir_stmtB_not_assume_never_assumviol =
+  store_thm("bir_stmtB_not_assume_never_assumviol",
   ``!stmtb st obs st'.
-    bir_stmtb_is_not_assume stmtb ==>
+    bir_stmtB_is_not_assume stmtb ==>
     (st.bst_status <> BST_AssumptionViolated) ==>
     (bir_exec_stmtB stmtb st = (obs, st')) ==>
     (st'.bst_status <> BST_AssumptionViolated)``,
@@ -42,7 +42,7 @@ REPEAT STRIP_TAC >>
 Cases_on `st` >>
 Cases_on `st'` >>
 Cases_on `stmtb` >> (
-  FULL_SIMP_TAC std_ss [bir_stmtb_is_not_assume_def,
+  FULL_SIMP_TAC std_ss [bir_stmtB_is_not_assume_def,
                         bir_exec_stmtB_def]
 ) >| [
   FULL_SIMP_TAC (std_ss++holBACore_ss)
@@ -109,7 +109,7 @@ Cases_on `stmtb` >> (
 val bir_stmtsB_has_no_assumes_def = Define `
   (bir_stmtsB_has_no_assumes [] = T) /\
   (bir_stmtsB_has_no_assumes (h::t) =
-    (bir_stmtb_is_not_assume h) /\ (bir_stmtsB_has_no_assumes t)
+    (bir_stmtB_is_not_assume h) /\ (bir_stmtsB_has_no_assumes t)
   )
 `;
 
@@ -150,7 +150,7 @@ Induct_on `stmtsB` >- (
 ) >>
 REPEAT STRIP_TAC >>
 FULL_SIMP_TAC std_ss [bir_stmtsB_has_no_assumes_def,
-                      bir_stmtb_is_not_assume_def,
+                      bir_stmtB_is_not_assume_def,
                       bir_exec_stmtsB_def] >>
 Cases_on `bir_state_is_terminated st` >| [
   FULL_SIMP_TAC std_ss [],
@@ -160,7 +160,7 @@ Cases_on `bir_state_is_terminated st` >| [
     FULL_SIMP_TAC std_ss [bir_exec_stmtB_exists]
   ) >>
   FULL_SIMP_TAC std_ss [LET_DEF] >>
-  IMP_RES_TAC bir_stmtb_not_assume_never_assumviol >>
+  IMP_RES_TAC bir_stmtB_not_assume_never_assumviol >>
   PAT_X_ASSUM ``!l'' c'' st''. _``
               (fn thm => ASSUME_TAC
                 (SPECL [``(OPT_CONS obs_test l): 'a list``,
@@ -518,8 +518,8 @@ IMP_RES_TAC bir_exec_to_labels_n_TO_bir_exec_block_n >>
 IMP_RES_TAC bir_prog_not_assume_never_assumviol_exec_block_n
 );
 
-val bir_exec_to_labels_no_av_triple_def = Define `
-  bir_exec_to_labels_no_av_triple p l ls pre post =
+val bir_exec_to_labels_triple_def = Define `
+  bir_exec_to_labels_triple p l ls pre post =
   !s r.
     bir_env_vars_are_initialised s.bst_environ
                                  (bir_vars_of_program p) ==>
@@ -557,11 +557,11 @@ val bir_never_assumviol_ht =
   store_thm("bir_never_assumviol_ht",
   ``!prog l ls pre post.
     bir_prog_has_no_assumes prog ==>
-    bir_exec_to_labels_triple prog l ls pre post ==>
-    bir_exec_to_labels_no_av_triple prog l ls pre post``,
+    bir_exec_to_labels_or_assumviol_triple prog l ls pre post ==>
+    bir_exec_to_labels_triple prog l ls pre post``,
 
-REWRITE_TAC [bir_exec_to_labels_no_av_triple_def,
-             bir_exec_to_labels_triple_def] >>
+REWRITE_TAC [bir_exec_to_labels_triple_def,
+             bir_exec_to_labels_or_assumviol_triple_def] >>
 REPEAT STRIP_TAC >>
 PAT_X_ASSUM ``!s r. _``
             (fn thm => ASSUME_TAC

--- a/src/theory/tools/wp/bir_wpScript.sml
+++ b/src/theory/tools/wp/bir_wpScript.sml
@@ -246,7 +246,7 @@ PAT_X_ASSUM ``bir_is_bool_exp_env s.bst_environ ex``
               (HO_MATCH_MP bir_bool_values thm)
             ) >>
 REV_FULL_SIMP_TAC std_ss [] >>
-FULL_SIMP_TAC std_ss [bir_neg_val_true, bir_exec_stmtB_def,
+FULL_SIMP_TAC std_ss [bir_not_val_true, bir_exec_stmtB_def,
                       bir_exec_stmt_assume_def,
                       bir_dest_bool_val_TF, bir_val_TF_dist] >>
 Cases_on `s` >> Cases_on `s'` >>

--- a/src/theory/tools/wp/bir_wpScript.sml
+++ b/src/theory/tools/wp/bir_wpScript.sml
@@ -246,7 +246,7 @@ PAT_X_ASSUM ``bir_is_bool_exp_env s.bst_environ ex``
               (HO_MATCH_MP bir_bool_values thm)
             ) >>
 REV_FULL_SIMP_TAC std_ss [] >>
-FULL_SIMP_TAC std_ss [bir_not_val_true, bir_exec_stmtB_def,
+FULL_SIMP_TAC std_ss [bir_neg_val_true, bir_exec_stmtB_def,
                       bir_exec_stmt_assume_def,
                       bir_dest_bool_val_TF, bir_val_TF_dist] >>
 Cases_on `s` >> Cases_on `s'` >>
@@ -1276,14 +1276,16 @@ val bir_exec_to_labels_triple_def = Define `
     (bir_eval_exp pre (s.bst_environ) = bir_val_true) ==>
     ((bir_exec_to_labels ls p s) = r) ==>
     (?l1 c1 c2 s'.
+      (r = BER_Ended l1 c1 c2 s') /\
       (
-        (r = BER_Ended l1 c1 c2 s') /\
-        (s'.bst_status = BST_Running) /\
-        bir_is_bool_exp_env s'.bst_environ post /\
-        (bir_eval_exp post (s'.bst_environ) = bir_val_true) /\
-        ((s'.bst_pc.bpc_index = 0) /\ (s'.bst_pc.bpc_label IN ls))
-      ) \/ (
-        (s'.bst_status = BST_AssumptionViolated)
+        (
+	  (s'.bst_status = BST_Running) /\
+	  bir_is_bool_exp_env s'.bst_environ post /\
+	  (bir_eval_exp post (s'.bst_environ) = bir_val_true) /\
+	  ((s'.bst_pc.bpc_index = 0) /\ (s'.bst_pc.bpc_label IN ls))
+        ) \/ (
+          (s'.bst_status = BST_AssumptionViolated)
+        )
       )
     )`;
 
@@ -1525,7 +1527,20 @@ FULL_SIMP_TAC (std_ss++holBACore_ss)
     FULL_SIMP_TAC (std_ss++holBACore_ss) []
   ),
 
+  (* Case: st12 is AssumptionViolated *)
   quantHeuristicsLib.QUANT_TAC [("s''", `st12`, [])] >>
+  FULL_SIMP_TAC (std_ss++holBACore_ss) [LET_DEF,
+                                        bir_state_COUNT_PC_def,
+                                        bir_block_pc_def] >>
+  FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_exec_to_labels_def] >>
+  subgoal `bir_state_is_terminated st12` >- (
+    FULL_SIMP_TAC (std_ss++holBACore_ss) []
+  ) >>
+  IMP_RES_TAC bir_exec_to_labels_n_REWR_TERMINATED >>
+  FULL_SIMP_TAC (std_ss++holBACore_ss) [] >>
+  quantHeuristicsLib.QUANT_TAC [("l1", `(st10 ++ [])`, []),
+                                ("c1", `st11`, []),
+                                ("c2", `0`, [])] >>
   FULL_SIMP_TAC (std_ss++holBACore_ss) []
 ]
 );
@@ -1748,6 +1763,18 @@ FULL_SIMP_TAC (std_ss++holBACore_ss)
 
   (* Case 3: st12 has status AssumptionViolated *)
   quantHeuristicsLib.QUANT_TAC [("s''", `st12`, [])] >>
+  FULL_SIMP_TAC (std_ss++holBACore_ss) [LET_DEF,
+                                        bir_state_COUNT_PC_def,
+                                        bir_block_pc_def] >>
+  FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_exec_to_labels_def] >>
+  subgoal `bir_state_is_terminated st12` >- (
+    FULL_SIMP_TAC (std_ss++holBACore_ss) []
+  ) >>
+  IMP_RES_TAC bir_exec_to_labels_n_REWR_TERMINATED >>
+  FULL_SIMP_TAC (std_ss++holBACore_ss) [] >>
+  quantHeuristicsLib.QUANT_TAC [("l1", `(st10 ++ [])`, []),
+                                ("c1", `st11`, []),
+                                ("c2", `0`, [])] >>
   FULL_SIMP_TAC (std_ss++holBACore_ss) []
 ]
 );

--- a/src/theory/tools/wp/bir_wpScript.sml
+++ b/src/theory/tools/wp/bir_wpScript.sml
@@ -1,20 +1,20 @@
 open HolKernel Parse boolLib bossLib;
 
-(* From /core: *)
+(* Theories from theory/bir: *)
 open bir_programTheory bir_typing_progTheory bir_envTheory
      bir_auxiliaryTheory bir_valuesTheory bir_expTheory
      bir_exp_immTheory bir_typing_expTheory bir_immTheory;
 
-(* From /theories: *)
+(* Theories from theory/bir-support: *)
 open bir_program_blocksTheory bir_program_terminationTheory
      bir_program_valid_stateTheory bir_exp_substitutionsTheory
      bir_bool_expTheory bir_program_env_orderTheory
      bir_program_multistep_propsTheory bir_exp_equivTheory;
 
+(* Simplification sets from theory/bir: *)
 open HolBACoreSimps;
 
 val _ = new_theory "bir_wp";
-
 
 (* Lemmata to move: *)
 
@@ -45,7 +45,7 @@ val bir_is_bool_exp_env_invar_bstmt =
 REPEAT STRIP_TAC >>
 FULL_SIMP_TAC std_ss [bir_is_bool_exp_env_def] >>
 IMP_RES_TAC bir_varinit_invar_bstmt >>
-PAT_X_ASSUM ``!bstmt. blah``
+PAT_X_ASSUM ``!bstmt. _``
             (fn thm => ASSUME_TAC
               (SPEC ``bstmt:'a bir_stmt_basic_t`` thm)
             ) >>
@@ -227,8 +227,8 @@ REV_FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_exec_stmtB_def,
 (* TODO: This theorem could also be stated with the precondition
  * holding instead of Booleanity holding. This antecedent is
  * needed to translate "not equal to True" to "equal to False". *)
-val bir_assume_assviol =
-  store_thm("bir_assume_assviol",
+val bir_assume_assumviol =
+  store_thm("bir_assume_assumviol",
   ``!s s' ex post obs.
       bir_is_bool_exp_env s.bst_environ
            (BExp_BinExp BIExp_Or (BExp_UnaryExp BIExp_Not ex)
@@ -281,7 +281,7 @@ Cases_on `bir_eval_exp ex s.bst_environ = bir_val_true` >| [
   FULL_SIMP_TAC std_ss [],
 
   subgoal `s'.bst_status = BST_AssumptionViolated` >- (
-    METIS_TAC [bir_assume_assviol]
+    METIS_TAC [bir_assume_assumviol]
   ) >>
   FULL_SIMP_TAC std_ss []
 ]
@@ -304,7 +304,7 @@ local
 
   val one_op_tac = (
     subst_induct_tac >>
-    PAT_X_ASSUM ``!e. blah`` (fn thm => ASSUME_TAC (SPEC ``ex':bir_exp_t`` thm)) >>
+    PAT_X_ASSUM ``!e. _`` (fn thm => ASSUME_TAC (SPEC ``ex':bir_exp_t`` thm)) >>
     Cases_on `type_of_bir_exp ex'` >> (
       FULL_SIMP_TAC std_ss []
     )
@@ -312,9 +312,9 @@ local
 
   val two_op_tac = (
     subst_induct_tac >>
-    PAT_ASSUM ``!e. blah``
+    PAT_ASSUM ``!e. _``
               (fn thm => ASSUME_TAC (SPEC ``ex':bir_exp_t`` thm)) >>
-    PAT_X_ASSUM ``!e. blah``
+    PAT_X_ASSUM ``!e. _``
                 (fn thm => ASSUME_TAC
                   (SPEC ``ex'':bir_exp_t`` thm)
                 ) >>
@@ -326,13 +326,13 @@ local
 
   val three_op_tac = (
     subst_induct_tac >>
-    PAT_ASSUM ``!e. blah``
+    PAT_ASSUM ``!e. _``
               (fn thm => ASSUME_TAC (SPEC ``ex':bir_exp_t`` thm)) >>
-    PAT_ASSUM ``!e. blah``
+    PAT_ASSUM ``!e. _``
               (fn thm => ASSUME_TAC
                 (SPEC ``ex'':bir_exp_t`` thm)
               ) >>
-    PAT_X_ASSUM ``!e. blah``
+    PAT_X_ASSUM ``!e. _``
                 (fn thm => ASSUME_TAC
                   (SPEC ``ex''':bir_exp_t`` thm)
                 ) >>
@@ -481,14 +481,14 @@ subgoal `bir_is_bool_exp post` >- (
 Cases_on `v` >> rename1 `(BVar vname vtype)` >>
 IMP_RES_TAC bir_assign_exec >>
 Cases_on `s.bst_environ` >> rename1 `BEnv f` >>
-PAT_X_ASSUM ``!f'. blah1 ==> blah2``
+PAT_X_ASSUM ``!f'. p1 ==> p2``
             (fn thm =>
                ASSUME_TAC (SPEC ``f:string |->
                                     bir_type_t # bir_val_t option``
                                 thm
                           )
             ) >>
-PAT_X_ASSUM ``!f'. blah``
+PAT_X_ASSUM ``!f'. _``
             (fn thm =>
                ASSUME_TAC (SPEC ``f:string |->
                                     bir_type_t # bir_val_t option``
@@ -860,8 +860,8 @@ ASSUME_TAC (ISPECL [``(\stmt:'a bir_stmt_basic_t.
 REV_FULL_SIMP_TAC std_ss [bir_varinit_invar_bstmt]
 );
 
-val bir_assviol_exec_stmtsB =
-  store_thm("bir_assviol_exec_stmtsB",
+val bir_assumviol_exec_stmtsB =
+  store_thm("bir_assumviol_exec_stmtsB",
   ``!obs c s stmts.
       (s.bst_status = BST_AssumptionViolated) ==>
       (bir_exec_stmtsB stmts (obs, c, s) = (REVERSE obs, c, s))
@@ -935,7 +935,7 @@ val bir_wp_exec_stmtsB_sound_thm =
         (* Case: AssumptionViolated in s'.
          * bir_exec_stmtsB is used to relate s'' to s', so you
          * should be able to prove this case easily. *)
-        FULL_SIMP_TAC std_ss [bir_assviol_exec_stmtsB] >>
+        FULL_SIMP_TAC std_ss [bir_assumviol_exec_stmtsB] >>
         REV_FULL_SIMP_TAC std_ss [],
 
         (* Case: Running in s. *)
@@ -945,7 +945,7 @@ val bir_wp_exec_stmtsB_sound_thm =
         ) >>
         (* Use induction hypothesis *)
         FULL_SIMP_TAC std_ss [bir_exec_stmtsB_triple_def] >>
-        PAT_X_ASSUM ``!s s' obs obs' c c'. blah`` (fn thm =>
+        PAT_X_ASSUM ``!s s' obs obs' c c'. _`` (fn thm =>
           ASSUME_TAC (Q.SPECL [`s'`, `s''`, `OPT_CONS q obs`,
                                `obs'`, `SUC c`, `c':num`] thm)) >>
         REV_FULL_SIMP_TAC std_ss [] >>
@@ -960,7 +960,7 @@ val bir_wp_exec_stmtsB_sound_thm =
                           [bir_is_valid_status_def]
       ],
 
-    FULL_SIMP_TAC std_ss [bir_assviol_exec_stmtsB] >>
+    FULL_SIMP_TAC std_ss [bir_assumviol_exec_stmtsB] >>
     REV_FULL_SIMP_TAC std_ss []
   ]
 );

--- a/src/theory/tools/wp/bir_wpScript.sml
+++ b/src/theory/tools/wp/bir_wpScript.sml
@@ -1265,8 +1265,8 @@ REV_FULL_SIMP_TAC (std_ss++holBACore_ss)
    -------------------------------------------------------------
 *)
   
-val bir_exec_to_labels_triple_def = Define `
-  bir_exec_to_labels_triple p l ls pre post =
+val bir_exec_to_labels_or_assumviol_triple_def = Define `
+  bir_exec_to_labels_or_assumviol_triple p l ls pre post =
   !s r.
     bir_env_vars_are_initialised s.bst_environ
                                  (bir_vars_of_program p) ==>
@@ -1391,8 +1391,8 @@ FULL_SIMP_TAC (srw_ss()) []>>
 RW_TAC std_ss []
 );
 
-val bir_exec_to_labels_triple_jmp =
-  store_thm("bir_exec_to_labels_triple_jmp",
+val bir_exec_to_labels_or_assumviol_triple_jmp =
+  store_thm("bir_exec_to_labels_or_assumviol_triple_jmp",
   ``!p l bl l1 ls post post'.
       bir_is_bool_exp post ==>
       bir_is_well_typed_program p ==>
@@ -1404,23 +1404,23 @@ val bir_exec_to_labels_triple_jmp =
       (bl.bb_last_statement = (BStmt_Jmp (BLE_Label l1))) ==>
       (((l1 IN ls) ==> (post' = post)) /\
        ((~(l1 IN ls)) ==>
-        (bir_exec_to_labels_triple p l1 ls post' post) /\
+        (bir_exec_to_labels_or_assumviol_triple p l1 ls post' post) /\
         (bir_is_bool_exp post')
        )
       ) ==>
-      (bir_exec_to_labels_triple p l ls
+      (bir_exec_to_labels_or_assumviol_triple p l ls
         (bir_wp_exec_stmtsB bl.bb_statements post') post
       )``,
 
 (* Expand definitions *)
 REPEAT (GEN_TAC ORELSE DISCH_TAC) >>
-SIMP_TAC std_ss [bir_exec_to_labels_triple_def] >>
+SIMP_TAC std_ss [bir_exec_to_labels_or_assumviol_triple_def] >>
 REPEAT (GEN_TAC ORELSE DISCH_TAC) >>
 (* "s'" is the state resulting from execution with
  * bir_exec_to_labels from s. *)
 Q.ABBREV_TAC `s' = bir_exec_to_labels ls p s` >>
 Q.ABBREV_TAC `cnd = l1 IN ls /\ (post' = post) \/
-  bir_exec_to_labels_triple p l1 ls pre post'` >>
+  bir_exec_to_labels_or_assumviol_triple p l1 ls pre post'` >>
 subgoal `(bir_get_current_block p s.bst_pc = SOME bl)` >- (
   FULL_SIMP_TAC std_ss [bir_get_current_block_def,
                         bir_get_program_block_info_by_label_MEM] >>
@@ -1498,7 +1498,7 @@ FULL_SIMP_TAC (std_ss++holBACore_ss)
   (* Case: We have not reach an end label *)
   FULL_SIMP_TAC std_ss [Abbr `cnd`, LET_DEF, bir_state_COUNT_PC_def,
                         bir_block_pc_def] >>
-  FULL_SIMP_TAC (srw_ss()) [bir_exec_to_labels_triple_def] >>
+  FULL_SIMP_TAC (srw_ss()) [bir_exec_to_labels_or_assumviol_triple_def] >>
   PAT_X_ASSUM ``!s''.p``
               (fn thm => ASSUME_TAC (Q.SPEC `st12` thm)) >>
   REV_FULL_SIMP_TAC (srw_ss()) [] >>
@@ -1545,8 +1545,8 @@ FULL_SIMP_TAC (std_ss++holBACore_ss)
 ]
 );
 
-val bir_exec_to_labels_triple_cjmp =
-  store_thm("bir_exec_to_labels_triple_cjmp",
+val bir_exec_to_labels_or_assumviol_triple_cjmp =
+  store_thm("bir_exec_to_labels_or_assumviol_triple_cjmp",
   ``!p l bl e l1 l2 ls post post1' post2'.
       bir_is_bool_exp post ==>
       bir_is_well_typed_program p ==>
@@ -1561,17 +1561,17 @@ val bir_exec_to_labels_triple_cjmp =
       ) ==>
       (((l1 IN ls) ==> (post1' = post)) /\
        ((~(l1 IN ls)) ==>
-         bir_exec_to_labels_triple p l1 ls post1' post /\
+         bir_exec_to_labels_or_assumviol_triple p l1 ls post1' post /\
          bir_is_bool_exp post1'
        )
       ) ==>
       (((l2 IN ls) ==> (post2' = post)) /\
        ((~(l2 IN ls)) ==>
-         bir_exec_to_labels_triple p l2 ls post2' post /\
+         bir_exec_to_labels_or_assumviol_triple p l2 ls post2' post /\
          bir_is_bool_exp post2'
        )
       ) ==>
-      (bir_exec_to_labels_triple p l ls
+      (bir_exec_to_labels_or_assumviol_triple p l ls
         (bir_wp_exec_stmtsB bl.bb_statements 
         (
           (BExp_BinExp BIExp_And 
@@ -1585,7 +1585,7 @@ val bir_exec_to_labels_triple_cjmp =
 
 (* Expand definitions *)
 REPEAT (GEN_TAC ORELSE DISCH_TAC) >>
-SIMP_TAC std_ss [bir_exec_to_labels_triple_def] >>
+SIMP_TAC std_ss [bir_exec_to_labels_or_assumviol_triple_def] >>
 REPEAT (GEN_TAC ORELSE DISCH_TAC) >>
 (* "s'" is the final state of execution *)
 Q.ABBREV_TAC `s' = bir_exec_to_labels ls p s` >>
@@ -1682,7 +1682,7 @@ FULL_SIMP_TAC (std_ss++holBACore_ss)
   (* We have not reached an end label *)
   FULL_SIMP_TAC std_ss [LET_DEF,
                         bir_state_COUNT_PC_def, bir_block_pc_def] >>
-  FULL_SIMP_TAC (srw_ss()) [bir_exec_to_labels_triple_def] >>
+  FULL_SIMP_TAC (srw_ss()) [bir_exec_to_labels_or_assumviol_triple_def] >>
   PAT_X_ASSUM ``!s''.p`` (fn thm=>ASSUME_TAC (Q.SPEC `st12` thm)) >>
   REV_FULL_SIMP_TAC (srw_ss()) [] >>
   subgoal `bir_env_vars_are_initialised st12.bst_environ
@@ -1734,7 +1734,7 @@ FULL_SIMP_TAC (std_ss++holBACore_ss)
   (* We have not reached an end label *)
   FULL_SIMP_TAC std_ss [LET_DEF,
                         bir_state_COUNT_PC_def, bir_block_pc_def] >>
-  FULL_SIMP_TAC (srw_ss()) [bir_exec_to_labels_triple_def] >>
+  FULL_SIMP_TAC (srw_ss()) [bir_exec_to_labels_or_assumviol_triple_def] >>
   PAT_X_ASSUM ``!s''.p`` (fn thm=>ASSUME_TAC (Q.SPEC `st12` thm)) >>
   REV_FULL_SIMP_TAC (srw_ss()) [] >>
   subgoal `bir_env_vars_are_initialised st12.bst_environ
@@ -2106,14 +2106,14 @@ val bir_wp_exec_of_block_sound_thm =
       FEVERY (\(l1, wp1).
                ((l1 IN ls) ==> (wp1 = post)) /\
                ((~(l1 IN ls)) ==>
-                 (bir_exec_to_labels_triple p l1 ls wp1 post)
+                 (bir_exec_to_labels_or_assumviol_triple p l1 ls wp1 post)
                )
              ) wps ==>
       ((bir_wp_exec_of_block p l ls post wps) = SOME wps') ==>
       (FEVERY (\(l1, wp1).
                 ((l1 IN ls) ==> (wp1 = post)) /\
                 ((~(l1 IN ls)) ==>
-                  (bir_exec_to_labels_triple p l1 ls wp1 post)
+                  (bir_exec_to_labels_or_assumviol_triple p l1 ls wp1 post)
                 )
               ) wps')
   ``,
@@ -2156,13 +2156,13 @@ Cases_on `FLOOKUP wps l` >- (
   ) >| [
     Cases_on `l1 IN FDOM wps` >- (
       FULL_SIMP_TAC std_ss [] >>
-      subgoal `bir_exec_to_labels_triple (BirProgram bls) l ls
+      subgoal `bir_exec_to_labels_or_assumviol_triple (BirProgram bls) l ls
                  (bir_wp_exec_stmtsB bl.bb_statements
                                      (FAPPLY wps l1)
                  ) post` >- (
         ASSUME_TAC (Q.SPECL [`BirProgram bls`, `l`, `bl`, `l1`,
                              `ls`, `post`]
-                            bir_exec_to_labels_triple_jmp) >>
+                            bir_exec_to_labels_or_assumviol_triple_jmp) >>
         subgoal `MEM l1 (bir_labels_of_program
                           (BirProgram bls)
                         )` >- (
@@ -2201,12 +2201,12 @@ Cases_on `FLOOKUP wps l` >- (
                                                    (FAPPLY wps l2)
                              )
                            )` >>
-      subgoal `bir_exec_to_labels_triple (BirProgram bls) l ls
+      subgoal `bir_exec_to_labels_or_assumviol_triple (BirProgram bls) l ls
                 (bir_wp_exec_stmtsB bl.bb_statements exp1)
                 post` >- (
         ASSUME_TAC (Q.SPECL [`BirProgram bls`, `l`, `bl`, `e`, `l1`,
                              `l2`, `ls`, `post`]
-                   bir_exec_to_labels_triple_cjmp) >>
+                   bir_exec_to_labels_or_assumviol_triple_cjmp) >>
         subgoal `MEM l1
                   (bir_labels_of_program (BirProgram bls)) /\
                  MEM l2
@@ -2251,7 +2251,7 @@ val bir_sound_wps_map_def = Define `
     (FEVERY (\(l1, wp1).
               ((l1 IN ls) ==> (wp1 = post)) /\
               ((~(l1 IN ls)) ==>
-                (bir_exec_to_labels_triple p l1 ls wp1 post)
+                (bir_exec_to_labels_or_assumviol_triple p l1 ls wp1 post)
               )
             ) wps
     )`;

--- a/src/tools/wp/bir_htLib.sig
+++ b/src/tools/wp/bir_htLib.sig
@@ -1,0 +1,10 @@
+signature bir_htLib =
+sig
+  include Abbrev
+
+  val bir_stmtb_is_not_assume_pp : term -> thm
+  val bir_stmtsB_has_no_assumes_pp : term -> thm
+  val bir_block_has_no_assumes_pp : term -> thm
+  val bir_prog_has_no_assumes_pp : term -> thm
+
+end

--- a/src/tools/wp/bir_htLib.sml
+++ b/src/tools/wp/bir_htLib.sml
@@ -28,9 +28,9 @@ struct
 
   in
 
-    fun bir_stmtb_is_not_assume_pp stmtb_is_na =
+    fun bir_stmtB_is_not_assume_pp stmtb_is_na =
       EQT_ELIM (
-	SIMP_CONV holba_ss [bir_stmtb_is_not_assume_def] stmtb_is_na
+	SIMP_CONV holba_ss [bir_stmtB_is_not_assume_def] stmtb_is_na
       );
 
     fun bir_stmtsB_has_no_assumes_pp stmtsB_is_na =
@@ -44,10 +44,10 @@ struct
 	  val thm1_lhs_tm = (snd o dest_eq o concl) thm1
 	  (* Can split with boolSyntax.strip_conj and prove
            * conjuncts individually using
-           * bir_stmtb_is_not_assume_pp. What is faster? *)
+           * bir_stmtB_is_not_assume_pp. What is faster? *)
 	  val thm1_lhs_thm =
 	    EQT_ELIM (
-	      SIMP_CONV holba_ss [bir_stmtb_is_not_assume_def,
+	      SIMP_CONV holba_ss [bir_stmtB_is_not_assume_def,
 				  stmtsB_empty_na] thm1_lhs_tm
 	    )
 	  val thm1_rhs = REWRITE_RULE [thm1_lhs_thm] thm1

--- a/src/tools/wp/bir_htLib.sml
+++ b/src/tools/wp/bir_htLib.sml
@@ -1,0 +1,89 @@
+structure bir_htLib =
+struct
+
+  local
+
+    (* For compilation *)
+    open HolKernel Parse boolLib bossLib liteLib simpLib;
+
+    (* Theories from theory/bir *)
+    open bir_programTheory;
+
+    (* Syntax function libraries from theory/bir *)
+    open bir_programSyntax;
+
+    (* Syntax function libraries from HOL4 *)
+    open boolSyntax listSyntax;
+
+    (* Simpsets from theory/bir *)
+    open HolBACoreSimps;
+
+    (* Local theories *)
+    open bir_htTheory;
+
+    val holba_ss = (std_ss++holBACore_ss)
+
+    val [stmtsB_empty_na, stmtsB_nempty_na] =
+      CONJUNCTS bir_stmtsB_has_no_assumes_def;
+
+  in
+
+    fun bir_stmtb_is_not_assume_pp stmtb_is_na =
+      EQT_ELIM (
+	SIMP_CONV holba_ss [bir_stmtb_is_not_assume_def] stmtb_is_na
+      );
+
+    fun bir_stmtsB_has_no_assumes_pp stmtsB_is_na =
+      if ((is_nil o snd o dest_comb) stmtsB_is_na)
+      then EQT_ELIM (REWRITE_CONV [stmtsB_empty_na] stmtsB_is_na)
+      else
+	let
+	  val thm1 =
+            SIMP_CONV std_ss [stmtsB_nempty_na] stmtsB_is_na
+
+	  val thm1_lhs_tm = (snd o dest_eq o concl) thm1
+	  (* Can split with boolSyntax.strip_conj and prove
+           * conjuncts individually using
+           * bir_stmtb_is_not_assume_pp. What is faster? *)
+	  val thm1_lhs_thm =
+	    EQT_ELIM (
+	      SIMP_CONV holba_ss [bir_stmtb_is_not_assume_def,
+				  stmtsB_empty_na] thm1_lhs_tm
+	    )
+	  val thm1_rhs = REWRITE_RULE [thm1_lhs_thm] thm1
+	in
+	  thm1_rhs
+	end
+    ;
+
+    fun bir_block_has_no_assumes_pp block_is_na =
+      let
+	val thm1 =
+	  SIMP_CONV holba_ss [bir_block_has_no_assumes_def]
+            block_is_na
+	val thm1_lhs_tm = (snd o dest_eq o concl) thm1
+	val thm1_lhs_thm = bir_stmtsB_has_no_assumes_pp thm1_lhs_tm
+	val thm1_rhs = REWRITE_RULE [thm1_lhs_thm] thm1
+      in
+	thm1_rhs
+      end
+    ;
+
+    fun bir_prog_has_no_assumes_pp prog_is_na =
+      let
+	val thm1 =
+	  SIMP_CONV holba_ss [bir_prog_has_no_assumes_def]
+            prog_is_na
+	val thm1_lhs_conj_tms =
+	  (boolSyntax.strip_conj o snd o dest_eq o concl) thm1
+	val thm1_lhs_conj_thms =
+	  map bir_block_has_no_assumes_pp thm1_lhs_conj_tms
+	val thm1_rhs = REWRITE_RULE thm1_lhs_conj_thms thm1
+      in
+	thm1_rhs
+      end
+    ;
+
+  end
+
+end


### PR DESCRIPTION
I added new theorems and definitions to obtain an AssumptionViolated-free Hoare triple from the regular one, provided the program contains no Assume statements. Also, corrected typo in exec_to_labels HT.

The terminology is a little rough around the edges. I will likely make some clean-up commit that renames and moves some lemmata around, and makes the proofs nicer. Please provide feedback so that everything can be sorted out in one go.

I am also working on a proof procedure to obtain the result of an Assume-free BIR program (the definitions should be very straightforward to use, however).

EDIT: Added commit to resolve #53.