### PR TITLE
Added infix in bir_wpLib

### DIFF
--- a/src/tools/wp/bir_wpLib.sml
+++ b/src/tools/wp/bir_wpLib.sml
@@ -244,7 +244,7 @@ struct
 
   (* produce wps1 and reestablish bool_sound_thm for this one *)
   fun bir_wp_comp_wps_iter_step2 (wps, wps_bool_sound_thm) prog_l_thm
-				 ((program, post, ls), (label)) defs =
+				 ((program, post, ls), (label)) defs wp_infix =
     let
       val wps_id_suffix = label_to_wps_id_suffix label
 
@@ -280,7 +280,7 @@ struct
                                         GSYM bir_exp_and_def]
                                        wps1_thm; 
       val wps1 = (snd o dest_comb o snd o dest_eq o concl) wps1_thm
-      val new_wp_id = wps_id_prefix^wps_id_suffix
+      val new_wp_id = wps_id_prefix^wp_infix^wps_id_suffix
       val new_wp_id_var = mk_var (new_wp_id, bir_exp_t_ty)
       val new_wp_def =
         Define `^new_wp_id_var = ^(extract_new_wp wps1)`
@@ -349,7 +349,7 @@ struct
   (* Recursive procedure for traversing the control flow graph *)
   fun bir_wp_comp_wps prog_thm ((wps, wps_bool_sound_thm),
 				(wpsdom, blstodo)
-			       ) (program, post, ls) defs =
+			       ) (program, post, ls) defs wp_infix =
     let
       val block = List.find (fn block =>
 	let
@@ -411,7 +411,7 @@ struct
 					 prog_l_thm
 					 ((program, post, ls),
 					  (label)
-					 ) defs
+					 ) defs wp_infix
 	    val blstodo1 =
 	      List.filter (
 		fn block =>
@@ -463,6 +463,7 @@ struct
 	    bir_wp_comp_wps prog_thm ((wps1, wps1_bool_sound_thm),
 				      (wpsdom1, blstodo1)
 				     ) (program, post, ls) defs
+                                     wp_infix
 	  end
         | NONE =>
           let


### PR DESCRIPTION
An issue with `bir_wpLib` is that the definitions for generated WPs can get overloaded. This is not problematic as long as you never generate and prove WPs for the same block labels in the same session. However, I think it would be nice to be able to do so.

This can be accomplished for example by adding an infix as an argument to `bir_wp_comp_wps` (and `bir_wp_comp_wps_iter_step2`) which ties these generated definitions to the particular WP.

In my estimation, this would also require changes to the following files (outside of the tutorial):

- `src/tools/wp/easy_noproof_wpLib.sml`
- `src/tools/wp/bir_wp_simpLib.sml`
- `src/tools/wp/examples/example-toy-pass.sml`
- `src/tools/wp/examples/test-toy.sml`
- `examples/aes/wp71-pass-test.sml`
- `examples/aes/wp-test.sml`
- `examples/aes/wp/aesM0WpsScript.sml`
- `examples/aes/wp/aesWpsScript.sml`
- `examples/aes/wp/aesM0SimpWpScript.sml`
- `examples/aes/wp/aesSimpWpScript.sml`

I am making this a draft PR to make it clear that we should discuss how to deal with this issue first.