### PR TITLE
SEFM cleanup

### DIFF
--- a/examples/tutorial/7-composition/tutorialExtra2_compositionScript.sml
+++ b/examples/tutorial/7-composition/tutorialExtra2_compositionScript.sml
@@ -28,6 +28,11 @@ val _ = new_theory "tutorialExtra2_composition";
 fun el_in_set elem set =
   EQT_ELIM (SIMP_CONV (std_ss++pred_setLib.PRED_SET_ss) [] (pred_setSyntax.mk_in (elem, set)));
 
+fun not_empty_set set =
+  EQT_ELIM (SIMP_CONV (std_ss++pred_setLib.PRED_SET_ss) []
+    (mk_neg (mk_eq (set, pred_setSyntax.mk_empty bir_label_t_ty))))
+;
+
 fun delete_not_empty_set elem set =
   let
     val delete_tm = pred_setSyntax.mk_delete (set, elem)
@@ -77,24 +82,24 @@ val (get_labels_from_set_repr, el_in_set_repr, delete_not_empty_set_repr,
 (* =============================================================== *)
 
 val bir_ieo_sec_iseven_loop_comp_ht =
-  use_pre_str_rule
-    (HO_MATCH_MP bir_label_ht_impl_weak_ht bir_ieo_sec_iseven_loop_ht)
+  use_pre_str_rule_map
+    (HO_MATCH_MP (HO_MATCH_MP bir_label_ht_impl_weak_ht (not_empty_set (get_contract_ls bir_ieo_sec_iseven_loop_ht))) bir_ieo_sec_iseven_loop_ht)
     contract_ev_1_imp_taut_thm;
 
 val bir_ieo_sec_iseven_exit_comp_ht =
-  use_pre_str_rule
-    (HO_MATCH_MP bir_label_ht_impl_weak_ht bir_ieo_sec_iseven_exit_ht)
+  use_pre_str_rule_map
+    (HO_MATCH_MP (HO_MATCH_MP bir_label_ht_impl_weak_ht (not_empty_set (get_contract_ls bir_ieo_sec_iseven_exit_ht))) bir_ieo_sec_iseven_exit_ht)
     contract_ev_2_imp_taut_thm;
 
 
 val bir_ieo_sec_isodd_loop_comp_ht =
-  use_pre_str_rule
-    (HO_MATCH_MP bir_label_ht_impl_weak_ht bir_ieo_sec_isodd_loop_ht)
+  use_pre_str_rule_map
+    (HO_MATCH_MP (HO_MATCH_MP bir_label_ht_impl_weak_ht (not_empty_set (get_contract_ls bir_ieo_sec_isodd_loop_ht))) bir_ieo_sec_isodd_loop_ht)
     contract_od_1_imp_taut_thm;
 
 val bir_ieo_sec_isodd_exit_comp_ht =
-  use_pre_str_rule
-    (HO_MATCH_MP bir_label_ht_impl_weak_ht bir_ieo_sec_isodd_exit_ht)
+  use_pre_str_rule_map
+    (HO_MATCH_MP (HO_MATCH_MP bir_label_ht_impl_weak_ht (not_empty_set (get_contract_ls bir_ieo_sec_isodd_exit_ht))) bir_ieo_sec_isodd_exit_ht)
     contract_od_2_imp_taut_thm;
 
 
@@ -104,17 +109,17 @@ val bir_ieo_sec_isodd_exit_comp_ht =
   val abs_ev_intro = prove(``bir_ieo_sec_iseven_loop_post v1 v = \l. bir_ieo_sec_iseven_loop_post v1 v l``, EVAL_TAC >> REWRITE_TAC []);
   val abs_ev_intro2 = prove(``bir_ieo_sec_iseven_exit_post v1 = \l. bir_ieo_sec_iseven_exit_post v1 l``, EVAL_TAC >> REWRITE_TAC []);
 
-  val loop_ht = REWRITE_RULE [Once abs_ev_intro] bir_ieo_sec_iseven_loop_comp_ht;
-  val loop_map_ht_ = bir_map_triple_from_bir_triple loop_ht;
+  val loop_map_ht_ = REWRITE_RULE [Once abs_ev_intro] bir_ieo_sec_iseven_loop_comp_ht;
 
   val new_ending_label_set = ``{BL_Address (Imm32 0x204w); BL_Address (Imm32 0x200w)}``;
   val ht = REWRITE_RULE [Once abs_ev_intro] bir_ieo_sec_iseven_exit_comp_ht;
 
-  val loop_exit_simp_ht = bir_remove_labels_from_ending_set ht new_ending_label_set;
+  val loop_exit_simp_ht = bir_remove_labels_from_ending_set not_empty_set ht new_ending_label_set;
 
-  val loop_exit_simp1_ht = (REWRITE_RULE [Once abs_ev_intro2] loop_exit_simp_ht);
+  val loop_exit_simp1_ht =
+    REWRITE_RULE [Once abs_ev_intro2] loop_exit_simp_ht;
   val loop_exit_simp2_ht =
-    use_post_weak_rule loop_exit_simp1_ht ``BL_Address (Imm32 0x000w)`` contract_ev_3_imp_taut_thm;
+    use_post_weak_rule_map loop_exit_simp1_ht ``BL_Address (Imm32 0x000w)`` contract_ev_3_imp_taut_thm;
   val loop_exit_simp3_ht = loop_exit_simp2_ht;
 
 
@@ -127,17 +132,16 @@ val bir_ieo_sec_isodd_exit_comp_ht =
   val abs_od_intro = prove(``bir_ieo_sec_isodd_loop_post v1 v = \l. bir_ieo_sec_isodd_loop_post v1 v l``, EVAL_TAC >> REWRITE_TAC []);
   val abs_od_intro2 = prove(``bir_ieo_sec_isodd_exit_post v1 = \l. bir_ieo_sec_isodd_exit_post v1 l``, EVAL_TAC >> REWRITE_TAC []);
 
-  val loop_ht = REWRITE_RULE [Once abs_od_intro] bir_ieo_sec_isodd_loop_comp_ht;
-  val loop_map_ht_ = bir_map_triple_from_bir_triple loop_ht;
+  val loop_map_ht_ = REWRITE_RULE [Once abs_od_intro] bir_ieo_sec_isodd_loop_comp_ht;
 
   val new_ending_label_set = ``{BL_Address (Imm32 0x204w); BL_Address (Imm32 0x200w)}``;
   val ht = REWRITE_RULE [Once abs_od_intro] bir_ieo_sec_isodd_exit_comp_ht;
 
-  val loop_exit_simp_ht = bir_remove_labels_from_ending_set ht new_ending_label_set;
+  val loop_exit_simp_ht = bir_remove_labels_from_ending_set not_empty_set ht new_ending_label_set;
 
-  val loop_exit_simp1_ht = (REWRITE_RULE [Once abs_od_intro2] loop_exit_simp_ht);
+  val loop_exit_simp1_ht = REWRITE_RULE [Once abs_od_intro2] loop_exit_simp_ht;
   val loop_exit_simp2_ht =
-    use_post_weak_rule loop_exit_simp1_ht ``BL_Address (Imm32 0x000w)`` contract_od_3_imp_taut_thm;
+    use_post_weak_rule_map loop_exit_simp1_ht ``BL_Address (Imm32 0x000w)`` contract_od_3_imp_taut_thm;
   val loop_exit_simp3_ht = loop_exit_simp2_ht;
 
 
@@ -160,8 +164,7 @@ val bir_ieo_sec_isodd_exit_comp_ht =
   val loop_condition = ``bir_ieo_condition``;
   val loop_variant   = ``bir_ieo_variant``;
 
-  val def_list = [bprog_is_even_odd_def,
-                  bir_ieo_condition_def,
+  val def_list = [bir_ieo_condition_def,
 		  bir_ieo_variant_def,
                   bir_ieo_invariant_def,
                   bir_ieo_sec_iseven_loop_post_def,
@@ -169,8 +172,8 @@ val bir_ieo_sec_isodd_exit_comp_ht =
                   bir_ieo_sec_iseven_exit_pre_def];
 
 val loop_and_exit_ev_ht =
-  bir_compose_loop_unsigned (simp_in_set_repr_tac, inter_set_repr_ss, union_set_repr_ss)
-    loop_map_ht loop_exit_ht loop_invariant loop_condition loop_variant def_list;
+  bir_compose_map_loop_unsigned (simp_in_set_repr_tac, inter_set_repr_ss, union_set_repr_ss)
+    loop_map_ht loop_exit_ht loop_invariant loop_condition loop_variant bprog_is_even_odd_def def_list;
 
 
 (* For debugging: *)
@@ -180,13 +183,12 @@ val loop_and_exit_ev_ht =
                                    simp_delete_set_repr_rule, simp_insert_set_repr_rule)
            (REWRITE_RULE [GSYM abs_od_intro, bir_ieo_sec_isodd_loop_post_def] loop_od_map_ht_2));
 
-  val loop_exit_ht   = loop_od_exit_ht;
+  val loop_exit_map_ht   = loop_od_exit_ht;
   val loop_invariant = ``bir_ieo_invariant v1``;
   val loop_condition = ``bir_ieo_condition``;
   val loop_variant   = ``bir_ieo_variant``;
 
-  val def_list = [bprog_is_even_odd_def,
-                  bir_ieo_condition_def,
+  val def_list = [bir_ieo_condition_def,
 		  bir_ieo_variant_def,
                   bir_ieo_invariant_def,
                   bir_ieo_sec_isodd_loop_post_def,
@@ -194,26 +196,24 @@ val loop_and_exit_ev_ht =
                   bir_ieo_sec_isodd_exit_pre_def];
 
 val loop_and_exit_od_ht =
-  bir_compose_loop_unsigned (simp_in_set_repr_tac, inter_set_repr_ss, union_set_repr_ss)
-    loop_map_ht loop_exit_ht loop_invariant loop_condition loop_variant def_list;
+  bir_compose_map_loop_unsigned (simp_in_set_repr_tac, inter_set_repr_ss, union_set_repr_ss)
+    loop_map_ht loop_exit_map_ht loop_invariant loop_condition loop_variant bprog_is_even_odd_def def_list;
 
 
 (* =============================================================== *)
 
 val is_even_1_ht =
-  REWRITE_RULE [contract_ev_4_imp_taut_thm] (use_pre_str_rule loop_and_exit_ev_ht contract_ev_4_imp_taut_thm);
+  REWRITE_RULE [contract_ev_4_imp_taut_thm] (use_pre_str_rule_map loop_and_exit_ev_ht contract_ev_4_imp_taut_thm);
 
-val thm1 = ((Q.SPECL [`bprog_is_even_odd`,
-          `BL_Address (Imm32 0w)`, `{BL_Address (Imm32 516w); BL_Address (Imm32 512w)}`,
-          `bir_ieo_pre v1`, `bir_ieo_pre v1`,
+val thm1 = ((Q.SPECL [`bprog_is_even_odd`, `bir_exp_true`,
+          `BL_Address (Imm32 0w)`, `{BL_Address (Imm32 516w); BL_Address (Imm32 512w)}`, `{}`, `bir_ieo_pre v1`,
           `\l.
             if l = BL_Address (Imm32 0w) then bir_ieo_invariant v1
             else bir_ieo_sec_iseven_exit_post v1 l`,
           `bir_ieo_sec_iseven_exit_post v1`])
-	      bir_wm_instTheory.bir_consequence_rule_thm);
-val thm2 = (fn x => REWRITE_RULE [(((REWRITE_CONV []) o fst o dest_imp o concl) x)] x) thm1;
-val thm3 = REWRITE_RULE [is_even_1_ht] thm2;
-val is_even_2_ht = REWRITE_RULE [prove(``^((fst o dest_imp o concl) thm3)``,
+	      bir_wm_instTheory.bir_map_weakening_rule_thm);
+val thm2 = REWRITE_RULE [is_even_1_ht] thm1;
+val is_even_2_ht = REWRITE_RULE [prove(``^((fst o dest_imp o concl) thm2)``,
   SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) [] >>
   REPEAT STRIP_TAC >> (
     REV_FULL_SIMP_TAC (std_ss++HolBACoreSimps.bir_TYPES_ss++wordsLib.WORD_ss)
@@ -221,7 +221,7 @@ val is_even_2_ht = REWRITE_RULE [prove(``^((fst o dest_imp o concl) thm3)``,
         bir_ieo_sec_iseven_loop_post_def,
         bir_exec_to_labels_triple_postcond_def]
   )
-  )] thm3;
+  )] thm2;
 
 
 val bir_ieo_is_even_ht = save_thm("bir_ieo_is_even_ht",
@@ -230,19 +230,18 @@ val bir_ieo_is_even_ht = save_thm("bir_ieo_is_even_ht",
 
 
 val is_odd_1_ht =
-  REWRITE_RULE [contract_od_4_imp_taut_thm] (use_pre_str_rule loop_and_exit_od_ht contract_od_4_imp_taut_thm);
+  REWRITE_RULE [contract_od_4_imp_taut_thm] (use_pre_str_rule_map loop_and_exit_od_ht contract_od_4_imp_taut_thm);
 
-val thm1 = ((Q.SPECL [`bprog_is_even_odd`,
-          `BL_Address (Imm32 0x100w)`, `{BL_Address (Imm32 516w); BL_Address (Imm32 512w)}`,
-          `bir_ieo_pre v1`, `bir_ieo_pre v1`,
+val thm1 = ((Q.SPECL [`bprog_is_even_odd`, `bir_exp_true`,
+          `BL_Address (Imm32 0x100w)`, `{BL_Address (Imm32 516w); BL_Address (Imm32 512w)}`, `{}`,
+          `bir_ieo_pre v1`,
           `\l.
             if l = BL_Address (Imm32 0w) then bir_ieo_invariant v1
             else bir_ieo_sec_isodd_exit_post v1 l`,
           `bir_ieo_sec_isodd_exit_post v1`])
-	      bir_wm_instTheory.bir_consequence_rule_thm);
-val thm2 = (fn x => REWRITE_RULE [(((REWRITE_CONV []) o fst o dest_imp o concl) x)] x) thm1;
-val thm3 = REWRITE_RULE [is_odd_1_ht] thm2;
-val is_odd_2_ht = REWRITE_RULE [prove(``^((fst o dest_imp o concl) thm3)``,
+	      bir_wm_instTheory.bir_map_weakening_rule_thm);
+val thm2 = REWRITE_RULE [is_odd_1_ht] thm1;
+val is_odd_2_ht = REWRITE_RULE [prove(``^((fst o dest_imp o concl) thm2)``,
   SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) [] >>
   REPEAT STRIP_TAC >> (
     REV_FULL_SIMP_TAC (std_ss++HolBACoreSimps.bir_TYPES_ss++wordsLib.WORD_ss)
@@ -250,14 +249,12 @@ val is_odd_2_ht = REWRITE_RULE [prove(``^((fst o dest_imp o concl) thm3)``,
         bir_ieo_sec_isodd_loop_post_def,
         bir_exec_to_labels_triple_postcond_def]
   )
-  )] thm3;
+  )] thm2;
 
 
 val bir_ieo_is_odd_ht = save_thm("bir_ieo_is_odd_ht",
   is_odd_2_ht
 );
-
-
 
 
 val _ = export_theory();

--- a/examples/tutorial/7-composition/tutorialExtra2_compositionScript.sml
+++ b/examples/tutorial/7-composition/tutorialExtra2_compositionScript.sml
@@ -1,12 +1,6 @@
 open HolKernel Parse boolLib bossLib;
 open bslSyntax;
 open bir_wm_instTheory;
-open bin_hoare_logicTheory;
-open bir_valuesTheory;
-open bir_bool_expTheory;
-open bir_auxiliaryTheory;
-open bir_exp_equivTheory;
-open bir_programTheory;
 
 open tutorial_compositionLib;
 open tutorial_wpSupportLib;

--- a/examples/tutorial/7-composition/tutorialExtra_compositionScript.sml
+++ b/examples/tutorial/7-composition/tutorialExtra_compositionScript.sml
@@ -36,16 +36,16 @@ val simp_in_set_tac =
   SIMP_TAC (std_ss++HolBACoreSimps.holBACore_ss++wordsLib.WORD_ss++pred_setLib.PRED_SET_ss) []
 
 (* DEBUG *)
-val (get_labels_from_set_repr, el_in_set_repr,
+val (not_empty_set_repr, get_labels_from_set_repr, el_in_set_repr,
      mk_set_repr, simp_delete_set_repr_rule,
-     simp_insert_set_repr_rule, simp_in_sing_set_repr_rule, simp_inter_set_repr_rule, simp_in_set_repr_tac, inter_set_repr_ss, union_set_repr_ss) = (ending_set_to_sml_list, el_in_set, mk_set, simp_delete_set_rule,
+     simp_insert_set_repr_rule, simp_in_sing_set_repr_rule, simp_inter_set_repr_rule, simp_in_set_repr_tac, inter_set_repr_ss, union_set_repr_ss) = (not_empty_set, ending_set_to_sml_list, el_in_set, mk_set, simp_delete_set_rule,
      simp_insert_set_rule, simp_in_sing_set_rule, simp_inter_set_rule, simp_in_set_tac, bir_inter_var_set_ss, bir_union_var_set_ss);
 (************************************)
 
 
 val bir_att_sec_add_1_comp_ct =
-  use_pre_str_rule
-    (HO_MATCH_MP bir_label_ht_impl_weak_ht bir_att_sec_add_1_ht)
+  use_pre_str_rule_map
+    (HO_MATCH_MP (HO_MATCH_MP bir_label_ht_impl_weak_ht (not_empty_set (get_contract_ls bir_att_sec_add_1_ht))) bir_att_sec_add_1_ht)
     contract_1_imp_taut_thm;
 
 val bir_att_sec_call_1_ct = bir_att_sec_call_1_ht;
@@ -205,15 +205,15 @@ METIS_TAC [pred_setTheory.NOT_EQUAL_SETS]
       map_ht1
     end;
 
-  val ht1 = bir_att_sec_add_1_comp_ct;
-  val map_ht1_ = bir_map_triple_from_bir_triple ht1;
+  val map_ht1_ = bir_att_sec_add_1_comp_ct;
 
   val elabels = ``(BL_Address (Imm32 v3)) INSERT v4s``;
   val map_ht1 = populate_blacklist_set_hack elabels map_ht1_;
 
-  val ht2 = 
-    (HO_MATCH_MP bir_label_ht_impl_weak_ht ((UNDISCH o UNDISCH o (Q.SPECL [`v1`, `v2`, `v3`, `v4s`])) bir_att_sec_add_2_ht));
-  val map_ht2_ = bir_map_triple_from_bir_triple ht2;
+  val ht2_undisch = ((UNDISCH o UNDISCH o (Q.SPECL [`v1`, `v2`, `v3`, `v4s`])) bir_att_sec_add_2_ht);
+  val map_ht2_ = 
+    HO_MATCH_MP
+      (HO_MATCH_MP bir_label_ht_impl_weak_ht (not_empty_set (get_contract_ls ht2_undisch))) ht2_undisch;
 
   val elabels = ``v4s:bir_label_t->bool``;
   val map_ht2 = populate_blacklist_set_hack elabels map_ht2_;

--- a/examples/tutorial/7-composition/tutorialExtra_compositionScript.sml
+++ b/examples/tutorial/7-composition/tutorialExtra_compositionScript.sml
@@ -7,43 +7,17 @@ open tutorialExtra_wpTheory tutorialExtra_smtTheory;
 
 open tutorial_wpSupportLib tutorial_compositionLib;
 
-val _ = new_theory "tutorialExtra_composition";
-
-(************************************)
-(* TODO: Where to place the below? *)
 open HolBACoreSimps;
 
-fun el_in_set elem set =
-  EQT_ELIM (SIMP_CONV (std_ss++pred_setLib.PRED_SET_ss) [] (pred_setSyntax.mk_in (elem, set)));
-
-val mk_set = pred_setSyntax.mk_set;
-
-val simp_delete_set_rule =
-  SIMP_RULE (std_ss++pred_setLib.PRED_SET_ss++HolBACoreSimps.holBACore_ss++wordsLib.WORD_ss)
-    [pred_setTheory.DELETE_DEF]
-
-val simp_insert_set_rule =
-  SIMP_RULE (std_ss++pred_setLib.PRED_SET_ss++HolBACoreSimps.holBACore_ss++wordsLib.WORD_ss)
-    [(* ??? *)]
-
-val simp_in_sing_set_rule =
-  SIMP_RULE std_ss [pred_setTheory.IN_SING]
-
-fun simp_inter_set_rule ht =
-  ONCE_REWRITE_RULE [EVAL (get_bir_map_triple_blist ht)] ht
-
-val simp_in_set_tac =
-  SIMP_TAC (std_ss++HolBACoreSimps.holBACore_ss++wordsLib.WORD_ss++pred_setLib.PRED_SET_ss) []
-
-(* DEBUG *)
-val (not_empty_set_repr, get_labels_from_set_repr, el_in_set_repr,
-     mk_set_repr, simp_delete_set_repr_rule,
-     simp_insert_set_repr_rule, simp_in_sing_set_repr_rule, simp_inter_set_repr_rule, simp_in_set_repr_tac, inter_set_repr_ss, union_set_repr_ss) = (not_empty_set, ending_set_to_sml_list, el_in_set, mk_set, simp_delete_set_rule,
-     simp_insert_set_rule, simp_in_sing_set_rule, simp_inter_set_rule, simp_in_set_tac, bir_inter_var_set_ss, bir_union_var_set_ss);
-(************************************)
-
+val _ = new_theory "tutorialExtra_composition";
 
 val bir_att_sec_add_1_comp_ct =
+(* TODO: Why not use
+  label_ct_to_map_ct_predset
+    bir_att_sec_add_1_ht
+    contract_1_imp_taut_thm;
+  ?
+*)
   use_pre_str_rule_map
     (HO_MATCH_MP (HO_MATCH_MP bir_label_ht_impl_weak_ht (not_empty_set (get_contract_ls bir_att_sec_add_1_ht))) bir_att_sec_add_1_ht)
     contract_1_imp_taut_thm;
@@ -123,11 +97,6 @@ val bir_att_sec_add_ct =
 
   val assumes = ASSUME ht_assmpt;
 
-val notin_insert_thm = prove(``(A NOTIN (B INSERT C)) ==> (A NOTIN C)``, 
-  Cases_on `A = B` >> (
-    SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) []
-  )
-);
 val notin_insert_neq_thm = prove(``!set el. el NOTIN set ==> (set <> el INSERT set)``,
 
 REPEAT STRIP_TAC >>
@@ -205,30 +174,33 @@ METIS_TAC [pred_setTheory.NOT_EQUAL_SETS]
       map_ht1
     end;
 
-  val map_ht1_ = bir_att_sec_add_1_comp_ct;
-
+(* For debugging:
   val elabels = ``(BL_Address (Imm32 v3)) INSERT v4s``;
-  val map_ht1 = populate_blacklist_set_hack elabels map_ht1_;
+  val map_ht = bir_att_sec_add_1_comp_ct;
+*)
+  val map_ht1 = populate_blacklist_set_hack ``(BL_Address (Imm32 v3)) INSERT v4s`` bir_att_sec_add_1_comp_ct;
 
   val ht2_undisch = ((UNDISCH o UNDISCH o (Q.SPECL [`v1`, `v2`, `v3`, `v4s`])) bir_att_sec_add_2_ht);
   val map_ht2_ = 
     HO_MATCH_MP
       (HO_MATCH_MP bir_label_ht_impl_weak_ht (not_empty_set (get_contract_ls ht2_undisch))) ht2_undisch;
 
+
+(* For debugging:
   val elabels = ``v4s:bir_label_t->bool``;
-  val map_ht2 = populate_blacklist_set_hack elabels map_ht2_;
+  val map_ht = map_ht2_;
+*)
+  val map_ht2 = populate_blacklist_set_hack ``v4s:bir_label_t->bool`` map_ht2_;
 
 
-
+(* For debugging:
   val def_list = [bprog_add_times_two_def, bir_att_sec_add_2_post_def,
 		  bir_att_sec_add_1_post_def];
 
   val assmpt = ht_assmpt;
-  val bir_att_sec_add_ct = bir_compose_seq_assmpt (get_labels_from_set_repr, simp_in_sing_set_repr_rule,
-                                           simp_inter_set_repr_rule)
-                           map_ht1 map_ht2 def_list assmpt;
-
-
+*)
+  val bir_att_sec_add_ct =
+    bir_compose_seq_assmpt_predset map_ht1 map_ht2 [bprog_add_times_two_def, bir_att_sec_add_2_post_def, bir_att_sec_add_1_post_def] ht_assmpt;
 
 
 (* ====================================== *)

--- a/examples/tutorial/7-composition/tutorial_backliftingScript.sml
+++ b/examples/tutorial/7-composition/tutorial_backliftingScript.sml
@@ -25,6 +25,6 @@ val _ = new_theory "tutorial_backlifting";
   val bir_is_lifted_prog_thm = examplesBinaryTheory.bir_add_reg_arm8_lift_THM;
 *)
 
-val arm8_add_reg_contract = get_arm8_contract_sing bir_add_reg_ct ``bir_add_reg_progbin`` ``arm8_add_reg_pre`` ``arm8_add_reg_post`` bir_add_reg_prog_def [bir_add_reg_contract_1_pre_def, bir_add_reg_pre_def] bir_add_reg_contract_1_pre_def arm8_pre_imp_bir_pre_thm [bir_add_reg_contract_4_post_def] arm8_post_imp_bir_post_thm examplesBinaryTheory.bir_add_reg_arm8_lift_THM;
+val arm_add_reg_contract_thm = save_thm("arm_add_reg_contract_thm", get_arm8_contract_sing bir_add_reg_ct ``bir_add_reg_progbin`` ``arm8_add_reg_pre`` ``arm8_add_reg_post`` bir_add_reg_prog_def [bir_add_reg_contract_1_pre_def, bir_add_reg_pre_def] bir_add_reg_contract_1_pre_def arm8_pre_imp_bir_pre_thm [bir_add_reg_contract_4_post_def] arm8_post_imp_bir_post_thm examplesBinaryTheory.bir_add_reg_arm8_lift_THM);
 
 val _ = export_theory();

--- a/examples/tutorial/7-composition/tutorial_backliftingScript.sml
+++ b/examples/tutorial/7-composition/tutorial_backliftingScript.sml
@@ -1,11 +1,9 @@
 open HolKernel Parse boolLib bossLib;
 
 open examplesBinaryTheory tutorial_bir_to_armTheory
-     tutorial_bir_to_armSupportTheory tutorial_compositionTheory;
-open bir_wm_instTheory;
+     tutorial_compositionTheory;
 
-open tutorial_compositionLib;
-open bir_auxiliaryLib;
+open tutorial_backliftingLib;
 
 val _ = new_theory "tutorial_backlifting";
 
@@ -13,75 +11,20 @@ val _ = new_theory "tutorial_backlifting";
 (*                    BACKLIFTING                    *)
 (*****************************************************)
 
-(* Specialise lift_contract_thm in order to obtain the antecedents enabling translation from BIR to
- * ARM HT. *)
-val add_lift_thm =
-  ISPECL [get_bir_map_triple_prog bir_add_reg_ct,
-          ``bir_add_reg_progbin``,
-          ``28w:word64``,
-          ``{72w:word64}``,
-          (((el 2) o snd o strip_comb o concl) examplesBinaryTheory.bir_add_reg_arm8_lift_THM),
-          ``arm8_add_reg_pre``, ``arm8_add_reg_post``,
-          get_bir_map_triple_pre bir_add_reg_ct,
-          get_bir_map_triple_post bir_add_reg_ct] tutorial_bir_to_armSupportTheory.lift_contract_thm;
+(* For debugging:
+  val bir_ct = bir_add_reg_ct;
+  val prog_bin = ``bir_add_reg_progbin``;
+  val arm8_pre = ``arm8_add_reg_pre``;
+  val arm8_post = ``arm8_add_reg_post``;
+  val bir_prog_def = bir_add_reg_prog_def;
+  val bir_pre_defs = [bir_add_reg_contract_1_pre_def, bir_add_reg_pre_def];
+  val bir_pre1_def = bir_add_reg_contract_1_pre_def;
+  val arm8_pre_imp_bir_pre_thm = arm8_pre_imp_bir_pre_thm;
+  val bir_post_defs = [bir_add_reg_contract_4_post_def];
+  val arm8_post_imp_bir_post_thm = arm8_post_imp_bir_post_thm;
+  val bir_is_lifted_prog_thm = examplesBinaryTheory.bir_add_reg_arm8_lift_THM;
+*)
 
-(* Prove the ARM triple by supplying the antecedents of lift_contract_thm *)
-val arm_add_reg_contract_thm = store_thm("arm_add_reg_contract_thm",
-  ``arm8_triple bir_add_reg_progbin 28w {72w} arm8_add_reg_pre
-            arm8_add_reg_post``,
-
-irule add_lift_thm >>
-REPEAT STRIP_TAC >| [
-  (* 1. Prove that the union of variables in the program and precondition are a well-founded variable
-   *    set *)
-  (* TODO: This subset computation is slooow... *)
-  FULL_SIMP_TAC (std_ss++HolBACoreSimps.holBACore_ss++HolBASimps.VARS_OF_PROG_ss
-                       ++pred_setLib.PRED_SET_ss)
-    [bir_add_reg_prog_def, bir_add_reg_contract_1_pre_def, bir_add_reg_pre_def, arm8_wf_varset_def,
-     arm8_vars_def],
-
-  (* 2. Starting address exists in program *)
-  FULL_SIMP_TAC std_ss
-    [EVAL ``MEM (^(get_bir_map_triple_start_label bir_add_reg_ct))
-		(bir_labels_of_program bir_add_reg_prog)``],
-
-  (* 3. Provide translation of the ARM8 precondition to the BIR precondition *)
-  FULL_SIMP_TAC std_ss [bir_add_reg_contract_1_pre_def, arm8_pre_imp_bir_pre_thm],
-
-  (* 4. Provide translation of the ARM8 postcondition to BIR postcondition *)
-  FULL_SIMP_TAC std_ss [bir_add_reg_contract_4_post_def] >>
-  ASSUME_TAC (Q.SPEC `{BL_Address (Imm64 ml') | ml' IN {72w}}` arm8_post_imp_bir_post_thm) >>
-  FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) [bir_post_bir_to_arm8_def] >>
-  FULL_SIMP_TAC std_ss [],
-
-  (* 5. Provide the lifter theorem of the program *)
-  FULL_SIMP_TAC std_ss [examplesBinaryTheory.bir_add_reg_arm8_lift_THM],
-
-  (* 6. Provide the BIR triple in the requisite format *)
-  ASSUME_TAC (CONJUNCT2 (SIMP_RULE std_ss [bir_triple_equiv_map_triple] bir_add_reg_ct)) >>
-  FULL_SIMP_TAC std_ss [pred_setTheory.UNION_EMPTY] >>
-  FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) [] >>
-
-  (*      Precondition: *)
-  FULL_SIMP_TAC std_ss [bir_triple_def, bin_hoare_logicTheory.weak_triple_def,
-			bir_exec_to_labels_triple_precond_def,
-			bir_exec_to_labels_triple_postcond_def, bir_exp_equivTheory.bir_and_op2,
-			bir_bool_expTheory.bir_is_bool_exp_env_REWRS] >>
-  REPEAT STRIP_TAC >>
-  QSPECL_X_ASSUM ``!s. _`` [`s`] >>
-  REV_FULL_SIMP_TAC std_ss [] >>
-  Q.EXISTS_TAC `s'` >>
-  FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) [] >>
-  Cases_on `s'.bst_pc.bpc_label = BL_Address (Imm64 72w)` >> (
-    FULL_SIMP_TAC std_ss [bir_exp_equivTheory.bir_and_op2,
-                          bir_bool_expTheory.bir_is_bool_exp_env_REWRS]
-  ) >>
-  FULL_SIMP_TAC (std_ss++bin_hoare_logicSimps.bir_wm_SS)
-    [bir_etl_wm_def, bir_weak_trs_def,
-     bir_programTheory.bir_exec_to_labels_def,
-     bir_programTheory.bir_exec_to_labels_n_def] >>
-  FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) []
-]
-);
+val arm8_add_reg_contract = get_arm8_contract_sing bir_add_reg_ct ``bir_add_reg_progbin`` ``arm8_add_reg_pre`` ``arm8_add_reg_post`` bir_add_reg_prog_def [bir_add_reg_contract_1_pre_def, bir_add_reg_pre_def] bir_add_reg_contract_1_pre_def arm8_pre_imp_bir_pre_thm [bir_add_reg_contract_4_post_def] arm8_post_imp_bir_post_thm examplesBinaryTheory.bir_add_reg_arm8_lift_THM;
 
 val _ = export_theory();

--- a/examples/tutorial/7-composition/tutorial_compositionScript.sml
+++ b/examples/tutorial/7-composition/tutorial_compositionScript.sml
@@ -10,9 +10,6 @@ open bslSyntax;
 
 val _ = new_theory "tutorial_composition";
 
-(* Program stays the same *)
-val prog_def = bir_add_reg_prog_def;
-
 (****************************************************************)
 (* Step 0: *)
 (* Translate contracts from bir_exec_to_labels_triple to bir_map_triple,
@@ -39,56 +36,64 @@ val bir_add_reg_loop_exit_comp_ct =
 (* Step 1: *)
 (* Compose 64 -> 32 and 32 -> 64 sequentially (using bir_map_std_seq_comp_thm) *)
 
-(* For debugging: *)
-  val ct1 = bir_add_reg_loop_continue_variant_comp_ct; (* 64 -> 32 *)
-  val ct2 = bir_add_reg_loop_variant_comp_ct; (* 32 -> 64 *)
+(* For debugging:
+  val map_ht1 = bir_add_reg_loop_continue_variant_comp_ct; (* 64 -> 32 *)
+  val map_ht2 = bir_add_reg_loop_variant_comp_ct; (* 32 -> 64 *)
   (* The definitions of any shorthands in postcondition of contract 1
    * and precondition of contract 2 *)
   val def_list = [bir_add_reg_contract_3_post_variant_def,
 		  bir_add_reg_contract_2_pre_variant_def];
+*)
 
 val loop_map_ct =
-  bir_compose_seq_predset ct1 ct2 def_list;
+  bir_compose_seq_predset bir_add_reg_loop_continue_variant_comp_ct bir_add_reg_loop_variant_comp_ct [bir_add_reg_contract_3_post_variant_def, bir_add_reg_contract_2_pre_variant_def];
 
 (****************************************************************)
 (* Step 2: *)
 (* Ditch the loop re-entry label from the loop exit contract blacklist *)
 
-(* For debugging: *)
+(* For debugging:
   val to_remove_from_blist = ``{BL_Address (Imm64 32w)}``;
   val map_ct = bir_add_reg_loop_exit_comp_ct;
+*)
 
 val loop_exit_simp_ct =
-  bir_remove_labels_from_blist_predset map_ct to_remove_from_blist;
+  bir_remove_labels_from_blist_predset bir_add_reg_loop_exit_comp_ct ``{BL_Address (Imm64 32w)}``;
 
 (****************************************************************)
 (* Step 3: *)
 (* Compose loop from loop_map_ht and bir_add_reg_loop_exit_comp_ht (using bir_while_rule_thm) *)
 
-(* For debugging: *)
+(* For debugging:
   val loop_map_ct = loop_map_ct;
   val loop_exit_map_ct = loop_exit_simp_ct;
   val loop_invariant = ``bir_add_reg_I``;
   val loop_condition = ``bir_add_reg_loop_condition``;
   val loop_variant = bden (bvar "R2" ``(BType_Imm Bit64)``);
+  val prog_def = ;
   (* The definitions of the loop condition and both preconditions *)
   val def_list = [bir_add_reg_loop_condition_def,
 		  bir_add_reg_contract_3_pre_variant_def, bir_add_reg_contract_2_post_variant_def,
                   bir_add_reg_contract_4_pre_def];
+*)
 
 val loop_and_exit_ct =
   bir_compose_map_loop_predset
-    loop_map_ct loop_exit_map_ct loop_invariant loop_condition loop_variant prog_def def_list;
+    loop_map_ct loop_exit_simp_ct ``bir_add_reg_I`` ``bir_add_reg_loop_condition`` (bden (bvar "R2" ``(BType_Imm Bit64)``)) bir_add_reg_prog_def [bir_add_reg_loop_condition_def,
+		  bir_add_reg_contract_3_pre_variant_def, bir_add_reg_contract_2_post_variant_def,
+                  bir_add_reg_contract_4_pre_def];
 
 (****************************************************************)
 (* Step 4: *)
 (* Compose loop intro with loop (using bir_map_std_seq_comp_thm) *)
-  val ct1 = bir_add_reg_entry_comp_ct
-  val ct2 = loop_and_exit_ct
+(* For debugging:
+  val map_ht1 = bir_add_reg_entry_comp_ct
+  val map_ht2 = loop_and_exit_ct
   val def_list = [bir_add_reg_contract_1_post_def, bir_add_reg_I_def];
+*)
 
 val bir_add_reg_ct =
-  bir_compose_seq_predset ct1 ct2 def_list;
+  bir_compose_seq_predset bir_add_reg_entry_comp_ct loop_and_exit_ct [bir_add_reg_contract_1_post_def, bir_add_reg_I_def];
 
 val _ = save_thm("bir_add_reg_ct", bir_add_reg_ct);
 

--- a/examples/tutorial/support/tutorial_backliftingLib.sml
+++ b/examples/tutorial/support/tutorial_backliftingLib.sml
@@ -1,0 +1,89 @@
+structure tutorial_backliftingLib =
+struct
+(* For debugging add_reg example:
+  val bir_ct = bir_add_reg_ct;
+  val prog_bin = ``bir_add_reg_progbin``;
+  val arm8_pre = ``arm8_add_reg_pre``;
+  val arm8_post = ``arm8_add_reg_post``;
+  val bir_prog_def = bir_add_reg_prog_def;
+  val bir_pre_defs = [bir_add_reg_contract_1_pre_def, bir_add_reg_pre_def];
+  val bir_pre1_def = bir_add_reg_contract_1_pre_def;
+  val arm8_pre_imp_bir_pre_thm = arm8_pre_imp_bir_pre_thm;
+  val bir_post_defs = [bir_add_reg_contract_4_post_def];
+  val arm8_post_imp_bir_post_thm = arm8_post_imp_bir_post_thm;
+  val bir_is_lifted_prog_thm = examplesBinaryTheory.bir_add_reg_arm8_lift_THM;
+*)
+
+  local
+    open tutorial_bir_to_armSupportTheory;
+    open tutorial_compositionLib;
+  in
+
+fun get_arm8_contract_sing bir_ct prog_bin arm8_pre arm8_post bir_prog_def bir_pre_defs bir_pre1_def arm8_pre_imp_bir_pre_thm bir_post_defs arm8_post_imp_bir_post_thm bir_is_lifted_prog_thm = 
+  let
+    val word_from_address = bir_immSyntax.dest_Imm64 o bir_programSyntax.dest_BL_Address
+
+    val bir_prog = get_bir_map_triple_prog bir_ct
+    val l =
+      word_from_address (get_bir_map_triple_start_label bir_ct)
+    val ls = pred_setSyntax.mk_set (map word_from_address (pred_setSyntax.strip_set (get_bir_map_triple_wlist bir_ct)))
+    (* TODO: Note that the proof below assumes ls is a singleton *)
+    val ls_sing = el 1 (pred_setSyntax.strip_set ls)
+
+    val add_lift_thm =
+      ISPECL [bir_prog,
+	      prog_bin,
+	      l,
+	      ls,
+	      (((el 2) o snd o strip_comb o concl) bir_is_lifted_prog_thm),
+	      arm8_pre, arm8_post,
+	      get_bir_map_triple_pre bir_ct,
+	      get_bir_map_triple_post bir_ct] tutorial_bir_to_armSupportTheory.lift_contract_thm;
+
+    (* Prove the ARM triple by supplying the antecedents of lift_contract_thm *)
+    val arm8_contract_thm = prove(
+      ``arm8_triple ^prog_bin ^l ^ls ^arm8_pre
+		^arm8_post``,
+
+    irule add_lift_thm >>
+    REPEAT STRIP_TAC >| [
+      (* 1. Prove that the union of variables in the program and precondition are a well-founded variable
+       *    set *)
+      (* TODO: This subset computation is slooow... *)
+      FULL_SIMP_TAC (std_ss++HolBACoreSimps.holBACore_ss++HolBASimps.VARS_OF_PROG_ss
+			   ++pred_setLib.PRED_SET_ss)
+	([bir_prog_def, arm8_wf_varset_def, arm8_vars_def]@bir_pre_defs),
+
+      (* 2. Starting address exists in program *)
+      FULL_SIMP_TAC std_ss
+	[EVAL ``MEM (^(get_bir_map_triple_start_label bir_ct))
+		    (bir_labels_of_program ^(bir_prog))``],
+
+      (* 3. Provide translation of the ARM8 precondition to the BIR precondition *)
+      FULL_SIMP_TAC std_ss [bir_pre1_def, arm8_pre_imp_bir_pre_thm],
+
+      (* 4. Provide translation of the ARM8 postcondition to BIR postcondition *)
+      FULL_SIMP_TAC std_ss bir_post_defs >>
+      ASSUME_TAC (Q.SPEC `{BL_Address (Imm64 ml') | ml' IN ^ls}` arm8_post_imp_bir_post_thm) >>
+      FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) [bir_post_bir_to_arm8_def] >>
+      FULL_SIMP_TAC std_ss [],
+
+      (* 5. Provide the lifter theorem of the program *)
+      FULL_SIMP_TAC std_ss [bir_is_lifted_prog_thm],
+
+      (* 6. Provide the BIR triple in the requisite format *)
+      ASSUME_TAC bir_ct >>
+      `{BL_Address (Imm64 ml') | ml' IN {72w}} = {BL_Address (Imm64 72w)}` suffices_by (
+              FULL_SIMP_TAC std_ss []
+      ) >>
+      FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) [pred_setTheory.EXTENSION]
+    ]
+    );
+
+  in
+    arm8_contract_thm
+  end
+;
+
+  end
+end

--- a/examples/tutorial/support/tutorial_bir_to_armSupportScript.sml
+++ b/examples/tutorial/support/tutorial_bir_to_armSupportScript.sml
@@ -3,6 +3,7 @@ open HolKernel Parse boolLib bossLib;
 open bir_programTheory;
 open bir_wm_instTheory;
 open bin_hoare_logicTheory;
+open bin_simp_hoare_logicTheory;
 open bin_hoare_logicSimps;
 open bir_program_multistep_propsTheory;
 open bir_auxiliaryTheory;
@@ -474,8 +475,8 @@ FULL_SIMP_TAC (std_ss++holBACore_ss++bir_wm_SS)
 
 val bir_get_ht_conseq_from_m_ante = prove(
   ``!bs p bpre bpost mpre ms ml mls.
-    bir_triple p (BL_Address (Imm64 ml))
-      {BL_Address (Imm64 ml') | ml' IN mls} bpre bpost ==>
+    bir_map_triple p bir_exp_true (BL_Address (Imm64 ml))
+      {BL_Address (Imm64 ml') | ml' IN mls} {} bpre bpost ==>
     bir_pre_arm8_to_bir mpre bpre ==>
     mpre ms ==>
     bmr_rel arm8_bmr bs ms ==>
@@ -493,7 +494,7 @@ val bir_get_ht_conseq_from_m_ante = prove(
 REPEAT GEN_TAC >>
 REPEAT DISCH_TAC >>
 FULL_SIMP_TAC (std_ss++bir_wm_SS)
-  [bir_triple_def, weak_triple_def,
+  [bir_map_triple_def, weak_map_triple_def, weak_triple_def,
    bir_exec_to_labels_triple_precond_def,
    bir_exec_to_labels_triple_postcond_def, bir_etl_wm_def] >>
 PAT_X_ASSUM ``!s. _``
@@ -503,7 +504,10 @@ subgoal `bir_is_bool_exp_env bs.bst_environ bpre /\
          (bir_eval_exp bpre bs.bst_environ = SOME bir_val_true)` >- (
   METIS_TAC [bir_pre_arm8_to_bir_def, bir_bool_expTheory.bir_is_bool_exp_env_def]
 ) >>
-FULL_SIMP_TAC std_ss [bir_block_pc_def] >>
+FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss)
+  [bir_bool_expTheory.bir_eval_exp_TF,
+   bir_bool_expTheory.bir_is_bool_exp_env_REWRS,
+   bir_block_pc_def] >>
 REV_FULL_SIMP_TAC (std_ss++holBACore_ss) []
 );
 
@@ -682,8 +686,8 @@ FULL_SIMP_TAC (std_ss++holBACore_ss++bir_wm_SS++pred_setLib.PRED_SET_ss)
 val lift_contract_thm = store_thm("lift_contract_thm",
   ``!p mms ml mls mu mpre mpost bpre bpost.
       MEM (BL_Address (Imm64 ml)) (bir_labels_of_program p) ==>
-      bir_triple p (BL_Address (Imm64 ml))
-	{BL_Address (Imm64 ml') | ml' IN mls} bpre bpost ==>
+      bir_map_triple p bir_exp_true (BL_Address (Imm64 ml))
+	{BL_Address (Imm64 ml') | ml' IN mls} {} bpre bpost ==>
       bir_is_lifted_prog arm8_bmr mu mms p ==>
       arm8_wf_varset (bir_vars_of_program p UNION bir_vars_of_exp bpre) ==>
       bir_pre_arm8_to_bir mpre bpre ==>

--- a/examples/tutorial/test-composition.sml
+++ b/examples/tutorial/test-composition.sml
@@ -75,10 +75,12 @@ val _ = print_and_check_thm
   "Example \"BIR optimized mutual recursion\" - is_even"
   bir_ieo_is_even_ht
   ``
-  bir_triple
+  bir_map_triple
     bprog_is_even_odd
+    bir_exp_true
     (BL_Address (Imm32 (0w :word32)))
     {BL_Address (Imm32 (516w :word32)); BL_Address (Imm32 (512w :word32))}
+    {}
     (bir_ieo_pre (v1 :word64)) (bir_ieo_sec_iseven_exit_post v1)
   ``;
 
@@ -86,9 +88,11 @@ val _ = print_and_check_thm
   "Example \"BIR optimized mutual recursion\" - is_odd"
   bir_ieo_is_odd_ht
   ``
-  bir_triple
+  bir_map_triple
     bprog_is_even_odd
+    bir_exp_true
     (BL_Address (Imm32 (256w :word32)))
     {BL_Address (Imm32 (516w :word32)); BL_Address (Imm32 (512w :word32))}
+    {}
     (bir_ieo_pre (v1 :word64)) (bir_ieo_sec_isodd_exit_post v1)
   ``;

--- a/src/theory/bin_hoare_logic/bin_simp_hoare_logicScript.sml
+++ b/src/theory/bin_hoare_logic/bin_simp_hoare_logicScript.sml
@@ -545,64 +545,6 @@ Q.EXISTS_TAC `(\ms. (C1 ms /\ (var ms = x)) /\ invariant ms)` >>
 FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) [pred_setTheory.UNION_ASSOC]
 );
 
-(* The below are still TODO: *)
-(*
-(* Condition *)
-val weak_map_std_seq_comp_thm = prove(``
-(weak_model m) ==>
-(ls1' SUBSET ls2) ==>
-(ls1 INTER ls1' = EMPTY) ==>
-(ls1' INTER ls2' = EMPTY) ==>
-(weak_map_triple m invariant l ls1 ls2 pre1 post1) ==>
-(!l1 . (l1 IN ls1) ==> (weak_map_triple m invariant l1 ls1' ls2' (post1 l1) post2)) ==>
-(weak_map_triple m invariant l ls1' (ls2 INTER ls2') pre1 post2)
-``,
-
-cheat);
-
-
-(* Function call *)
-val weak_map_std_seq_comp_thm = prove(``
-(weak_model m) ==>
-(ls1' SUBSET ls2) ==>
-(ls1 INTER ls1' = EMPTY) ==>
-(ls1' INTER ls2' = EMPTY) ==>
-(weak_map_triple m invariant l ls1 ls2 pre1 post1) ==>
-(!l1 . (l1 IN ls1) ==> (weak_map_triple m invariant l1 ls1' ls2' (post1 l1) post2)) ==>
-(weak_map_triple m invariant l ls1' (ls2 INTER ls2') pre1 post2)
-``,
-
-cheat);
-
-
-(* Recursive function *)
-val weak_map_std_seq_comp_thm = prove(``
-(weak_model m) ==>
-(ls1' SUBSET ls2) ==>
-(ls1 INTER ls1' = EMPTY) ==>
-(ls1' INTER ls2' = EMPTY) ==>
-(weak_map_triple m invariant l ls1 ls2 pre1 post1) ==>
-(!l1 . (l1 IN ls1) ==> (weak_map_triple m invariant l1 ls1' ls2' (post1 l1) post2)) ==>
-(weak_map_triple m invariant l ls1' (ls2 INTER ls2') pre1 post2)
-``,
-
-cheat);
-
-
-(* Mutually Recursive function *)
-val weak_map_std_seq_comp_thm = prove(``
-(weak_model m) ==>
-(ls1' SUBSET ls2) ==>
-(ls1 INTER ls1' = EMPTY) ==>
-(ls1' INTER ls2' = EMPTY) ==>
-(weak_map_triple m invariant l ls1 ls2 pre1 post1) ==>
-(!l1 . (l1 IN ls1) ==> (weak_map_triple m invariant l1 ls1' ls2' (post1 l1) post2)) ==>
-(weak_map_triple m invariant l ls1' (ls2 INTER ls2') pre1 post2)
-``,
-
-cheat);
-*)
-
 val _ = export_theory();
 
 

--- a/src/theory/tools/comp/bir_wm_instScript.sml
+++ b/src/theory/tools/comp/bir_wm_instScript.sml
@@ -91,17 +91,8 @@ val bir_exec_to_labels_triple_postcond_def = Define `
     (bir_is_bool_exp_env st.bst_environ (post st.bst_pc.bpc_label))
 `;
 
-(* The main BIR triple to be used for composition *)
-val bir_triple_def = Define `
-  bir_triple prog l ls pre post =
-    weak_triple (bir_etl_wm prog) l ls
-      (\s. bir_exec_to_labels_triple_precond s pre prog)
-      (\s'. bir_exec_to_labels_triple_postcond s' post prog)
-`;
-
 
 (* BIR map triple, mirroring weak_map_triple *)
-(* See bir_triple_from_map_triple below for how to get a bir_map_triple from bir_triple *)
 val bir_map_triple_def = Define `
   bir_map_triple prog invariant (l:bir_label_t) ls ls' pre post =
     weak_map_triple (bir_etl_wm prog)
@@ -500,783 +491,39 @@ CASE_TAC >| [
 ]
 );
 
-
-(* Obtaining a bir_triple (weak_triple instantiation)
- * from a bir_exec_to_labels_triple *)
-val bir_label_ht_impl_weak_ht =
-  store_thm("bir_label_ht_impl_weak_ht",
-  ``!prog l ls pre post.
-    bir_exec_to_labels_triple prog l ls pre post ==>
-    bir_triple prog l ls pre post``,
-
-FULL_SIMP_TAC (std_ss++bir_wm_SS)
-              [bir_triple_def, weak_triple_def, bir_etl_wm_def,
-               bir_exec_to_labels_triple_def,
-               bir_exec_to_labels_triple_precond_def,
-               bir_exec_to_labels_triple_postcond_def] >>
-REPEAT STRIP_TAC >>
-QSPECL_X_ASSUM ``!s. _`` [`s`] >>
-REV_FULL_SIMP_TAC std_ss [] >>
-Q.EXISTS_TAC `s'` >>
-FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_weak_trs_def,
-                                      bir_exec_to_labels_def] >>
-IMP_RES_TAC bir_exec_to_labels_n_ENV_ORDER >>
-IMP_RES_TAC bir_env_oldTheory.bir_env_vars_are_initialised_ORDER
-);
-
-
-(* TODO: This actually combines two rules: Postcondition weakening and
- * precondition strenghtening *)
-val bir_consequence_rule_thm =
-  store_thm("bir_consequence_rule_thm",
-  ``!prog l ls pre1 pre2 post1 post2.
-    (!st. (st.bst_pc.bpc_label = l) ==>
-          (bir_exec_to_labels_triple_precond st pre2 prog) ==>
-          (bir_exec_to_labels_triple_precond st pre1 prog)
-    ) ==>
-    (!st. (st.bst_pc.bpc_label IN ls) ==>
-          (bir_exec_to_labels_triple_postcond st post1 prog) ==>
-          (bir_exec_to_labels_triple_postcond st post2 prog)
-    ) ==>
-    bir_triple prog l ls pre1 post1 ==>
-    bir_triple prog l ls pre2 post2
-  ``,
-
-REPEAT STRIP_TAC >>
-FULL_SIMP_TAC std_ss [bir_triple_def] >>
-irule weak_weakening_rule_thm >>
-REPEAT STRIP_TAC >- (
-  METIS_TAC [bir_model_is_weak]
-) >>
-Q.EXISTS_TAC `\st. (bir_exec_to_labels_triple_postcond st post1 prog)` >>
-Q.EXISTS_TAC `\st. (bir_exec_to_labels_triple_precond st pre1 prog)` >>
-REPEAT STRIP_TAC >| [
-  QSPECL_X_ASSUM ``!st. (st.bst_pc.bpc_label = l) ==> _`` [`ms`] >>
-  FULL_SIMP_TAC (std_ss++bir_wm_SS) [bir_etl_wm_def],
-
-  QSPECL_X_ASSUM ``!st. (st.bst_pc.bpc_label IN ls) ==> _`` [`ms`] >>
-  FULL_SIMP_TAC (std_ss++bir_wm_SS) [bir_etl_wm_def],
-
-  FULL_SIMP_TAC std_ss []
-]
-);
-
-(* Precondition strengthening rule for use with bir_exp_is_taut *)
-val bir_taut_pre_str_rule_thm = store_thm("bir_taut_pre_str_rule_thm",
-  ``!pre pre' prog l ls post.
-    ((bir_vars_of_exp pre') SUBSET (bir_vars_of_program prog)) ==>
-    ((bir_vars_of_exp pre) SUBSET (bir_vars_of_program prog)) ==>
-    bir_triple prog l ls pre post ==>
-    bir_exp_is_taut (BExp_BinExp BIExp_Or (BExp_UnaryExp BIExp_Not pre') pre) ==>
-    bir_triple prog l ls pre' post``,
-
-REPEAT STRIP_TAC >>
-FULL_SIMP_TAC std_ss [bir_triple_def, weak_triple_def, bir_exec_to_labels_triple_precond_def] >>
-REPEAT STRIP_TAC >>
-PAT_X_ASSUM ``!s. _`` (fn thm => ASSUME_TAC (Q.SPEC `s` thm)) >>
-REV_FULL_SIMP_TAC std_ss [] >>
-subgoal `(bir_vars_of_exp pre' = bir_vars_of_exp pre) ==>
-         !s.
-             bir_is_bool_exp_env s.bst_environ pre' <=>
-             bir_is_bool_exp_env s.bst_environ pre` >- (
-  IMP_RES_TAC bir_exp_is_taut_same_vars_both_bool
-) >>
-
-FULL_SIMP_TAC std_ss [bir_exp_tautologiesTheory.bir_exp_is_taut_def] >>
-PAT_X_ASSUM ``!env. _`` (fn thm => ASSUME_TAC (Q.SPEC `s.bst_environ` thm)) >>
-subgoal `bir_env_vars_are_initialised s.bst_environ
-           (bir_vars_of_exp
-              (BExp_BinExp BIExp_Or (BExp_UnaryExp BIExp_Not pre') pre))` >- (
-  FULL_SIMP_TAC std_ss [bir_typing_expTheory.bir_vars_of_exp_def,
-                        bir_env_oldTheory.bir_env_vars_are_initialised_UNION] >>
-  IMP_RES_TAC bir_env_oldTheory.bir_env_vars_are_initialised_SUBSET >>
-  FULL_SIMP_TAC std_ss []
-) >>
-FULL_SIMP_TAC std_ss [] >> 
-ASSUME_TAC (Q.SPECL [`s.bst_environ`, `pre'`, `pre`]  bir_exp_equivTheory.bir_impl_equiv) >>
-REV_FULL_SIMP_TAC std_ss [] >>
-subgoal `bir_is_bool_exp_env s.bst_environ pre` >- (
-  FULL_SIMP_TAC std_ss [bir_bool_expTheory.bir_is_bool_exp_REWRS,
-                        bir_typing_expTheory.bir_vars_of_exp_def,
-                        bir_env_oldTheory.bir_env_vars_are_initialised_UNION,
-                        bir_bool_expTheory.bir_is_bool_exp_env_def]
-) >>
-METIS_TAC []
-);
-
-(* Postcondition weakening rule for use with bir_exp_is_taut *)
-val bir_taut_post_weak_rule_thm = store_thm("bir_taut_post_weak_rule_thm",
-  ``!pre prog l ls l2 post post'.
-    ((bir_vars_of_exp (post l2)) SUBSET (bir_vars_of_program prog)) ==>
-    ((bir_vars_of_exp (post' l2)) SUBSET (bir_vars_of_program prog)) ==>
-    (!l'. (l' <> l2) ==> (post l' = post' l')) ==>
-    bir_triple prog l ls pre post ==>
-    bir_exp_is_taut (BExp_BinExp BIExp_Or (BExp_UnaryExp BIExp_Not (post l2)) (post' l2)) ==>
-    bir_triple prog l ls pre post'``,
-
-FULL_SIMP_TAC std_ss [bir_triple_def, weak_triple_def, bir_exec_to_labels_triple_postcond_def] >>
-REPEAT STRIP_TAC >>
-PAT_X_ASSUM ``!s. _`` (fn thm => ASSUME_TAC (Q.SPEC `s` thm)) >>
-REV_FULL_SIMP_TAC std_ss [] >>
-
-Q.EXISTS_TAC `s'` >>
-Cases_on `s'.bst_pc.bpc_label <> l2` >- (
-  METIS_TAC []
-) >>
-Q.ABBREV_TAC `env' = s'.bst_environ` >>
-
-subgoal `bir_env_vars_are_initialised env' (bir_vars_of_exp
-                  (BExp_BinExp BIExp_Or (BExp_UnaryExp BIExp_Not (post l2))
-                     (post' l2)))` >- (
-  FULL_SIMP_TAC std_ss [bir_is_bool_exp_env_def, bir_vars_of_exp_def,
-                        bir_env_oldTheory.bir_env_vars_are_initialised_UNION] >>
-  METIS_TAC [bir_env_oldTheory.bir_env_vars_are_initialised_SUBSET]
-) >>
-
-IMP_RES_TAC bir_exp_tautologiesTheory.bir_exp_is_taut_def >>
-
-subgoal `bir_is_bool_exp_env s'.bst_environ (post' l2)` >- (
-  FULL_SIMP_TAC std_ss [bir_is_bool_exp_env_def, bir_vars_of_exp_def,
-                        bir_env_oldTheory.bir_env_vars_are_initialised_UNION,
-                        bir_is_bool_exp_REWRS]
-) >>
-
-METIS_TAC [bir_exp_equivTheory.bir_impl_equiv, bir_exp_tautologiesTheory.bir_exp_is_taut_def]
-);
-
-
-(* bir_exec_to_labels_triple_precond can be swapped for
- * bir_exec_to_labels_triple_postcond *)
-val bir_weak_triple_post_pre = store_thm("bir_weak_triple_post_pre",
-  ``!prog ls1 ls2 post.
-    (!l1. l1 IN ls1 ==> weak_triple (bir_etl_wm prog) l1 ls2
-                          (\s'.
-                             bir_exec_to_labels_triple_precond s' (post l1) prog
-                          )
-                          (\s'.
-                             bir_exec_to_labels_triple_postcond s' post prog
-                          )
-    ) ==>
-    (!l1. l1 IN ls1 ==> weak_triple (bir_etl_wm prog) l1 ls2
-                          (\s'.
-                             bir_exec_to_labels_triple_postcond s' post prog
-                          )
-                          (\s'.
-                             bir_exec_to_labels_triple_postcond s' post prog
-                          )
-     )``,
-
-REPEAT STRIP_TAC >>
-ASSUME_TAC (Q.SPEC `prog` bir_model_is_weak) >>
-QSPECL_X_ASSUM ``!l1'. _`` [`l1`] >>
-REV_FULL_SIMP_TAC std_ss [weak_triple_def,
-                          bir_exec_to_labels_triple_precond_def,
-                          bir_exec_to_labels_triple_postcond_def] >>
-REPEAT STRIP_TAC >>
-QSPECL_X_ASSUM ``!s'. _`` [`s'`] >>
-REV_FULL_SIMP_TAC std_ss [] >>
-Q.SUBGOAL_THEN `s'.bst_pc.bpc_label = l1` (fn thm => FULL_SIMP_TAC std_ss [thm]) >- (
-  FULL_SIMP_TAC (std_ss++bir_wm_SS) [bir_etl_wm_def]
-)
-);
-
-
-(* Main sequential composition theorem for bir_triples *)
-val bir_seq_rule_thm = store_thm("bir_seq_rule_thm",
-  ``!prog l ls1 ls2 pre post.
-    bir_triple prog l (ls1 UNION ls2) pre post ==>
-    (!l1. (l1 IN ls1) ==>
-          bir_triple prog l1 ls2 (post l1) post) ==>
-    bir_triple prog l ls2 pre post``,
-
-REPEAT STRIP_TAC >>
-FULL_SIMP_TAC std_ss [bir_triple_def] >>
-IMP_RES_TAC bir_weak_triple_post_pre >>
-ASSUME_TAC bir_model_is_weak >>
-QSPECL_X_ASSUM ``!prog. _`` [`prog`] >>
-IMP_RES_TAC weak_seq_rule_thm
-);
-
-
-(* TODO: Why isn't bir_loop_contract defined in terms directly of weak_loop_contract?
-(* Two requirements for this to be possible: Either x is of option type,
- * or var is also a function of x, to some inequality type. *)
-
-(* Solution sketch: *)
-val bir_loop_variant_value_def = Define `
-  bir_loop_variant_value v st =
-    if (bir_env_vars_are_initialised st.bst_environ (bir_vars_of_exp v))
-    then let
-           (* x computed here *)
-         in
-           SOME x
-         end
-    else NONE
-`;
-val bir_loop_contract_def = Define `
-  bir_loop_contract prog (l:bir_label_t) le invariant C1 variant =
-    (bir_vars_of_exp v) SUBSET (bir_vars_of_prog prog) /\
-    weak_loop_contract (bir_etl_wm prog) (l:bir_label_t) le
-      (\s. bir_exec_to_labels_triple_precond s invariant prog)
-      (\s. bir_exec_to_labels_triple_precond s C1 prog)
-      (\s. bir_loop_variant_value s variant)
-`;
-
- *)
-val bir_loop_contract_def = Define `
-  bir_loop_contract prog l le invariant C1 variant =
-    (~(l IN le)) /\
-    (!x. (bir_triple prog l ({l} UNION le)
-           (* (\ms. (invariant ms) /\ (C1 ms) /\ ((var ms) = x:num)) *)
-           (BExp_BinExp BIExp_And invariant
-             (BExp_BinExp BIExp_And
-               C1
-               (BExp_BinPred BIExp_Equal variant (BExp_Const (Imm64 x)))
-             )
-           )
-           (* (\ms.(((m.pc ms)=l) /\ (invariant ms) /\ ((var ms) < x) /\ ((var ms) >= 0)))) *)
-	   (\l'. if l' = l then (BExp_BinExp BIExp_And invariant
-		   		  (BExp_BinExp BIExp_And
-				    (BExp_BinPred BIExp_LessThan variant (BExp_Const (Imm64 x)))
-				    (BExp_BinPred BIExp_LessOrEqual (BExp_Const (Imm64 0w)) variant)
-                                  )
-			        )
-                            else bir_exp_false
-	   )
-         )
-    )
-`;
-
-val bir_signed_loop_contract_def = Define `
-  bir_signed_loop_contract prog l le invariant C1 variant =
-    (~(l IN le)) /\
-    (!x. (bir_triple prog l ({l} UNION le)
-           (* (\ms. (invariant ms) /\ (C1 ms) /\ ((var ms) = x:num)) *)
-           (* TODO: Variant greater than 0 here? *)
-           (BExp_BinExp BIExp_And invariant
-             (BExp_BinExp BIExp_And
-               C1
-               (BExp_BinPred BIExp_Equal variant (BExp_Const (Imm64 x)))
-             )
-           )
-           (* (\ms.(((m.pc ms)=l) /\ (invariant ms) /\ ((var ms) < x) /\ ((var ms) >= 0)))) *)
-	   (\l'. if l' = l then (BExp_BinExp BIExp_And invariant
-		   		  (BExp_BinExp BIExp_And
-				    (BExp_BinPred BIExp_SignedLessThan
-                                      variant (BExp_Const (Imm64 x))
-                                    )
-				    (BExp_BinPred BIExp_SignedLessOrEqual
-                                      (BExp_Const (Imm64 0w)) variant
-                                    )
-                                  )
-			        )
-                            else bir_exp_false
-	   )
-         )
-    )
-`;
-
-(* TODO: Very ugly little critter... *)
-val iv2i_def = Define `
-    iv2i (BVal_Imm i) = i
-`;
-
-
-(* TODO: Check all theorems containing antecedents on initialization in the entirety of HolBA
- * to see if they can be resolved by new theorem giving variable initialisation... *)
-(* Also booleanity and bir_eval_TF_is_bool *)
-
-val bir_weak_triple_loop = store_thm("bir_weak_triple_loop",
-  ``!prog l le invariant variant C1.
-    (* Note: Due to the method of obtaining a number from the variant,
-     * we need these two antecedents to prove
-     * bir_eval_exp variant st.bst_environ = SOME (BVal_Imm (Imm64 w)) *)
-    (type_of_bir_exp variant = SOME (BType_Imm Bit64)) ==>
-    (bir_vars_of_exp variant) SUBSET (bir_vars_of_program prog) ==>
-    (l NOTIN le) ==>
-    (!x. weak_triple (bir_etl_wm prog) l ({l} UNION le)
-      (\st. bir_exec_to_labels_triple_precond st
-             (BExp_BinExp BIExp_And invariant
-               (BExp_BinExp BIExp_And
-                 C1
-                 (BExp_BinPred BIExp_Equal variant (BExp_Const (Imm64 (n2w x))))
-               )
-             )
-             prog
-      )
-      (\st'. bir_exec_to_labels_triple_postcond st' 
-               (\l'.
-		  if l' = l then
-		    BExp_BinExp BIExp_And invariant
-		      (BExp_BinExp BIExp_And
-			 (BExp_BinPred BIExp_LessThan variant
-			    (BExp_Const (Imm64 (n2w x))))
-			 (BExp_BinPred BIExp_LessOrEqual
-			    (BExp_Const (Imm64 0w)) variant))
-		  else bir_exp_false
-               ) prog
-      )
-    ) ==>
-    weak_loop_contract (bir_etl_wm prog) l le
-      (\st. bir_exec_to_labels_triple_precond st invariant prog)
-      (\st. bir_eval_exp C1 st.bst_environ = SOME bir_val_true)
-      (\st. b2n (iv2i (THE (bir_eval_exp variant st.bst_environ))))``,
-
-FULL_SIMP_TAC std_ss [weak_loop_contract_def] >>
-REPEAT STRIP_TAC >>
-FULL_SIMP_TAC std_ss [weak_triple_def] >>
-SIMP_TAC std_ss [bir_exec_to_labels_triple_precond_def] >>
-REPEAT STRIP_TAC >>
-QSPECL_X_ASSUM ``!x st. _`` [`x`, `st`] >>
-
-(* This is needed for both steps below *)
-subgoal `bir_eval_exp variant st.bst_environ = SOME (BVal_Imm (Imm64 (n2w x)))` >- (
-  IMP_RES_TAC bir_env_oldTheory.bir_env_vars_are_initialised_SUBSET >>
-  IMP_RES_TAC type_of_bir_exp_THM_with_init_vars >>
-  Q.SUBGOAL_THEN `va = (BVal_Imm (Imm64 (n2w x)))` (fn thm => FULL_SIMP_TAC std_ss [thm]) >- (
-    IMP_RES_TAC (el 5 (CONJUNCTS bir_eval_imm_types)) >>
-    FULL_SIMP_TAC (std_ss++holBACore_ss) [] >>
-    RW_TAC std_ss [wordsTheory.n2w_w2n, iv2i_def, bir_immTheory.b2n_def]
-  )
-) >>
-
-(* Prove precondition of the weak triple using precondition of the weak loop contract *)
-Q.SUBGOAL_THEN `bir_exec_to_labels_triple_precond st
-		  (BExp_BinExp BIExp_And invariant
-		     (BExp_BinExp BIExp_And C1
-			(BExp_BinPred BIExp_Equal variant
-			   (BExp_Const (Imm64 (n2w x)))))) prog`
-  (fn thm => FULL_SIMP_TAC std_ss [thm]) >- (
-  SIMP_TAC std_ss [bir_exec_to_labels_triple_precond_def, GSYM bir_and_equiv,
-                   bir_is_bool_exp_env_REWRS] >>
-  FULL_SIMP_TAC (std_ss++holBACore_ss)
-    [bir_env_oldTheory.bir_env_vars_are_initialised_EMPTY,
-     bir_vars_of_exp_def, bir_val_true_def, bir_is_bool_exp_env_def] >>
-  subgoal `type_of_bir_val (BVal_Imm (Imm1 1w)) = BType_Imm Bit1` >- (
-    FULL_SIMP_TAC (std_ss++holBACore_ss) []
-  ) >>
-  METIS_TAC [bir_env_oldTheory.bir_env_vars_are_initialised_SUBSET, bir_is_bool_exp_def,
-             bir_eval_exp_IS_SOME_IMPLIES_INIT, bir_eval_exp_IS_SOME_IMPLIES_TYPE]
-) >>
-REV_FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_exec_to_labels_triple_postcond_def] >>
-
-(* Prove the postcondition of the weak loop contract using the postcondition of the weak triple *)
-Q.EXISTS_TAC `st'` >>
-Cases_on `st'.bst_pc.bpc_label <> l` >- (
-  FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_eval_exp_TF, bir_val_TF_dist]
-) >>
-FULL_SIMP_TAC (std_ss++bir_wm_SS)
-  [bir_is_bool_exp_env_REWRS,
-   bir_etl_wm_def, bir_weak_trs_EQ, GSYM bir_and_equiv] >>
-subgoal `b2n (iv2i (THE (bir_eval_exp variant st'.bst_environ))) < x` >- (
-  subgoal `?x'. bir_eval_exp variant st'.bst_environ =
-                  SOME (BVal_Imm (Imm64 x'))` >- (
-    subgoal `?va. (bir_eval_exp variant st'.bst_environ = SOME va) /\
-                   (type_of_bir_val va = (BType_Imm it'))` >- (
-      METIS_TAC [type_of_bir_exp_THM_with_init_vars]
-    ) >>
-    METIS_TAC [bir_eval_imm_types]
-  ) >>
-  `bir_imm_word_lo (bir_eval_exp variant st'.bst_environ)
-                     (bir_eval_exp (BExp_Const (Imm64 (n2w x))) st'.bst_environ)` suffices_by (
-     FULL_SIMP_TAC (arith_ss++holBACore_ss) [bir_imm_word_lo_def, wordsTheory.WORD_LO,
-                                             wordsTheory.w2n_n2w, iv2i_def]
-  ) >>
-  FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_lessthan_equiv, bir_imm_word_lo_def, bir_val_true_def]
-) >>
-FULL_SIMP_TAC (std_ss++holBACore_ss) []
-);
-
-val bir_weak_triple_signed_loop = store_thm("bir_weak_triple_signed_loop",
-  ``!prog l le invariant variant C1.
-    (* Note: Due to the method of obtaining a number from the variant,
-     * we need these two antecedents to prove
-     * bir_eval_exp variant st.bst_environ = SOME (BVal_Imm (Imm64 w)) *)
-    (type_of_bir_exp variant = SOME (BType_Imm Bit64)) ==>
-    (bir_vars_of_exp variant) SUBSET (bir_vars_of_program prog) ==>
-    (l NOTIN le) ==>
-    (!x. weak_triple (bir_etl_wm prog) l ({l} UNION le)
-      (\st. bir_exec_to_labels_triple_precond st
-             (BExp_BinExp BIExp_And invariant
-               (BExp_BinExp BIExp_And
-                 C1
-                 (BExp_BinPred BIExp_Equal variant (BExp_Const (Imm64 (n2w x))))
-               )
-             )
-             prog
-      )
-      (\st'. bir_exec_to_labels_triple_postcond st' 
-               (\l'.
-		  if l' = l then
-		    BExp_BinExp BIExp_And invariant
-		      (BExp_BinExp BIExp_And
-			 (BExp_BinPred BIExp_SignedLessThan variant
-			    (BExp_Const (Imm64 (n2w x))))
-			 (BExp_BinPred BIExp_SignedLessOrEqual
-			    (BExp_Const (Imm64 0w)) variant))
-		  else bir_exp_false
-               ) prog
-      )
-    ) ==>
-    weak_loop_contract (bir_etl_wm prog) l le
-      (\st. bir_exec_to_labels_triple_precond st invariant prog)
-      (\st. bir_eval_exp C1 st.bst_environ = SOME bir_val_true)
-      (\st. b2n (iv2i (THE (bir_eval_exp variant st.bst_environ))))``,
-
-FULL_SIMP_TAC std_ss [weak_loop_contract_def] >>
-REPEAT STRIP_TAC >>
-FULL_SIMP_TAC std_ss [weak_triple_def] >>
-SIMP_TAC std_ss [bir_exec_to_labels_triple_precond_def] >>
-REPEAT STRIP_TAC >>
-QSPECL_X_ASSUM ``!x st. _`` [`x`, `st`] >>
-
-(* This is needed for both steps below *)
-subgoal `bir_eval_exp variant st.bst_environ = SOME (BVal_Imm (Imm64 (n2w x)))` >- (
-  IMP_RES_TAC bir_env_oldTheory.bir_env_vars_are_initialised_SUBSET >>
-  IMP_RES_TAC type_of_bir_exp_THM_with_init_vars >>
-  Q.SUBGOAL_THEN `va = (BVal_Imm (Imm64 (n2w x)))` (fn thm => FULL_SIMP_TAC std_ss [thm]) >- (
-    IMP_RES_TAC (el 5 (CONJUNCTS bir_eval_imm_types)) >>
-    FULL_SIMP_TAC (std_ss++holBACore_ss) [] >>
-    RW_TAC std_ss [wordsTheory.n2w_w2n, iv2i_def, bir_immTheory.b2n_def]
-  )
-) >>
-
-(* Prove precondition of the weak triple using precondition of the weak loop contract *)
-Q.SUBGOAL_THEN `bir_exec_to_labels_triple_precond st
-		  (BExp_BinExp BIExp_And invariant
-		     (BExp_BinExp BIExp_And C1
-			(BExp_BinPred BIExp_Equal variant
-			   (BExp_Const (Imm64 (n2w x)))))) prog`
-  (fn thm => FULL_SIMP_TAC std_ss [thm]) >- (
-  SIMP_TAC std_ss [bir_exec_to_labels_triple_precond_def, GSYM bir_and_equiv,
-                   bir_is_bool_exp_env_REWRS] >>
-  FULL_SIMP_TAC (std_ss++holBACore_ss)
-    [bir_env_oldTheory.bir_env_vars_are_initialised_EMPTY,
-     bir_vars_of_exp_def, bir_val_true_def, bir_is_bool_exp_env_def] >>
-  subgoal `type_of_bir_val (BVal_Imm (Imm1 1w)) = BType_Imm Bit1` >- (
-    FULL_SIMP_TAC (std_ss++holBACore_ss) []
-  ) >>
-  METIS_TAC [bir_env_oldTheory.bir_env_vars_are_initialised_SUBSET, bir_is_bool_exp_def,
-             bir_eval_exp_IS_SOME_IMPLIES_INIT, bir_eval_exp_IS_SOME_IMPLIES_TYPE]
-) >>
-REV_FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_exec_to_labels_triple_postcond_def] >>
-
-(* Prove the postcondition of the weak loop contract using the postcondition of the weak triple *)
-Q.EXISTS_TAC `st'` >>
-Cases_on `st'.bst_pc.bpc_label <> l` >- (
-  FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_eval_exp_TF, bir_val_TF_dist]
-) >>
-FULL_SIMP_TAC (std_ss++bir_wm_SS)
-  [bir_is_bool_exp_env_REWRS,
-   bir_etl_wm_def, bir_weak_trs_EQ, GSYM bir_and_equiv] >>
-subgoal `b2n (iv2i (THE (bir_eval_exp variant st'.bst_environ))) < x` >- (
-  subgoal `?x'. bir_eval_exp variant st'.bst_environ =
-                  SOME (BVal_Imm (Imm64 x'))` >- (
-    subgoal `?va. (bir_eval_exp variant st'.bst_environ = SOME va) /\
-                   (type_of_bir_val va = (BType_Imm it'))` >- (
-      METIS_TAC [type_of_bir_exp_THM_with_init_vars]
-    ) >>
-    METIS_TAC [bir_eval_imm_types]
-  ) >>
-  `bir_imm_word_lt (bir_eval_exp variant st'.bst_environ)
-                     (bir_eval_exp (BExp_Const (Imm64 (n2w x))) st'.bst_environ)` suffices_by (
-     FULL_SIMP_TAC (arith_ss++holBACore_ss++wordsLib.WORD_ss)
-       [bir_imm_word_lt_def, wordsTheory.WORD_LT,
-        iv2i_def, wordsTheory.WORD_LE,
-        bir_val_true_def]
-  ) >>
-  FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_slessthan_equiv, bir_imm_word_lt_def, bir_val_true_def]
-) >>
-FULL_SIMP_TAC (std_ss++holBACore_ss) []
-);
-
-
-(* This should be used to instantiate weak_while_rule_thm *)
-val bir_weak_triple_precond_conj = store_thm("bir_weak_triple_precond_conj",
-  ``!prog l le invariant C1 post.
-    weak_triple (bir_etl_wm prog) l le
-      (\s.
-	   bir_exec_to_labels_triple_precond s
-	     (BExp_BinExp BIExp_And invariant
-		(BExp_UnaryExp BIExp_Not C1)) prog)
-      (\s'. bir_exec_to_labels_triple_postcond s' post prog) ==>
-    weak_triple (bir_etl_wm prog) l le
-      (\s. (bir_exec_to_labels_triple_precond s invariant prog) /\
-           (* All the precondition stuff here as well, but we only need booleanity of C1 *)
-           (bir_exec_to_labels_triple_precond s (BExp_UnaryExp BIExp_Not C1) prog)
-      )
-      (\s'. bir_exec_to_labels_triple_postcond s' post prog)``,
-
-FULL_SIMP_TAC std_ss [bir_exec_to_labels_triple_precond_def,
-                      bir_exec_to_labels_triple_postcond_def,
-                      weak_triple_def] >>
-REPEAT STRIP_TAC >>
-QSPECL_X_ASSUM ``!s. _`` [`s`] >>
-REV_FULL_SIMP_TAC std_ss [GSYM bir_and_equiv, bir_not_equiv, 
-                          bir_is_bool_exp_env_REWRS] >>
-Q.EXISTS_TAC `s'` >>
-FULL_SIMP_TAC std_ss []
-);
-
-(* Likewise, use weak_invariant_rule_thm to prove the BIR version of it.
- * Called bir_while_rule_thm to distinguish from bir_do_while_rule_thm *)
-val bir_while_rule_thm = store_thm("bir_while_rule_thm",
-  ``!prog l le invariant C1 var post.
-    (* Compute in place using proof procedures: *)
-    (*   These two needed to use bir_weak_triple_loop *)
-    (type_of_bir_exp var = SOME (BType_Imm Bit64)) ==>
-    bir_vars_of_exp var SUBSET bir_vars_of_program prog ==>
-    (*   These two needed to prove bir_is_bool_exp_env ms.bst_environ C1 *)
-    bir_is_bool_exp C1 ==>
-    (bir_vars_of_exp C1) SUBSET (bir_vars_of_program prog) ==>
-    (* Obtain bir_loop contract through some rule: *)
-    bir_loop_contract prog l le
-      invariant
-      C1 var ==>
-    bir_triple prog l le
-      (BExp_BinExp BIExp_And
-        invariant
-        (BExp_UnaryExp BIExp_Not C1)
-      ) post ==>
-    bir_triple prog l le
-      invariant
-      post``,
-
-FULL_SIMP_TAC std_ss [bir_triple_def, bir_loop_contract_def] >>
-REPEAT STRIP_TAC >>
-ASSUME_TAC bir_model_is_weak >>
-QSPECL_X_ASSUM ``!prog. _`` [`prog`] >>
-(* 1. Somehow obtain the (correct) weak_loop_contract from bir_loop_contract *)
-subgoal `weak_loop_contract (bir_etl_wm prog) l le
-           (\st. bir_exec_to_labels_triple_precond st invariant prog)
-           (\st. bir_eval_exp C1 st.bst_environ = SOME bir_val_true)
-           (\st. b2n (iv2i (THE (bir_eval_exp var st.bst_environ))))` >- (
-  IMP_RES_TAC bir_weak_triple_loop >>
-  QSPECL_X_ASSUM ``!invariant. _`` [`invariant`] >>
-  REV_FULL_SIMP_TAC std_ss []
-) >>
-(* Delete used-up assumptions *)
-Q.PAT_X_ASSUM `!x. _` (fn thm => ALL_TAC) >>
-Q.PAT_X_ASSUM `l NOTIN ls` (fn thm => ALL_TAC) >>
-(* 2. Change the BIR conjunction to a HOL conjunction *)
-subgoal `weak_triple (bir_etl_wm prog) l le
-	   (\ms.
-	      (\s. bir_exec_to_labels_triple_precond s invariant prog) ms /\
-	      ~(\s. bir_eval_exp C1 s.bst_environ = SOME bir_val_true) ms)
-	      (\s. bir_exec_to_labels_triple_postcond s post prog)` >- (
-  IMP_RES_TAC bir_weak_triple_precond_conj >>
-  FULL_SIMP_TAC std_ss [weak_triple_def] >>
-  REPEAT STRIP_TAC >>
-  subgoal `bir_is_bool_exp_env ms.bst_environ C1` >- (
-    FULL_SIMP_TAC std_ss [bir_is_bool_exp_env_def, bir_exec_to_labels_triple_precond_def] >>
-    IMP_RES_TAC bir_env_oldTheory.bir_env_vars_are_initialised_SUBSET
-  ) >>
-  QSPECL_X_ASSUM ``!s. _`` [`ms`] >>
-  QSPECL_X_ASSUM ``!s. _`` [`ms`] >>
-  IMP_RES_TAC bir_not_equiv >>
-  REV_FULL_SIMP_TAC std_ss [bir_is_bool_exp_env_REWRS, bir_exec_to_labels_triple_precond_def]
-) >>
-(* 3. Use weak_invariant_rule_thm *)
-IMP_RES_TAC weak_invariant_rule_thm
-);
-
-(* Signed version of the above *)
-val bir_signed_while_rule_thm = store_thm("bir_signed_while_rule_thm",
-  ``!prog l le invariant C1 var post.
-    (* Compute in place using proof procedures: *)
-    (*   These two needed to use bir_weak_triple_loop *)
-    (type_of_bir_exp var = SOME (BType_Imm Bit64)) ==>
-    bir_vars_of_exp var SUBSET bir_vars_of_program prog ==>
-    (*   These two needed to prove bir_is_bool_exp_env ms.bst_environ C1 *)
-    bir_is_bool_exp C1 ==>
-    (bir_vars_of_exp C1) SUBSET (bir_vars_of_program prog) ==>
-    (* Obtain bir_loop contract through some rule: *)
-    bir_signed_loop_contract prog l le
-      invariant
-      C1 var ==>
-    bir_triple prog l le
-      (BExp_BinExp BIExp_And
-        invariant
-        (BExp_UnaryExp BIExp_Not C1)
-      ) post ==>
-    bir_triple prog l le
-      invariant
-      post``,
-
-FULL_SIMP_TAC std_ss [bir_triple_def, bir_signed_loop_contract_def] >>
-REPEAT STRIP_TAC >>
-ASSUME_TAC bir_model_is_weak >>
-QSPECL_X_ASSUM ``!prog. _`` [`prog`] >>
-(* 1. Somehow obtain the (correct) weak_loop_contract from bir_loop_contract *)
-subgoal `weak_loop_contract (bir_etl_wm prog) l le
-           (\st. bir_exec_to_labels_triple_precond st invariant prog)
-           (\st. bir_eval_exp C1 st.bst_environ = SOME bir_val_true)
-           (\st. b2n (iv2i (THE (bir_eval_exp var st.bst_environ))))` >- (
-  IMP_RES_TAC bir_weak_triple_signed_loop >>
-  QSPECL_X_ASSUM ``!invariant. _`` [`invariant`] >>
-  REV_FULL_SIMP_TAC std_ss []
-) >>
-(* Delete used-up assumptions *)
-Q.PAT_X_ASSUM `!x. _` (fn thm => ALL_TAC) >>
-Q.PAT_X_ASSUM `l NOTIN ls` (fn thm => ALL_TAC) >>
-(* 2. Change the BIR conjunction to a HOL conjunction *)
-subgoal `weak_triple (bir_etl_wm prog) l le
-	   (\ms.
-	      (\s. bir_exec_to_labels_triple_precond s invariant prog) ms /\
-	      ~(\s. bir_eval_exp C1 s.bst_environ = SOME bir_val_true) ms)
-	      (\s. bir_exec_to_labels_triple_postcond s post prog)` >- (
-  IMP_RES_TAC bir_weak_triple_precond_conj >>
-  FULL_SIMP_TAC std_ss [weak_triple_def] >>
-  REPEAT STRIP_TAC >>
-  subgoal `bir_is_bool_exp_env ms.bst_environ C1` >- (
-    FULL_SIMP_TAC std_ss [bir_is_bool_exp_env_def, bir_exec_to_labels_triple_precond_def] >>
-    IMP_RES_TAC bir_env_oldTheory.bir_env_vars_are_initialised_SUBSET
-  ) >>
-  QSPECL_X_ASSUM ``!s. _`` [`ms`] >>
-  QSPECL_X_ASSUM ``!s. _`` [`ms`] >>
-  IMP_RES_TAC bir_not_equiv >>
-  REV_FULL_SIMP_TAC std_ss [bir_is_bool_exp_env_REWRS, bir_exec_to_labels_triple_precond_def]
-) >>
-(* 3. Use weak_invariant_rule_thm *)
-IMP_RES_TAC weak_invariant_rule_thm
-);
-
 (*****************************************************)
 (* BIR map triple theorems                           *)
 (*****************************************************)
 
-(* How to obtain a bir_map_triple from a bir_triple: *)
-val bir_triple_equiv_map_triple = store_thm("bir_triple_equiv_map_triple",
-  ``!prog invariant l ls ls' pre post.
-    bir_map_triple prog invariant l ls ls' pre post <=>
-      (((ls INTER ls') = EMPTY) /\ (ls <> EMPTY) /\
-       (bir_triple prog l (ls UNION ls')
-		   (BExp_BinExp BIExp_And pre invariant)
-		   (\label. if (label IN ls)
-			    then (BExp_BinExp BIExp_And (post label) invariant)
-			    else bir_exp_false
-		   )
-       )
-      )
-  ``,
+(* Obtaining a bir_map_triple from a bir_exec_to_labels_triple *)
+val bir_label_ht_impl_weak_ht =
+  store_thm("bir_label_ht_impl_weak_ht",
+  ``!prog l ls pre post.
+    ls <> {} ==>
+    bir_exec_to_labels_triple prog l ls pre post ==>
+    bir_map_triple prog bir_exp_true l ls {} pre post``,
 
-REPEAT STRIP_TAC >>
-FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_triple_def, bir_map_triple_def, weak_map_triple_def] >>
-EQ_TAC >> (
-  REPEAT STRIP_TAC >> (
-    FULL_SIMP_TAC std_ss []
-  ) >>
-  FULL_SIMP_TAC std_ss [weak_triple_def] >>
-  REPEAT STRIP_TAC >>
-  QSPECL_X_ASSUM ``!s. _`` [`s`] >>
-  REV_FULL_SIMP_TAC std_ss []
-) >| [
-  (* bir_map_triple -> bir_triple *)
-  subgoal `bir_exec_to_labels_triple_precond s pre prog /\
-           bir_exec_to_labels_triple_precond s invariant prog` >- (
-    FULL_SIMP_TAC std_ss [bir_exec_to_labels_triple_precond_def, bir_is_bool_exp_env_REWRS,
-                          GSYM bir_and_equiv]
-  ) >>
-  FULL_SIMP_TAC std_ss [] >>
-  Q.EXISTS_TAC `s'` >>
-  FULL_SIMP_TAC std_ss [bir_exec_to_labels_triple_postcond_def] >>
-  Cases_on `s'.bst_pc.bpc_label IN ls` >| [
-    FULL_SIMP_TAC std_ss [bir_is_bool_exp_env_REWRS, GSYM bir_and_equiv,
-                          bir_exec_to_labels_triple_precond_def],
-
-    (* We know that s'.pc NOTIN ls', but also that ls INTER ls' = {}, s'.bst_status = BST_Running and
-     * that (bir_etl_wm prog).weak s (ls UNION ls') s'. Ergo, s'.pc must be in ls. *)
-    (*FULL_SIMP_TAC (std_ss++bir_wm_SS) [bir_etl_wm_def, bir_eval_exp_TF,
-                                         bir_val_TF_dist]*)
-    FULL_SIMP_TAC (std_ss++bir_wm_SS) [bir_etl_wm_def] >>
-    `s'.bst_pc.bpc_label IN (ls UNION ls')` suffices_by
-      FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) [] >>
-    FULL_SIMP_TAC std_ss [bir_weak_trs_EQ]
-  ],
-
-  (* bir_triple -> bir_map_triple *)
-  subgoal `bir_exec_to_labels_triple_precond s
-             (BExp_BinExp BIExp_And pre invariant) prog` >- (
-    FULL_SIMP_TAC std_ss [bir_exec_to_labels_triple_precond_def, bir_is_bool_exp_env_REWRS,
-                          GSYM bir_and_equiv]
-  ) >>
-  FULL_SIMP_TAC std_ss [] >>
-  Q.EXISTS_TAC `s'` >>
-  FULL_SIMP_TAC std_ss [bir_exec_to_labels_triple_postcond_def] >>
-  Cases_on `s'.bst_pc.bpc_label IN ls` >| [
-    (* What needs to be added is similar to cheated case above... *)
-    FULL_SIMP_TAC (std_ss++bir_wm_SS) [bir_is_bool_exp_env_REWRS, GSYM bir_and_equiv,
-                                       bir_exec_to_labels_triple_precond_def, bir_etl_wm_def,
-                                       bir_weak_trs_EQ] >>
-    METIS_TAC [INTER_EMPTY_IN_NOT_IN_thm],
-
-    FULL_SIMP_TAC std_ss [bir_eval_exp_TF, bir_val_TF_dist]
-  ]
-]
+FULL_SIMP_TAC (std_ss++bir_wm_SS)
+              [bir_map_triple_def, weak_map_triple_def,
+               weak_triple_def, bir_etl_wm_def,
+               bir_exec_to_labels_triple_def,
+               bir_exec_to_labels_triple_precond_def,
+               bir_exec_to_labels_triple_postcond_def] >>
+REPEAT STRIP_TAC >> (
+  FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) []
+) >>
+QSPECL_X_ASSUM ``!s. _`` [`s`] >>
+REV_FULL_SIMP_TAC std_ss [] >>
+Q.EXISTS_TAC `s'` >>
+FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_weak_trs_def,
+				      bir_exec_to_labels_def] >>
+IMP_RES_TAC bir_exec_to_labels_n_ENV_ORDER >>
+IMP_RES_TAC bir_env_oldTheory.bir_env_vars_are_initialised_ORDER >>
+FULL_SIMP_TAC std_ss [bir_bool_expTheory.bir_eval_exp_TF,
+		      bir_bool_expTheory.bir_is_bool_exp_env_REWRS]
 );
 
-val bir_triple_equiv_map_triple_alt = store_thm("bir_triple_equiv_map_triple_alt",
-  ``!prog invariant l ls ls' pre post.
-    bir_map_triple prog invariant l ls ls' pre post <=>
-      (((ls INTER ls') = EMPTY) /\ (ls <> EMPTY) /\
-       (bir_triple prog l (ls UNION ls')
-		   (BExp_BinExp BIExp_And pre invariant)
-		   (\label. if (label IN ls')
-			    then bir_exp_false
-			    else (BExp_BinExp BIExp_And (post label) invariant)
-		   )
-       )
-      )
-  ``,
-
-REPEAT STRIP_TAC >>
-FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_triple_def, bir_map_triple_def, weak_map_triple_def] >>
-EQ_TAC >> (
-  REPEAT STRIP_TAC >> (
-    FULL_SIMP_TAC std_ss []
-  ) >>
-  FULL_SIMP_TAC std_ss [weak_triple_def] >>
-  REPEAT STRIP_TAC >>
-  QSPECL_X_ASSUM ``!s. _`` [`s`] >>
-  REV_FULL_SIMP_TAC std_ss []
-) >| [
-  (* bir_map_triple -> bir_triple *)
-  subgoal `bir_exec_to_labels_triple_precond s pre prog /\
-           bir_exec_to_labels_triple_precond s invariant prog` >- (
-    FULL_SIMP_TAC std_ss [bir_exec_to_labels_triple_precond_def, bir_is_bool_exp_env_REWRS,
-                          GSYM bir_and_equiv]
-  ) >>
-  FULL_SIMP_TAC std_ss [] >>
-  Q.EXISTS_TAC `s'` >>
-  FULL_SIMP_TAC std_ss [bir_exec_to_labels_triple_postcond_def] >>
-  Cases_on `s'.bst_pc.bpc_label IN ls'` >| [
-    FULL_SIMP_TAC (std_ss++bir_wm_SS) [bir_etl_wm_def],
-
-    FULL_SIMP_TAC std_ss [bir_is_bool_exp_env_REWRS, GSYM bir_and_equiv,
-                          bir_exec_to_labels_triple_precond_def]
-  ],
-
-  (* bir_triple -> bir_map_triple *)
-  subgoal `bir_exec_to_labels_triple_precond s
-             (BExp_BinExp BIExp_And pre invariant) prog` >- (
-    FULL_SIMP_TAC std_ss [bir_exec_to_labels_triple_precond_def, bir_is_bool_exp_env_REWRS,
-                          GSYM bir_and_equiv]
-  ) >>
-  FULL_SIMP_TAC std_ss [] >>
-  Q.EXISTS_TAC `s'` >>
-  FULL_SIMP_TAC std_ss [bir_exec_to_labels_triple_postcond_def] >>
-  Cases_on `s'.bst_pc.bpc_label IN ls'` >| [
-    FULL_SIMP_TAC std_ss [bir_eval_exp_TF, bir_val_TF_dist],
-
-    FULL_SIMP_TAC (std_ss++bir_wm_SS) [bir_is_bool_exp_env_REWRS, GSYM bir_and_equiv,
-                                       bir_exec_to_labels_triple_precond_def, bir_etl_wm_def]
-  ]
-]
-);
-
-
-(* bir_map_triples are all generated from bir_triples, which have no explicit notion
- * of blacklist. This theorem moves ending labels which are implicitly
+(* This theorem moves ending labels which are implicitly
  * blacklisted by the postcondition from the whitelist of a bir_map_triple to the blacklist. *)
 val bir_map_triple_move_to_blacklist = store_thm("bir_map_triple_move_to_blacklist",
   ``!prog inv l wlist blist pre post elabel.
@@ -1315,32 +562,6 @@ NTAC 2 STRIP_TAC >>
 QSPECL_X_ASSUM ``!prog. _`` [`(bir_etl_wm prog).pc ms`] >>
 SIMP_TAC std_ss [bir_exec_to_labels_triple_postcond_def] >>
 FULL_SIMP_TAC (std_ss++bir_wm_SS) [bir_etl_wm_def, bir_eval_exp_TF, bir_val_TF_dist]
-);
-
-
-(* Shrinking the Ending label set is possible if the corresponding postcondition never holds. *)
-val bir_subset_rule_thm =
- store_thm("bir_subset_rule_thm",
-  ``!prog l ls1 ls2 pre post .
-    (!st. (bir_eval_exp (post st.bst_pc.bpc_label) st.bst_environ = SOME bir_val_true) ==>
-          (~(st.bst_pc.bpc_label IN ls2))
-    ) ==>
-    bir_triple prog l (ls1 UNION ls2) pre post ==>
-    bir_triple prog l ls1 pre post``,
-
-REPEAT STRIP_TAC >>
-REV_FULL_SIMP_TAC std_ss [bir_triple_def, weak_triple_def] >>
-REPEAT STRIP_TAC >>
-QSPECL_X_ASSUM ``!s. _`` [`s`] >>
-ASSUME_TAC (SPECL [``prog:'a bir_program_t``] bir_model_is_weak) >>
-REV_FULL_SIMP_TAC std_ss [] >>
-IMP_RES_TAC weak_union_pc_not_in_thm >>
-QSPECL_X_ASSUM ``!st. _`` [`s'`] >>
-subgoal `bir_eval_exp (post s'.bst_pc.bpc_label) s'.bst_environ =
-          SOME bir_val_true` >- (
-  FULL_SIMP_TAC std_ss [bir_exec_to_labels_triple_postcond_def]
-) >>
-FULL_SIMP_TAC (std_ss++bir_wm_SS) [bir_etl_wm_def]
 );
 
 
@@ -1494,6 +715,11 @@ REPEAT STRIP_TAC >> (
                                      bir_etl_wm_def]
 ]
 );
+
+
+val iv2i_def = Define `
+    iv2i (BVal_Imm i) = i
+`;
 
 val bir_map_signed_loop_thm = store_thm("bir_map_signed_loop_thm",
   ``!prog l wl bl invariant C1 variant post.
@@ -1797,6 +1023,37 @@ STRIP_TAC >| [
   Q.EXISTS_TAC `s'` >>
   FULL_SIMP_TAC std_ss []
 ]
+);
+
+(* Shrinking the whitelist is possible if the corresponding
+ * postcondition never holds. *)
+val bir_map_subset_rule_thm =
+ store_thm("bir_map_subset_rule_thm",
+  ``!prog l ls1 ls2 pre post.
+    ls1 <> {} ==>
+    (!st. (bir_eval_exp (post st.bst_pc.bpc_label) st.bst_environ = SOME bir_val_true) ==>
+          (~(st.bst_pc.bpc_label IN ls2))
+    ) ==>
+    bir_map_triple prog bir_exp_true l (ls1 UNION ls2) {} pre post ==>
+    bir_map_triple prog bir_exp_true l ls1 {} pre post``,
+
+REPEAT STRIP_TAC >>
+REV_FULL_SIMP_TAC std_ss [bir_map_triple_def, weak_map_triple_def,
+                          weak_triple_def] >>
+REPEAT STRIP_TAC >> (
+  FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) []
+) >> (
+  QSPECL_X_ASSUM ``!s. _`` [`s`] >>
+  ASSUME_TAC (SPECL [``prog:'a bir_program_t``] bir_model_is_weak) >>
+  REV_FULL_SIMP_TAC std_ss [] >>
+  IMP_RES_TAC weak_union_pc_not_in_thm >>
+  QSPECL_X_ASSUM ``!st. _`` [`s''`] >>
+  subgoal `bir_eval_exp (post s''.bst_pc.bpc_label) s''.bst_environ =
+	    SOME bir_val_true` >- (
+    FULL_SIMP_TAC std_ss [bir_exec_to_labels_triple_postcond_def]
+  ) >>
+  FULL_SIMP_TAC (std_ss++bir_wm_SS) [bir_etl_wm_def]
+)
 );
 
 val bir_map_subset_blacklist_rule_thm =


### PR DESCRIPTION
This removes the redundant `bir_triple` and simplifies the tutorial examples.