### PR TITLE
New L_AS judgment now integrated with examples

### DIFF
--- a/examples/tutorial/7-composition/tutorialExtra2_compositionScript.sml
+++ b/examples/tutorial/7-composition/tutorialExtra2_compositionScript.sml
@@ -28,6 +28,26 @@ val _ = new_theory "tutorialExtra2_composition";
 fun el_in_set elem set =
   EQT_ELIM (SIMP_CONV (std_ss++pred_setLib.PRED_SET_ss) [] (pred_setSyntax.mk_in (elem, set)));
 
+fun delete_not_empty_set elem set =
+  let
+    val delete_tm = pred_setSyntax.mk_delete (set, elem)
+
+    val delete_thm =
+      SIMP_CONV (std_ss++pred_setLib.PRED_SET_ss++HolBACoreSimps.holBACore_ss++wordsLib.WORD_ss)
+	[pred_setTheory.DELETE_DEF]
+	delete_tm
+
+    val notempty_thm =
+      SIMP_CONV (std_ss++pred_setLib.PRED_SET_ss) []
+	(mk_neg (mk_eq ((snd o dest_eq o concl) delete_thm, pred_setSyntax.mk_empty bir_label_t_ty)))
+
+  in
+    EQT_ELIM (SIMP_CONV std_ss [delete_thm, notempty_thm] 
+      (mk_neg (mk_eq (delete_tm, pred_setSyntax.mk_empty bir_label_t_ty)))
+    )
+  end
+;
+
 val mk_set = pred_setSyntax.mk_set;
 
 val simp_delete_set_rule =
@@ -48,9 +68,9 @@ val simp_in_set_tac =
   SIMP_TAC (std_ss++HolBACoreSimps.holBACore_ss++wordsLib.WORD_ss++pred_setLib.PRED_SET_ss) []
 
 (* DEBUG *)
-val (get_labels_from_set_repr, el_in_set_repr,
+val (get_labels_from_set_repr, el_in_set_repr, delete_not_empty_set_repr,
      mk_set_repr, simp_delete_set_repr_rule,
-     simp_insert_set_repr_rule, simp_in_sing_set_repr_rule, simp_inter_set_repr_rule, simp_in_set_repr_tac, inter_set_repr_ss, union_set_repr_ss) = (ending_set_to_sml_list, el_in_set, mk_set, simp_delete_set_rule,
+     simp_insert_set_repr_rule, simp_in_sing_set_repr_rule, simp_inter_set_repr_rule, simp_in_set_repr_tac, inter_set_repr_ss, union_set_repr_ss) = (ending_set_to_sml_list, el_in_set, delete_not_empty_set, mk_set, simp_delete_set_rule,
      simp_insert_set_rule, simp_in_sing_set_rule, simp_inter_set_rule, simp_in_set_tac, bir_inter_var_set_ss, bir_union_var_set_ss);
 (************************************)
 
@@ -130,7 +150,8 @@ val bir_ieo_sec_isodd_exit_comp_ht =
 
 (* For debugging: *)
   val loop_map_ht    = REWRITE_RULE [GSYM bir_ieo_sec_iseven_loop_post_def, Once abs_ev_intro]
-          (bir_populate_blacklist (get_labels_from_set_repr, el_in_set_repr, mk_set_repr,
+          (bir_populate_blacklist (get_labels_from_set_repr, el_in_set_repr,
+                                   delete_not_empty_set_repr, mk_set_repr,
                                    simp_delete_set_repr_rule, simp_insert_set_repr_rule)
            (REWRITE_RULE [GSYM abs_ev_intro, bir_ieo_sec_iseven_loop_post_def] loop_ev_map_ht_2));
 
@@ -154,7 +175,8 @@ val loop_and_exit_ev_ht =
 
 (* For debugging: *)
   val loop_map_ht    = REWRITE_RULE [GSYM bir_ieo_sec_isodd_loop_post_def, Once abs_od_intro]
-          (bir_populate_blacklist (get_labels_from_set_repr, el_in_set_repr, mk_set_repr,
+          (bir_populate_blacklist (get_labels_from_set_repr, el_in_set_repr,
+                                   delete_not_empty_set_repr, mk_set_repr,
                                    simp_delete_set_repr_rule, simp_insert_set_repr_rule)
            (REWRITE_RULE [GSYM abs_od_intro, bir_ieo_sec_isodd_loop_post_def] loop_od_map_ht_2));
 

--- a/src/theory/bin_hoare_logic/bin_simp_hoare_logicScript.sml
+++ b/src/theory/bin_hoare_logic/bin_simp_hoare_logicScript.sml
@@ -73,7 +73,7 @@ val weak_map_move_to_whitelist = store_thm("weak_map_move_to_whitelist",
     weak_map_triple m invariant l (l' INSERT ls) (ls' DELETE l') pre post``,
 
 REPEAT STRIP_TAC >>
-FULL_SIMP_TAC std_ss [weak_map_triple_def, weak_triple_def] >>
+FULL_SIMP_TAC std_ss [weak_map_triple_def] >>
 subgoal `?ls''. (ls' = l' INSERT ls'') /\ l' NOTIN ls''` >- (
   METIS_TAC [pred_setTheory.DECOMPOSITION]
 ) >>
@@ -88,7 +88,6 @@ REPEAT STRIP_TAC >| [
   ONCE_REWRITE_TAC [pred_setTheory.INTER_COMM] >>
   FULL_SIMP_TAC std_ss [pred_setTheory.DELETE_INTER, pred_setTheory.INSERT_INTER,
                         pred_setTheory.COMPONENT] >>
-
   FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) [pred_setTheory.INSERT_INTER,
                                                    pred_setTheory.COMPONENT,
                                                    pred_setTheory.INSERT_EQ_SING] >>
@@ -96,9 +95,12 @@ REPEAT STRIP_TAC >| [
   FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) [pred_setTheory.INSERT_INTER] >>
   FULL_SIMP_TAC std_ss [Once pred_setTheory.INTER_COMM],
 
-  QSPECL_X_ASSUM ``!ms. _`` [`ms`] >>
-  REV_FULL_SIMP_TAC std_ss [] >>
-  Q.EXISTS_TAC `ms'` >>
+  FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) [],
+
+  irule weak_weakening_rule_thm >>
+  FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) [] >>
+  Q.EXISTS_TAC `(\ms. m.pc ms NOTIN l' INSERT ls'' /\ post ms /\ invariant ms)` >>
+  Q.EXISTS_TAC `(\ms. pre ms /\ invariant ms)` >>
   FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) [] >>
   `((l' INSERT ls) UNION ((l' INSERT ls'') DELETE l')) = (ls UNION (l' INSERT ls''))` suffices_by (
     FULL_SIMP_TAC std_ss []
@@ -317,6 +319,10 @@ STRIP_TAC >- (
                         pred_setTheory.UNION_OVER_INTER,
                         pred_setTheory.UNION_EMPTY]
 ) >>
+STRIP_TAC >- (
+  FULL_SIMP_TAC (std_ss++pred_setSimps.PRED_SET_ss) [] >>
+  METIS_TAC [pred_setTheory.MEMBER_NOT_EMPTY]
+) >>
 irule weak_seq_rule_thm >>
 FULL_SIMP_TAC std_ss [] >>
 Q.EXISTS_TAC `wl1` >>
@@ -399,14 +405,11 @@ METIS_TAC [pred_setTheory.MEMBER_NOT_EMPTY]
 );
 
 
-(* TODO: Do new version of this *)
 val weak_map_std_seq_comp_thm = store_thm("weak_map_std_seq_comp_thm",
   ``!m ls1 ls1' ls2 ls2' invariant l pre1 post1 post2.
     weak_model m ==>
     ls1' SUBSET ls2 ==>
     (ls1 INTER ls1' = EMPTY) ==>
-(*    (ls1' INTER ls2' = EMPTY) ==>*)
-(*    ls1 <> {} ==> *)
     weak_map_triple m invariant l ls1 ls2 pre1 post1 ==>
     (!l1. (l1 IN ls1) ==> (weak_map_triple m invariant l1 ls1' ls2' post1 post2)) ==>
     weak_map_triple m invariant l ls1' (ls2 INTER ls2') pre1 post2``,

--- a/src/theory/tools/comp/bir_wm_instScript.sml
+++ b/src/theory/tools/comp/bir_wm_instScript.sml
@@ -1154,7 +1154,7 @@ IMP_RES_TAC weak_invariant_rule_thm
 val bir_triple_equiv_map_triple = store_thm("bir_triple_equiv_map_triple",
   ``!prog invariant l ls ls' pre post.
     bir_map_triple prog invariant l ls ls' pre post <=>
-      (((ls INTER ls') = EMPTY) /\
+      (((ls INTER ls') = EMPTY) /\ (ls <> EMPTY) /\
        (bir_triple prog l (ls UNION ls')
 		   (BExp_BinExp BIExp_And pre invariant)
 		   (\label. if (label IN ls)
@@ -1223,7 +1223,7 @@ EQ_TAC >> (
 val bir_triple_equiv_map_triple_alt = store_thm("bir_triple_equiv_map_triple_alt",
   ``!prog invariant l ls ls' pre post.
     bir_map_triple prog invariant l ls ls' pre post <=>
-      (((ls INTER ls') = EMPTY) /\
+      (((ls INTER ls') = EMPTY) /\ (ls <> EMPTY) /\
        (bir_triple prog l (ls UNION ls')
 		   (BExp_BinExp BIExp_And pre invariant)
 		   (\label. if (label IN ls')
@@ -1288,6 +1288,7 @@ val bir_map_triple_move_to_blacklist = store_thm("bir_map_triple_move_to_blackli
   ``!prog inv l wlist blist pre post elabel.
     bir_map_triple prog inv l wlist blist pre post ==>
     elabel IN wlist ==>
+    wlist DELETE elabel <> {} ==>
     (post elabel = bir_exp_false) ==>
     bir_map_triple prog inv l (wlist DELETE elabel) (elabel INSERT blist) pre post``,
 
@@ -1306,7 +1307,7 @@ val bir_map_triple_move_set_to_blacklist = store_thm("bir_map_triple_move_set_to
   ``!prog inv l wlist blist pre post elabels.
     bir_map_triple prog inv l wlist blist pre post ==>
     FINITE elabels ==>
-    elabels SUBSET wlist ==>
+    elabels PSUBSET wlist ==>
     (!elabel. elabel IN elabels ==> (post elabel = bir_exp_false)) ==>
     bir_map_triple prog inv l (wlist DIFF elabels) (elabels UNION blist) pre post``,
 
@@ -1471,7 +1472,6 @@ val bir_map_std_seq_comp_thm =
   ``!prog ls1 ls1' ls2 ls2' invariant l pre1 post1 post2.
     ls1' SUBSET ls2 ==>
     (ls1 INTER ls1' = EMPTY) ==>
-    (ls1' INTER ls2' = EMPTY) ==>
     bir_map_triple prog invariant l ls1 ls2 pre1 post1 ==>
     (!l1. (l1 IN ls1) ==> (bir_map_triple prog invariant l1 ls1' ls2' (post1 l1) post2)) ==>
     bir_map_triple prog invariant l ls1' (ls2 INTER ls2') pre1 post2``,


### PR DESCRIPTION
An additional condition that whitelist be non-empty was added to the L_AS judgment, this has now also been propagated to the examples, where this led to some technical changes.