### PR TITLE
Program composition theorems

### DIFF
--- a/src/theory/bin_hoare_logic/bin_hoare_logicScript.sml
+++ b/src/theory/bin_hoare_logic/bin_hoare_logicScript.sml
@@ -177,7 +177,7 @@ val weak_model_comp_rule_thm = store_thm("weak_model_comp_rule_thm",
     weak_model m ==>
     weak_model n ==>
     (!ms ls ms'. m.weak ms ls ms' ==> n.weak ms ls ms') ==>
-    (!ms l'. (n.pc ms = l')  ==> (m.pc ms = l')) ==>
+    (!ms l. (n.pc ms = l)  ==> (m.pc ms = l)) ==>
     weak_triple m l ls pre post ==>
     weak_triple n l ls pre post``,
 

--- a/src/theory/bin_hoare_logic/bin_hoare_logicScript.sml
+++ b/src/theory/bin_hoare_logic/bin_hoare_logicScript.sml
@@ -172,6 +172,30 @@ val weak_triple_def = Define `
 `;
 
 
+val weak_model_comp_rule_thm = store_thm("weak_model_comp_rule_thm",
+  ``!m n.
+    weak_model m ==>
+    weak_model n ==>
+    !ls l pre post.
+    (!ms ms'. m.weak ms ls ms' ==> n.weak ms ls ms') ==>
+    (!ms l'. (n.pc ms = l')  ==> (m.pc ms = l')) ==>
+    weak_triple m l ls pre post ==>
+    weak_triple n l ls pre post``,
+
+REPEAT STRIP_TAC >>
+FULL_SIMP_TAC std_ss [weak_triple_def] >>
+REPEAT STRIP_TAC >>
+QSPECL_X_ASSUM ``!ms. _`` [`ms`] >>
+QSPECL_X_ASSUM ``!ms. _`` [`ms`] >>
+REV_FULL_SIMP_TAC std_ss [] >>
+FULL_SIMP_TAC std_ss [] >>
+QSPECL_X_ASSUM ``!ms ms'. _`` [`ms`, `ms'`] >>
+REV_FULL_SIMP_TAC std_ss [] >>
+Q.EXISTS_TAC `ms'` >>
+FULL_SIMP_TAC std_ss []
+);
+
+
 val weak_case_rule_thm = prove(``
 !m l ls pre post C1.
   weak_triple m l ls (\ms. (pre ms) /\ (C1 ms)) post ==>

--- a/src/theory/bin_hoare_logic/bin_hoare_logicScript.sml
+++ b/src/theory/bin_hoare_logic/bin_hoare_logicScript.sml
@@ -173,11 +173,10 @@ val weak_triple_def = Define `
 
 
 val weak_model_comp_rule_thm = store_thm("weak_model_comp_rule_thm",
-  ``!m n.
+  ``!m n l ls pre post.
     weak_model m ==>
     weak_model n ==>
-    !ls l pre post.
-    (!ms ms'. m.weak ms ls ms' ==> n.weak ms ls ms') ==>
+    (!ms ls ms'. m.weak ms ls ms' ==> n.weak ms ls ms') ==>
     (!ms l'. (n.pc ms = l')  ==> (m.pc ms = l')) ==>
     weak_triple m l ls pre post ==>
     weak_triple n l ls pre post``,
@@ -189,7 +188,7 @@ QSPECL_X_ASSUM ``!ms. _`` [`ms`] >>
 QSPECL_X_ASSUM ``!ms. _`` [`ms`] >>
 REV_FULL_SIMP_TAC std_ss [] >>
 FULL_SIMP_TAC std_ss [] >>
-QSPECL_X_ASSUM ``!ms ms'. _`` [`ms`, `ms'`] >>
+QSPECL_X_ASSUM ``!ms ls ms'. _`` [`ms`, `ls`, `ms'`] >>
 REV_FULL_SIMP_TAC std_ss [] >>
 Q.EXISTS_TAC `ms'` >>
 FULL_SIMP_TAC std_ss []

--- a/src/theory/bin_hoare_logic/bin_simp_hoare_logicScript.sml
+++ b/src/theory/bin_hoare_logic/bin_simp_hoare_logicScript.sml
@@ -24,7 +24,7 @@ val weak_map_model_comp_rule_thm = store_thm("weak_map_model_comp_rule_thm",
     weak_model m ==>
     weak_model n ==>
     (!ms ls ms'. m.weak ms ls ms' ==> n.weak ms ls ms') ==>
-    (!ms l'. (n.pc ms = l')  ==> (m.pc ms = l')) ==>
+    (!ms l. (n.pc ms = l)  ==> (m.pc ms = l)) ==>
     weak_map_triple m invariant l ls ls' pre post ==>
     weak_map_triple n invariant l ls ls' pre post``,
 

--- a/src/theory/bin_hoare_logic/bin_simp_hoare_logicScript.sml
+++ b/src/theory/bin_hoare_logic/bin_simp_hoare_logicScript.sml
@@ -18,6 +18,23 @@ val weak_map_triple_def = Define `
     )
 `;
 
+
+val weak_map_model_comp_rule_thm = store_thm("weak_map_model_comp_rule_thm",
+  ``!m n invariant l ls ls' pre post.
+    weak_model m ==>
+    weak_model n ==>
+    (!ms ls ms'. m.weak ms ls ms' ==> n.weak ms ls ms') ==>
+    (!ms l'. (n.pc ms = l')  ==> (m.pc ms = l')) ==>
+    weak_map_triple m invariant l ls ls' pre post ==>
+    weak_map_triple n invariant l ls ls' pre post``,
+
+REPEAT STRIP_TAC >>
+FULL_SIMP_TAC std_ss [weak_map_triple_def] >>
+irule weak_model_comp_rule_thm >>
+METIS_TAC []
+);
+
+
 val weak_map_subset_blacklist_rule_thm =
   store_thm("weak_map_subset_blacklist_rule_thm",
   ``!m.


### PR DESCRIPTION
This PR adds a program composition theorem for BIR, as well as abstract model composition theorems for L_A and L_AS. Currently, there are no proof procedures to mechanise usage of these.