### PR TITLE
Move to Kananaskis-14

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        polyml: ['v5.7.1', 'v5.8']
+        polyml: ['v5.7.1', 'v5.8.1']
 
     env:
       HOLBA_POLYML_VERSION: ${{ matrix.polyml }}
@@ -32,7 +32,7 @@ jobs:
         with:
           path: |
             ${{ env.HOLBA_OPT_DIR }}
-          key: os-${{ runner.os }}_polyml-${{ matrix.polyml }}
+          key: os-${{ runner.os }}_polyml-${{ matrix.polyml }}_hol4-k14
 
       - name: Static analysis
         timeout-minutes: 5

--- a/README.md
+++ b/README.md
@@ -164,10 +164,12 @@ Notice that this sequence is just an example, and it is possible to selectively 
 
 ## References
 
-* D. Lundberg, R. Guanciale, A. Lindner and M. Dam, **"Hoare-Style Logic for Unstructured Programs"**, in Software Engineering and Formal Methods, p. 193-213, 2020. [Link](https://doi.org/10.1007/978-3-030-58768-0_11). _(program logic used for decomposition of verification)_
+* D. Lundberg, R. Guanciale, A. Lindner and M. Dam, **"Hoare-Style Logic for Unstructured Programs"**, in Software Engineering and Formal Methods, pp. 193-213, 2020. [Link](https://doi.org/10.1007/978-3-030-58768-0_11). _(program logic used for decomposition of verification)_
 
-* A. Lindner, R. Guanciale and R. Metere, **"TrABin : Trustworthy analyses of binaries"**, Science of Computer Programming, vol. 174, p. 72-89, 2019. [Link](https://doi.org/10.1016/j.scico.2019.01.001). _(the proof-producing binary analysis framework with weakest preconditions in HOL4)_
+* H. Nemati, P. Buiras, A. Lindner, R. Guanciale and S. Jacobs, **"Validation of Abstract Side-Channel Models for Computer Architectures"**, in International Conference on Computer Aided Verification, pp. 225-248, 2020. [Link](https://doi.org/10.1007/978-3-030-53288-8_12). _(framework to validate abstract side-channel models)_
+
+* A. Lindner, R. Guanciale and R. Metere, **"TrABin : Trustworthy analyses of binaries"**, Science of Computer Programming, vol. 174, pp. 72-89, 2019. [Link](https://doi.org/10.1016/j.scico.2019.01.001). _(the proof-producing binary analysis framework with weakest preconditions in HOL4)_
 
 * D. Lundberg, **"Provably Sound and Secure Automatic Proving and Generation of Verification Conditions"**, Master Thesis, 2018. [Link](http://urn.kb.se/resolve?urn=urn%3Anbn%3Ase%3Akth%3Adiva-239441).
 
-* R. Metere, A. Lindner and R. Guanciale, **"Sound Transpilation from Binary to Machine-Independent Code"**, in 20th Brazilian Symposium on Formal Methods, p. 197-214, 2017. [Link](https://doi.org/10.1007/978-3-319-70848-5_13). _(formalization of intermediate language and proof-producing lifter in HOL4)_
+* R. Metere, A. Lindner and R. Guanciale, **"Sound Transpilation from Binary to Machine-Independent Code"**, in 20th Brazilian Symposium on Formal Methods, pp. 197-214, 2017. [Link](https://doi.org/10.1007/978-3-319-70848-5_13). _(formalization of intermediate language and proof-producing lifter in HOL4)_

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ ${HOLBA_HOLMAKE}
 
 - HOL4 (`https://github.com/HOL-Theorem-Prover/HOL`)
   - tag: kananaskis-14
-- Poly/ML 5.7.1 (version packaged for Ubuntu 20.04)
+- Poly/ML 5.8.1
+  - alternatively, Poly/ML 5.7.1 (version packaged for Ubuntu 20.04)
 - Z3 v4.8.4
 
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ ${HOLBA_HOLMAKE}
 ### Software versions
 
 - HOL4 (`https://github.com/HOL-Theorem-Prover/HOL`)
-  - tag: kananaskis-13
+  - tag: kananaskis-14
 - Poly/ML 5.7.1 (version packaged for Ubuntu 20.04)
 - Z3 v4.8.4
 

--- a/scripts/setup/env_config_gen.sh
+++ b/scripts/setup/env_config_gen.sh
@@ -111,7 +111,7 @@ echo
 # first define HOLBA_HOL_DIR if undefined (default)
 if [[ ( -z "${HOLBA_HOL_DIR}" ) || ( ! -z "${OPT_DIR_PARAM}" ) ]]; then
   print_export_msg "HOLBA_HOL_DIR"
-  export HOLBA_HOL_DIR="${HOLBA_OPT_DIR}/hol_k13"
+  export HOLBA_HOL_DIR="${HOLBA_OPT_DIR}/hol_k14"
 fi
 
 HOLBA_HOL_BIN_DIR="${HOLBA_HOL_DIR}/bin"

--- a/scripts/setup/install_hol4.sh
+++ b/scripts/setup/install_hol4.sh
@@ -17,7 +17,7 @@ source "${SETUP_DIR}/env_config_gen.sh" "${OPT_DIR_PARAM}"
 
 
 # make polyml binaries and libraries available
-POLY_VERSION="v5.7.1"
+POLY_VERSION="v5.8.1"
 
 # if poly version is specified in the environment, use this
 if [[ ! -z "${HOLBA_POLYML_VERSION}" ]]; then

--- a/scripts/setup/install_hol4.sh
+++ b/scripts/setup/install_hol4.sh
@@ -30,10 +30,10 @@ export LD_LIBRARY_PATH=${POLY_DIR}/lib:$LD_LIBRARY_PATH
 
 # HOL4 source and branch
 GIT_URL=https://github.com/HOL-Theorem-Prover/HOL.git
-GIT_BRANCH=kananaskis-13
+GIT_BRANCH=kananaskis-14
 GIT_IS_TAG=1
 
-HOL4_DIR=${HOLBA_OPT_DIR}/hol_k13
+HOL4_DIR=${HOLBA_OPT_DIR}/hol_k14
 
 
 ##################################################################

--- a/scripts/setup/install_hol4_latest.sh
+++ b/scripts/setup/install_hol4_latest.sh
@@ -17,7 +17,7 @@ source "${SETUP_DIR}/env_config_gen.sh" "${OPT_DIR_PARAM}"
 
 
 # make polyml binaries and libraries available
-POLY_VERSION="v5.7.1"
+POLY_VERSION="v5.8.1"
 
 # if poly version is specified in the environment, use this
 if [[ ! -z "${HOLBA_POLYML_VERSION}" ]]; then

--- a/scripts/setup/install_poly.sh
+++ b/scripts/setup/install_poly.sh
@@ -19,7 +19,7 @@ source "${SETUP_DIR}/env_config_gen.sh" "${OPT_DIR_PARAM}"
 # based on HOL4 developers/install-poly.sh
 # --------------------------------------------
 POLY_BASE="https://github.com/polyml/polyml"
-POLY_VERSION="v5.7.1"
+POLY_VERSION="v5.8.1"
 
 # if poly version is specified in the environment, use this
 if [[ ! -z "${HOLBA_POLYML_VERSION}" ]]; then

--- a/src/shared/HolSmt/SmtLib.sml
+++ b/src/shared/HolSmt/SmtLib.sml
@@ -161,7 +161,7 @@ local
     (intSyntax.leq_tm, apfst_K "<="),
     (intSyntax.less_tm, apfst_K "<"),
     (intSyntax.geq_tm, apfst_K ">="),
-    (intSyntax.great_tm, apfst_K ">"),
+    (intSyntax.greater_tm, apfst_K ">"),
     (* decimals (excluding 'realSyntax.negate_tm') *)
     (Term.mk_var ("x", realSyntax.real_ty), Lib.apfst (fn tm =>
       if realSyntax.is_real_literal tm andalso not (realSyntax.is_negated tm)
@@ -187,7 +187,7 @@ local
     (realSyntax.leq_tm, apfst_K "<="),
     (realSyntax.less_tm, apfst_K "<"),
     (realSyntax.geq_tm, apfst_K ">="),
-    (realSyntax.great_tm, apfst_K ">"),
+    (realSyntax.greater_tm, apfst_K ">"),
     (intrealSyntax.real_of_int_tm, apfst_K "to_real"),
     (intrealSyntax.INT_FLOOR_tm, apfst_K "to_int"),
     (intrealSyntax.is_int_tm, apfst_K "is_int"),

--- a/src/shared/HolSmt/SmtLib_Logics.sml
+++ b/src/shared/HolSmt/SmtLib_Logics.sml
@@ -122,7 +122,7 @@ in
         ("<=", chainable (realSyntax.mk_leq o one_int_to_real)),
         ("<", chainable (realSyntax.mk_less o one_int_to_real)),
         (">=", chainable (realSyntax.mk_geq o one_int_to_real)),
-        (">", chainable (realSyntax.mk_great o one_int_to_real))
+        (">", chainable (realSyntax.mk_greater o one_int_to_real))
       ]]
   end
 

--- a/src/shared/HolSmt/SmtLib_Theories.sml
+++ b/src/shared/HolSmt/SmtLib_Theories.sml
@@ -267,7 +267,7 @@ in
       ("<=", chainable intSyntax.mk_leq),
       ("<", chainable intSyntax.mk_less),
       (">=", chainable intSyntax.mk_geq),
-      (">", chainable intSyntax.mk_great)
+      (">", chainable intSyntax.mk_greater)
     ]
 
   end
@@ -298,7 +298,7 @@ in
       ("<=", chainable realSyntax.mk_leq),
       ("<", chainable realSyntax.mk_less),
       (">=", chainable realSyntax.mk_geq),
-      (">", chainable realSyntax.mk_great)
+      (">", chainable realSyntax.mk_greater)
     ]
 
   end
@@ -329,7 +329,7 @@ in
       ("<=", chainable intSyntax.mk_leq),
       ("<", chainable intSyntax.mk_less),
       (">=", chainable intSyntax.mk_geq),
-      (">", chainable intSyntax.mk_great),
+      (">", chainable intSyntax.mk_greater),
       (* decimals *)
       ("_", zero_zero real_of_decimal),
       ("-", K_zero_one realSyntax.mk_negated),
@@ -340,7 +340,7 @@ in
       ("<=", chainable realSyntax.mk_leq),
       ("<", chainable realSyntax.mk_less),
       (">=", chainable realSyntax.mk_geq),
-      (">", chainable realSyntax.mk_great),
+      (">", chainable realSyntax.mk_greater),
       ("to_real", K_zero_one intrealSyntax.mk_real_of_int),
       ("to_int", K_zero_one intrealSyntax.mk_INT_FLOOR),
       ("is_int", K_zero_one intrealSyntax.mk_is_int)

--- a/src/shared/HolSmt/Yices.sml
+++ b/src/shared/HolSmt/Yices.sml
@@ -97,7 +97,7 @@ structure Yices = struct
          "(ite (< x y) y x)))"),
     (intSyntax.less_tm, "<", ""),
     (intSyntax.leq_tm, "<=", ""),
-    (intSyntax.great_tm, ">", ""),
+    (intSyntax.greater_tm, ">", ""),
     (intSyntax.geq_tm, ">=", ""),
     (realSyntax.negate_tm, "- 0", ""),
     (realSyntax.absval_tm, "hol_real_abs",
@@ -117,7 +117,7 @@ structure Yices = struct
          "(ite (< x y) y x)))"),
     (realSyntax.less_tm, "<", ""),
     (realSyntax.leq_tm, "<=", ""),
-    (realSyntax.great_tm, ">", ""),
+    (realSyntax.greater_tm, ">", ""),
     (realSyntax.geq_tm, ">=", ""),
     (pairSyntax.comma_tm, "mk-tuple", ""),
     (wordsSyntax.word_and_tm, "bv-and", ""),
@@ -615,10 +615,11 @@ structure Yices = struct
                  it may not be needed at all: ensuring that the constant name
                  is identical to the field selector name may already be
                  sufficient. *)
+              val fix_fields = (fn fields => map (fn (str, fi) => (str, #ty fi)) fields)
               val j = Lib.index (fn (field_name, field_ty) =>
                   select_name = record_name ^ "_" ^ field_name andalso
                     Lib.can (Type.match_type field_ty) rng_ty)
-                (TypeBase.fields_of record_ty)
+                (fix_fields (TypeBase.fields_of record_ty))
               (* translate argument *)
               val (acc, yices_x) = translate_term (acc, x)
               val (_, _, ty_dict, _, _) = acc
@@ -650,10 +651,11 @@ structure Yices = struct
                  it may not be needed at all: ensuring that the constant name
                  is identical to the field update function's name may already be
                  sufficient. *)
+              val fix_fields = (fn fields => map (fn (str, fi) => (str, #ty fi)) fields)
               val j = Lib.index (fn (field_name, field_ty) =>
                   update_name = record_name ^ "_" ^ field_name ^ "_fupd" andalso
                     Lib.can (Type.match_type field_ty) val_ty)
-                (TypeBase.fields_of record_ty)
+                (fix_fields (TypeBase.fields_of record_ty))
               val (acc, yices_x) = translate_term (acc, x)
               val (acc, yices_val) = translate_term (acc, new_val)
               val (_, _, ty_dict, _, _) = acc

--- a/src/shared/HolSmt/Yices.sml
+++ b/src/shared/HolSmt/Yices.sml
@@ -615,11 +615,10 @@ structure Yices = struct
                  it may not be needed at all: ensuring that the constant name
                  is identical to the field selector name may already be
                  sufficient. *)
-              val fix_fields = (fn fields => map (fn (str, fi) => (str, #ty fi)) fields)
-              val j = Lib.index (fn (field_name, field_ty) =>
+              val j = Lib.index (fn (field_name, {ty = field_ty, ...}) =>
                   select_name = record_name ^ "_" ^ field_name andalso
                     Lib.can (Type.match_type field_ty) rng_ty)
-                (fix_fields (TypeBase.fields_of record_ty))
+                (TypeBase.fields_of record_ty)
               (* translate argument *)
               val (acc, yices_x) = translate_term (acc, x)
               val (_, _, ty_dict, _, _) = acc
@@ -651,11 +650,10 @@ structure Yices = struct
                  it may not be needed at all: ensuring that the constant name
                  is identical to the field update function's name may already be
                  sufficient. *)
-              val fix_fields = (fn fields => map (fn (str, fi) => (str, #ty fi)) fields)
-              val j = Lib.index (fn (field_name, field_ty) =>
+              val j = Lib.index (fn (field_name, {ty = field_ty, ...}) =>
                   update_name = record_name ^ "_" ^ field_name ^ "_fupd" andalso
                     Lib.can (Type.match_type field_ty) val_ty)
-                (fix_fields (TypeBase.fields_of record_ty))
+                (TypeBase.fields_of record_ty)
               val (acc, yices_x) = translate_term (acc, x)
               val (acc, yices_val) = translate_term (acc, new_val)
               val (_, _, ty_dict, _, _) = acc

--- a/src/theory/bir-support/bir_nzcv_expScript.sml
+++ b/src/theory/bir-support/bir_nzcv_expScript.sml
@@ -486,8 +486,22 @@ SIMP_TAC std_ss [nzcv_BIR_SUB_NZCV_REWRS,
 ] >>
 REPEAT CONJ_TAC >| [
   SIMP_TAC (std_ss++boolSimps.CONJ_ss) [WORD_LOWER_NOT_EQ],
+  
   SIMP_TAC (std_ss++boolSimps.CONJ_ss) [WORD_LOWER_NOT_EQ],
-  METIS_TAC[]
+  
+  METIS_TAC [],
+
+  REPEAT GEN_TAC >>
+  EQ_TAC >| [
+    CCONTR_TAC >>
+    FULL_SIMP_TAC (std_ss++boolSimps.CONJ_ss) [WORD_LOWER_NOT_EQ] >>
+    FULL_SIMP_TAC (std_ss++boolSimps.CONJ_ss) [WORD_LESS_CASES_IMP],
+
+    REPEAT STRIP_TAC >> (
+      FULL_SIMP_TAC (std_ss++boolSimps.CONJ_ss) []
+    ) >>
+    METIS_TAC [WORD_LESS_ANTISYM]
+  ]
 ]);
 
 

--- a/src/theory/bir-support/bir_program_blocksScript.sml
+++ b/src/theory/bir-support/bir_program_blocksScript.sml
@@ -259,7 +259,6 @@ Cases_on `stmts` >> (
     bir_exec_stmtsB_def, LET_DEF]
 ) >>
 REPEAT GEN_TAC >>
-DISJ2_TAC >>
 ONCE_REWRITE_TAC[bir_exec_stmtsB_RESET_COUNTER] >>
 SIMP_TAC (arith_ss++pairSimps.gen_beta_ss) [LET_DEF]);
 

--- a/src/theory/bir-support/bir_program_multistep_propsScript.sml
+++ b/src/theory/bir-support/bir_program_multistep_propsScript.sml
@@ -222,7 +222,6 @@ METIS_TAC[arithmeticTheory.LESS_EQ_SUC_REFL, arithmeticTheory.LESS_EQ_TRANS]);
 val bir_exec_infinite_steps_fun_COUNT_PCs_EQ = store_thm (
 "bir_exec_infinite_steps_fun_COUNT_PCs_EQ",
 ``!pc_cond p state i.
-
    (bir_exec_infinite_steps_fun_COUNT_PCs pc_cond p state i = i) <=> (
    !j. j < i ==> bir_state_COUNT_PC pc_cond (bir_exec_infinite_steps_fun p state (SUC j)))``,
 
@@ -233,9 +232,9 @@ Induct_on `i` >> (
     DISJ_IMP_THM, FORALL_AND_THM]
 ) >>
 GEN_TAC >>
-DISJ2_TAC >>
 `~(SUC i <= i)` by DECIDE_TAC >>
-METIS_TAC[bir_exec_infinite_steps_fun_COUNT_PCs_LESS_EQ]);
+METIS_TAC[bir_exec_infinite_steps_fun_COUNT_PCs_LESS_EQ]
+);
 
 
 val bir_state_COUNT_PC_ALL_STEPS = store_thm ("bir_state_COUNT_PC_ALL_STEPS",
@@ -1347,7 +1346,6 @@ Cases_on ` bir_exec_infinite_steps_fun_COUNT_PCs pc_count p state0 c_pc1 < n1` >
   FULL_SIMP_TAC (std_ss++boolSimps.CONJ_ss) [bir_exec_infinite_steps_fun_COUNT_PCs_def] >>
   Tactical.REVERSE CONJ_TAC >- (
     REPEAT STRIP_TAC >>
-    DISJ2_TAC >>
     `n1 <= n1 + n2` by DECIDE_TAC >>
     METIS_TAC[bir_exec_infinite_steps_fun_COUNT_PCs_COMPLETE_LESS_EQ,
       arithmeticTheory.LESS_EQ_LESS_TRANS]
@@ -1361,7 +1359,7 @@ Tactical.REVERSE CONJ_TAC >- (
   rename1 `(n:num) < c_pc1 + _` >>
   Cases_on `n < c_pc1` >- (
     ASM_SIMP_TAC std_ss [] >>
-    GEN_TAC >> DISJ2_TAC >>
+    GEN_TAC >> 
     rename1 `_ <> (n1:num) + n2` >>
     `n1 <= n1 + n2` by DECIDE_TAC >>
     METIS_TAC[bir_exec_infinite_steps_fun_COUNT_PCs_COMPLETE_LESS_EQ,

--- a/src/theory/bir-support/bir_program_terminationScript.sml
+++ b/src/theory/bir-support/bir_program_terminationScript.sml
@@ -1141,12 +1141,9 @@ subgoal `bir_exec_infinite_steps_fun prog st n = st'` >- (
   FULL_SIMP_TAC std_ss [bir_exec_block_n_EQ_THM]
 ) >>
 FULL_SIMP_TAC (std_ss++holBACore_ss)
-	      [bir_state_is_terminated_def] >| [
-  IMP_RES_TAC bir_exec_block_n_block_nz_final_running >>
-  REV_FULL_SIMP_TAC arith_ss [bir_state_is_terminated_def],
-
-  FULL_SIMP_TAC std_ss []
-]
+	      [bir_state_is_terminated_def] >>
+IMP_RES_TAC bir_exec_block_n_block_nz_final_running >>
+REV_FULL_SIMP_TAC arith_ss [bir_state_is_terminated_def]
 );
 
 

--- a/src/theory/bir-support/bir_update_blockScript.sml
+++ b/src/theory/bir-support/bir_update_blockScript.sml
@@ -170,7 +170,7 @@ val bir_update_blockB_desc_OK_CONS = store_thm("bir_update_blockB_desc_OK_CONS",
 )``,
 
 SIMP_TAC (list_ss++boolSimps.EQUIV_EXTRACT_ss) [bir_update_blockB_desc_OK_def,
-  FORALL_AND_THM, EVERY_MEM, MEM_MAP, indexedListsTheory.LT_SUC,
+  FORALL_AND_THM, EVERY_MEM, MEM_MAP, arithmeticTheory.LT_SUC,
   RIGHT_AND_OVER_OR, DISJ_IMP_THM, GSYM LEFT_EXISTS_AND_THM, GSYM LEFT_FORALL_IMP_THM,
   LEFT_AND_OVER_OR, GSYM RIGHT_EXISTS_AND_THM, IN_IMAGE] >>
 REPEAT STRIP_TAC >>

--- a/src/theory/bir/bir_typing_expScript.sml
+++ b/src/theory/bir/bir_typing_expScript.sml
@@ -475,7 +475,7 @@ val bir_type_of_bir_exp_NONE = store_thm("bir_type_of_bir_exp_NONE",
 REPEAT STRIP_TAC >>
 Induct_on `ex` >> (
   REPEAT STRIP_TAC >>
-  FULL_SIMP_TAC std_ss [type_of_bir_exp_EQ_NONE_REWRS, bir_eval_exp_def]
+  FULL_SIMP_TAC pure_ss [type_of_bir_exp_EQ_NONE_REWRS, bir_eval_exp_def]
 ) >| [
   (* Cast *)
   IMP_RES_TAC type_of_bir_exp_NOT_SOME_Imm >> (

--- a/src/theory/tools/comp/bir_wm_instScript.sml
+++ b/src/theory/tools/comp/bir_wm_instScript.sml
@@ -421,14 +421,11 @@ CASE_TAC >| [
      * value of FUNPOW_OPT (bir_trs prog) would be NONE). *)
     FULL_SIMP_TAC std_ss [GSYM boolTheory.IMP_DISJ_THM] >>
     REPEAT STRIP_TAC >>
-    DISJ1_TAC >>
     rename1 `FUNPOW_OPT (bir_trs prog) n' st = SOME ms'` >>
     rename1 `FUNPOW_OPT (bir_trs prog) n' st = SOME st''` >>
     rename1
       `bir_exec_to_labels ls prog st = BER_Ended l n n0 st'` >>
-    DISCH_TAC >>
     rename1 `m' > 0` >>
-    DISCH_TAC >>
     rename1
       `bir_exec_to_labels ls prog st = BER_Ended l' n n0 st'` >>
     rename1
@@ -480,7 +477,6 @@ CASE_TAC >| [
     FULL_SIMP_TAC std_ss []
   ) >>
   rename1 `m > 0` >>
-  DISJ1_TAC >>
   REPEAT STRIP_TAC >>
   IMP_RES_TAC FUNPOW_OPT_bir_trs_to_bir_exec_block_n >>
   rename1 `bir_exec_block_n prog st m = (l',n,c_l',ms')` >>

--- a/src/tools/lifter/selftestLib.sig
+++ b/src/tools/lifter/selftestLib.sig
@@ -1,5 +1,5 @@
 signature test_bmr = sig
-  type lift_inst_cache
+  type lift_inst_cache;
 
   include Arbnum;
   include Abbrev;
@@ -38,16 +38,4 @@ signature test_bmr = sig
 	     (thm option * bir_inst_liftingExn_data option * string) list
   (* Prints the final results *)
   val final_results : string -> string list -> unit
-end
-
-signature selftestLib = sig
-
-  include PPBackEnd;
-
-  (* TODO: Put test instances here? *)
-  val sty_OK     : pp_style list
-  val sty_CACHE  : pp_style list
-  val sty_FAIL   : pp_style list
-  val sty_HEADER : pp_style list
-
 end

--- a/src/tools/lifter/selftestLib.sig
+++ b/src/tools/lifter/selftestLib.sig
@@ -1,3 +1,10 @@
+(* Dummy so that we don't have to make separate Holmake stuff for test_bmr*)
+signature selftestLib = sig
+
+  include PPBackEnd;
+
+end;
+
 signature test_bmr = sig
   type lift_inst_cache;
 

--- a/src/tools/lifter/selftestLib.sml
+++ b/src/tools/lifter/selftestLib.sml
@@ -2,20 +2,6 @@
 (* Testing infrastructure *)
 (**************************)
 
-structure selftestLib :> selftestLib = struct
-
-  open PPBackEnd;
-
-  (* TODO: Put test instances here? *)
-
-  (* Styles for success, fail and header *)
-  val sty_OK     = [FG Green];
-  val sty_CACHE  = [FG Yellow];
-  val sty_FAIL   = [FG OrangeRed];
-  val sty_HEADER = [Bold, Underline];
-
-end
-
 (* Struct for lifter testing *)
 functor test_bmr (structure MD : bir_inst_lifting; structure log_name_str : sig val log_name: string end) = struct
 (* For debugging:
@@ -48,6 +34,8 @@ open bir_inst_liftingLibTypes
 open PPBackEnd Parse
 
 open bir_inst_liftingHelpersLib;
+
+open selftest_styleLib;
 (* ================================================ *)
 
     open HolKernel Parse;
@@ -97,19 +85,19 @@ open bir_inst_liftingHelpersLib;
     val _ = case res of
 	       SOME (thm, _, cache_used) =>
 		   (success_hexcodes_list := (hex_code, desc, thm)::(!success_hexcodes_list);
-		   (print_log_with_style selftestLib.sty_OK log_f "OK");
-		   (if cache_used then (print_log log_f " - "; print_log_with_style selftestLib.sty_CACHE log_f "cached") else ());
+		   (print_log_with_style sty_OK log_f "OK");
+		   (if cache_used then (print_log log_f " - "; print_log_with_style sty_CACHE log_f "cached") else ());
 		   (print_log log_f "\n");
 		   (if log_f then ((TextIO.output (log, thm_to_string thm));
 				   (TextIO.output (log, "\n"))) else ()))
 	     | NONE =>
 	       (failed_hexcodes_list := (hex_code, desc, ed)::(!failed_hexcodes_list);
-	       (print_log_with_style selftestLib.sty_FAIL log_f "FAILED\n"));
+	       (print_log_with_style sty_FAIL log_f "FAILED\n"));
     val _ = case ed of
 	NONE => ()
       | SOME d => (let
 	  val s = ("   "^(bir_inst_liftingExn_data_to_string d) ^ "\n");
-	in print_log_with_style selftestLib.sty_FAIL log_f s end)
+	in print_log_with_style sty_FAIL log_f s end)
     val _ = if log_f then TextIO.output (log, "\n") else ();
   in
     (res', ed, d_s, cache')
@@ -161,7 +149,7 @@ open bir_inst_liftingHelpersLib;
 
 
   fun final_results name expected_failed_hexcodes = let
-    val _ = print_log_with_style selftestLib.sty_HEADER true ("\n\n\nSUMMARY FAILING HEXCODES " ^ name ^ "\n\n");
+    val _ = print_log_with_style sty_HEADER true ("\n\n\nSUMMARY FAILING HEXCODES " ^ name ^ "\n\n");
     val _ = print_log true "\n";
     val failing_l = op_mk_set (fn (x, _, _) => fn (y, _, _) => (x = y)) (!failed_hexcodes_list)
     val ok_l = op_mk_set (fn (x, _, _) => fn (y, _, _) => (x = y)) (!success_hexcodes_list)
@@ -188,7 +176,7 @@ open bir_inst_liftingHelpersLib;
       | print_failed ((hex_code, desc, ed_opt, broken)::l) =
     let
       (* print the ones that failed, but were not excepted to in red *)
-      val st = if broken then selftestLib.sty_FAIL else [];
+      val st = if broken then sty_FAIL else [];
       val _ = print_log true "   ";
       val _ = print_log_with_style st true ("\""^hex_code^"\"");
 
@@ -203,14 +191,14 @@ open bir_inst_liftingHelpersLib;
     (* Show the hex-codes that were expected to fail, but succeeded. These
        are the ones fixed by recent changes. *)
     val _ = print_log true ("Instructions FIXED: " ^ (Int.toString (length fixed_l)) ^ "\n\n");
-    val _ = List.map (fn s => print_log_with_style selftestLib.sty_OK true ("   " ^ s ^"\n")) fixed_l;
+    val _ = List.map (fn s => print_log_with_style sty_OK true ("   " ^ s ^"\n")) fixed_l;
     val _ = print_log true "\n\n";
 
     (* Show the hex-codes that were expected to succeed, but failed. These
        are the ones broken by recent changes. *)
     val broken_l = List.filter (fn (hc, d, edo, br) => br) failing_l';
     val _ = print_log true ("Instructions BROKEN: " ^ (Int.toString (List.length broken_l)) ^ "\n\n");
-    val _ = List.map (fn (hc, desc, ed_opt, _) => print_log_with_style selftestLib.sty_FAIL true ("   " ^ hc ^
+    val _ = List.map (fn (hc, desc, ed_opt, _) => print_log_with_style sty_FAIL true ("   " ^ hc ^
 	 (comment_of_failing desc ed_opt) ^ "\n")) broken_l;
     val _ = print_log true "\n\n";
 

--- a/src/tools/lifter/selftestLib.sml
+++ b/src/tools/lifter/selftestLib.sml
@@ -2,6 +2,15 @@
 (* Testing infrastructure *)
 (**************************)
 
+(* Dummy so that we don't have to make separate Holmake stuff for test_bmr*)
+structure selftestLib :> selftestLib = struct
+
+  open PPBackEnd;
+
+  (* TODO: Put test instances here? *)
+
+end;
+
 (* Struct for lifter testing *)
 functor test_bmr (structure MD : bir_inst_lifting; structure log_name_str : sig val log_name: string end) = struct
 (* For debugging:

--- a/src/tools/lifter/selftest_arm.sml
+++ b/src/tools/lifter/selftest_arm.sml
@@ -5,6 +5,7 @@ open bir_inst_liftingLibTypes;
 open bir_inst_liftingHelpersLib;
 open PPBackEnd;
 
+open selftest_styleLib;
 open selftestLib;
 
 (******************)

--- a/src/tools/lifter/selftest_arm.sml
+++ b/src/tools/lifter/selftest_arm.sml
@@ -926,11 +926,7 @@ in () end;
 val arm8_expected_failed_hexcodes:string list =
 [
    "9BC37C41" (* umulh x1, x2, x3 lifting of ``Imm64 ((127 >< 64) (w2w (ms.REG 3w) * w2w (ms.REG 2w)))`` failed *),
-   "9B437C41" (* smulh x1, x2, x3 lifting of ``Imm64 ((127 >< 64) (sw2sw (ms.REG 3w) * sw2sw (ms.REG 2w)))`` failed *),
-   "DAC01441" (* clz x1, x2 lifting of ``Imm64 (n2w (CountLeadingZeroBits (ms.REG 2w)))`` failed *),
-   "5AC01441" (* clz w1, w2 lifting of ``Imm64 (n2w (BITS 31 0 (CountLeadingZeroBits (w2w (ms.REG 2w)))))`` failed *),
-   "DAC01041" (* cls x1, x2 lifting of ``Imm64 (n2w (CountLeadingSignBits (ms.REG 2w)))`` failed *),
-   "5AC01041" (* cls w1, w2 lifting of ``Imm64 (n2w (BITS 31 0 (CountLeadingSignBits (w2w (ms.REG 2w)))))`` failed *)
+   "9B437C41" (* smulh x1, x2, x3 lifting of ``Imm64 ((127 >< 64) (sw2sw (ms.REG 3w) * sw2sw (ms.REG 2w)))`` failed *)
 ];
 
 val _ = if (not test_arm8) then () else let

--- a/src/tools/lifter/selftest_arm8.log
+++ b/src/tools/lifter/selftest_arm8.log
@@ -3,37 +3,37 @@ MANUAL TESTS - ARMv8
 
 8B020020 (add x0, x1, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 0w; 2w; 139w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 0w; 2w; 139w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "add x0, x1, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "add x0, x1, x2";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "R1" (BType_Imm Bit64)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 8B010021 (add x1, x1, x1) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[33w; 0w; 1w; 139w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[33w; 0w; 1w; 139w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "add x1, x1, x1";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "add x1, x1, x1";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Mult (BExp_Const (Imm64 2w))
                    (BExp_Den (BVar "R1" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 AB020020 (adds x0, x1, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 0w; 2w; 171w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 0w; 2w; 171w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "adds x0, x1, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "adds x0, x1, x2";
            bb_statements :=
              [BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit64)))
@@ -54,42 +54,42 @@ AB020020 (adds x0, x1, x2) @ 0x10030 - OK
                    (BExp_Den (BVar "R1" (BType_Imm Bit64)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 8B020000 (add x0, x0, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[0w; 0w; 2w; 139w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[0w; 0w; 2w; 139w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "add x0, x0, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "add x0, x0, x2";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "R0" (BType_Imm Bit64)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 CB020020 (sub x0, x1, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 0w; 2w; 203w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 0w; 2w; 203w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "sub x0, x1, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "sub x0, x1, x2";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Minus
                    (BExp_Den (BVar "R1" (BType_Imm Bit64)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9A020020 (adc x0, x1, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 0w; 2w; 154w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 0w; 2w; 154w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "adc x0, x1, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "adc x0, x1, x2";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
@@ -100,14 +100,14 @@ CB020020 (sub x0, x1, x2) @ 0x10030 - OK
                       (BExp_Den (BVar "ProcState_C" BType_Bool))
                       (BExp_Const (Imm64 1w)) (BExp_Const (Imm64 0w))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9A010020 (adc x0, x1, x1) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 0w; 1w; 154w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 0w; 1w; 154w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "adc x0, x1, x1";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "adc x0, x1, x1";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
@@ -117,14 +117,14 @@ CB020020 (sub x0, x1, x2) @ 0x10030 - OK
                       (BExp_Den (BVar "ProcState_C" BType_Bool))
                       (BExp_Const (Imm64 1w)) (BExp_Const (Imm64 0w))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 1A010020 (adc w0, w1, w1) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 0w; 1w; 26w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 0w; 1w; 26w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "adc w0, w1, w1";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "adc w0, w1, w1";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -137,14 +137,14 @@ CB020020 (sub x0, x1, x2) @ 0x10030 - OK
                          (BExp_Const (Imm32 1w)) (BExp_Const (Imm32 0w))))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 BA020020 (adcs x0, x1, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 0w; 2w; 186w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 0w; 2w; 186w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "adcs x0, x1, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "adcs x0, x1, x2";
            bb_statements :=
              [BStmt_Assign (BVar "tmp_ProcState_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C
@@ -177,14 +177,14 @@ BA020020 (adcs x0, x1, x2) @ 0x10030 - OK
               BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_Den (BVar "tmp_ProcState_C" BType_Bool))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 BA010020 (adcs x0, x1, x1) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 0w; 1w; 186w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 0w; 1w; 186w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "adcs x0, x1, x1";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "adcs x0, x1, x1";
            bb_statements :=
              [BStmt_Assign (BVar "tmp_ProcState_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C
@@ -216,14 +216,14 @@ BA010020 (adcs x0, x1, x1) @ 0x10030 - OK
               BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_Den (BVar "tmp_ProcState_C" BType_Bool))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 3A020020 (adcs w0, w1, w2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 0w; 2w; 58w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 0w; 2w; 58w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "adcs w0, w1, w2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "adcs w0, w1, w2";
            bb_statements :=
              [BStmt_Assign (BVar "tmp_ProcState_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C
@@ -268,14 +268,14 @@ BA010020 (adcs x0, x1, x1) @ 0x10030 - OK
               BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_Den (BVar "tmp_ProcState_C" BType_Bool))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 3A010020 (adcs w0, w1, w1) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 0w; 1w; 58w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 0w; 1w; 58w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "adcs w0, w1, w1";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "adcs w0, w1, w1";
            bb_statements :=
              [BStmt_Assign (BVar "tmp_ProcState_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C
@@ -318,14 +318,14 @@ BA010020 (adcs x0, x1, x1) @ 0x10030 - OK
               BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_Den (BVar "tmp_ProcState_C" BType_Bool))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 FA020000 (sbcs x0, x0, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[0w; 0w; 2w; 250w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[0w; 0w; 2w; 250w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "sbcs x0, x0, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "sbcs x0, x0, x2";
            bb_statements :=
              [BStmt_Assign (BVar "tmp_ProcState_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C
@@ -362,14 +362,14 @@ FA020000 (sbcs x0, x0, x2) @ 0x10030 - OK
               BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_Den (BVar "tmp_ProcState_C" BType_Bool))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 FA010020 (sbcs x0, x1, x1) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 0w; 1w; 250w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 0w; 1w; 250w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "sbcs x0, x1, x1";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "sbcs x0, x1, x1";
            bb_statements :=
              [BStmt_Assign (BVar "tmp_ProcState_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C
@@ -403,14 +403,14 @@ FA010020 (sbcs x0, x1, x1) @ 0x10030 - OK
               BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_Den (BVar "tmp_ProcState_C" BType_Bool))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 7A020020 (sbcs w0, w1, w2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 0w; 2w; 122w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 0w; 2w; 122w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "sbcs w0, w1, w2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "sbcs w0, w1, w2";
            bb_statements :=
              [BStmt_Assign (BVar "tmp_ProcState_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C
@@ -459,14 +459,14 @@ FA010020 (sbcs x0, x1, x1) @ 0x10030 - OK
               BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_Den (BVar "tmp_ProcState_C" BType_Bool))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 7A010020 (sbcs w0, w1, w1) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 0w; 1w; 122w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 0w; 1w; 122w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "sbcs w0, w1, w1";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "sbcs w0, w1, w1";
            bb_statements :=
              [BStmt_Assign (BVar "tmp_ProcState_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C
@@ -510,14 +510,14 @@ FA010020 (sbcs x0, x1, x1) @ 0x10030 - OK
               BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_Den (BVar "tmp_ProcState_C" BType_Bool))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 DA020000 (sbc x0, x0, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[0w; 0w; 2w; 218w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[0w; 0w; 2w; 218w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "sbc x0, x0, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "sbc x0, x0, x2";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Minus
@@ -528,42 +528,42 @@ DA020000 (sbc x0, x0, x2) @ 0x10030 - OK
                       (BExp_Den (BVar "ProcState_C" BType_Bool))
                       (BExp_Const (Imm64 0w)) (BExp_Const (Imm64 1w))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 CB020020 (sub x0, x1, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 0w; 2w; 203w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 0w; 2w; 203w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "sub x0, x1, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "sub x0, x1, x2";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Minus
                    (BExp_Den (BVar "R1" (BType_Imm Bit64)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9B027C20 (mul x0, x1, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 124w; 2w; 155w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 124w; 2w; 155w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "mul x0, x1, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "mul x0, x1, x2";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Mult
                    (BExp_Den (BVar "R1" (BType_Imm Bit64)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 1B017C20 (mul w0, w1, w1) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 124w; 1w; 27w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 124w; 1w; 27w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "mul w0, w1, w1";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "mul w0, w1, w1";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -574,14 +574,14 @@ CB020020 (sub x0, x1, x2) @ 0x10030 - OK
                          (BExp_Den (BVar "R1" (BType_Imm Bit64))) Bit32))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 7100001F (cmp w0, #0) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[31w; 0w; 0w; 113w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[31w; 0w; 0w; 113w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "cmp w0, #0";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "cmp w0, #0";
            bb_statements :=
              [BStmt_Assign (BVar "ProcState_C" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "ProcState_N" BType_Bool)
@@ -595,14 +595,14 @@ CB020020 (sub x0, x1, x2) @ 0x10030 - OK
                       (BExp_Den (BVar "R0" (BType_Imm Bit64))) Bit32)
                    (BExp_Const (Imm32 0w)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 3100001F (cmn w0, #0) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[31w; 0w; 0w; 49w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[31w; 0w; 0w; 49w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "cmn w0, #0";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "cmn w0, #0";
            bb_statements :=
              [BStmt_Assign (BVar "ProcState_C" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "ProcState_N" BType_Bool)
@@ -616,14 +616,14 @@ CB020020 (sub x0, x1, x2) @ 0x10030 - OK
                       (BExp_Den (BVar "R0" (BType_Imm Bit64))) Bit32)
                    (BExp_Const (Imm32 0w)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 2B01001F (cmn w0, w1) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[31w; 0w; 1w; 43w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[31w; 0w; 1w; 43w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "cmn w0, w1";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "cmn w0, w1";
            bb_statements :=
              [BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_nzcv_ADD_C
@@ -650,14 +650,14 @@ CB020020 (sub x0, x1, x2) @ 0x10030 - OK
                    (BExp_Cast BIExp_LowCast
                       (BExp_Den (BVar "R1" (BType_Imm Bit64))) Bit32))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 AB09001F (cmn x0, x9) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[31w; 0w; 9w; 171w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[31w; 0w; 9w; 171w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "cmn x0, x9";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "cmn x0, x9";
            bb_statements :=
              [BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R0" (BType_Imm Bit64)))
@@ -674,61 +674,61 @@ AB09001F (cmn x0, x9) @ 0x10030 - OK
                 (BExp_nzcv_ADD_Z (BExp_Den (BVar "R0" (BType_Imm Bit64)))
                    (BExp_Den (BVar "R9" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 D65F03C0 (ret) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[192w; 3w; 95w; 214w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[192w; 3w; 95w; 214w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ret";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ret";
            bb_statements := [];
            bb_last_statement :=
              BStmt_Jmp (BLE_Exp (BExp_Den (BVar "R30" (BType_Imm Bit64))))|>])
 
 D2800080 (mov x0, #4) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[128w; 0w; 128w; 210w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[128w; 0w; 128w; 210w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "mov x0, #4";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "mov x0, #4";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_Const (Imm64 4w))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 AA0103E0 (mov x0, x1) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[224w; 3w; 1w; 170w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[224w; 3w; 1w; 170w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "mov x0, x1";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "mov x0, x1";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_Den (BVar "R1" (BType_Imm Bit64)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 AA2103E0 (mvn x0, x1) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[224w; 3w; 33w; 170w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[224w; 3w; 33w; 170w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "mvn x0, x1";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "mvn x0, x1";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_UnaryExp BIExp_Not
                    (BExp_Den (BVar "R1" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 B1002040 (adds x0, x2, #8) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[64w; 32w; 0w; 177w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[64w; 32w; 0w; 177w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "adds x0, x2, #8";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "adds x0, x2, #8";
            bb_statements :=
              [BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R2" (BType_Imm Bit64)))
@@ -749,14 +749,14 @@ B1002040 (adds x0, x2, #8) @ 0x10030 - OK
                    (BExp_Den (BVar "R2" (BType_Imm Bit64)))
                    (BExp_Const (Imm64 8w)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 F1002040 (subs x0, x2, #8) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[64w; 32w; 0w; 241w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[64w; 32w; 0w; 241w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "subs x0, x2, #8";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "subs x0, x2, #8";
            bb_statements :=
              [BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R2" (BType_Imm Bit64)))
@@ -777,14 +777,14 @@ F1002040 (subs x0, x2, #8) @ 0x10030 - OK
                    (BExp_Den (BVar "R2" (BType_Imm Bit64)))
                    (BExp_Const (Imm64 8w)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 AB020020 (adds x0, x1, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 0w; 2w; 171w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 0w; 2w; 171w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "adds x0, x1, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "adds x0, x1, x2";
            bb_statements :=
              [BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit64)))
@@ -805,42 +805,43 @@ AB020020 (adds x0, x1, x2) @ 0x10030 - OK
                    (BExp_Den (BVar "R1" (BType_Imm Bit64)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 8B020000 (add x0, x0, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[0w; 0w; 2w; 139w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[0w; 0w; 2w; 139w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "add x0, x0, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "add x0, x0, x2";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "R0" (BType_Imm Bit64)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 CB020020 (sub x0, x1, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 0w; 2w; 203w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 0w; 2w; 203w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "sub x0, x1, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "sub x0, x1, x2";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Minus
                    (BExp_Den (BVar "R1" (BType_Imm Bit64)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 8B020800 (add x0, x0, x2, LSL #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[0w; 8w; 2w; 139w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[0w; 8w; 2w; 139w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "add x0, x0, x2, LSL #2";
+        [<|bb_label :=
+             BL_Address_HC (Imm64 0x10030w) "add x0, x0, x2, LSL #2";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
@@ -849,14 +850,15 @@ CB020020 (sub x0, x1, x2) @ 0x10030 - OK
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))
                       (BExp_Const (Imm64 2w))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 8B820800 (add x0, x0, x2, ASR #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[0w; 8w; 130w; 139w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[0w; 8w; 130w; 139w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "add x0, x0, x2, ASR #2";
+        [<|bb_label :=
+             BL_Address_HC (Imm64 0x10030w) "add x0, x0, x2, ASR #2";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
@@ -865,14 +867,15 @@ CB020020 (sub x0, x1, x2) @ 0x10030 - OK
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))
                       (BExp_Const (Imm64 2w))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 8B420800 (add x0, x0, x2, LSR #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[0w; 8w; 66w; 139w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[0w; 8w; 66w; 139w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "add x0, x0, x2, LSR #2";
+        [<|bb_label :=
+             BL_Address_HC (Imm64 0x10030w) "add x0, x0, x2, LSR #2";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
@@ -881,84 +884,87 @@ CB020020 (sub x0, x1, x2) @ 0x10030 - OK
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))
                       (BExp_Const (Imm64 2w))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 8B020000 (add x0, x0, x2, LSL #0) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[0w; 0w; 2w; 139w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[0w; 0w; 2w; 139w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "add x0, x0, x2, LSL #0";
+        [<|bb_label :=
+             BL_Address_HC (Imm64 0x10030w) "add x0, x0, x2, LSL #0";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "R0" (BType_Imm Bit64)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 8B820000 (add x0, x0, x2, ASR #0) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[0w; 0w; 130w; 139w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[0w; 0w; 130w; 139w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "add x0, x0, x2, ASR #0";
+        [<|bb_label :=
+             BL_Address_HC (Imm64 0x10030w) "add x0, x0, x2, ASR #0";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "R0" (BType_Imm Bit64)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 8B420000 (add x0, x0, x2, LSR #0) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[0w; 0w; 66w; 139w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[0w; 0w; 66w; 139w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "add x0, x0, x2, LSR #0";
+        [<|bb_label :=
+             BL_Address_HC (Imm64 0x10030w) "add x0, x0, x2, LSR #0";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "R0" (BType_Imm Bit64)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 910023E4 (add x4, SP, #8) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[228w; 35w; 0w; 145w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[228w; 35w; 0w; 145w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "add x4, SP, #8";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "add x4, SP, #8";
            bb_statements :=
              [BStmt_Assign (BVar "R4" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "SP_EL0" (BType_Imm Bit64)))
                    (BExp_Const (Imm64 8w)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 910023E4 (add x4, SP, #8) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[228w; 35w; 0w; 145w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[228w; 35w; 0w; 145w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "add x4, SP, #8";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "add x4, SP, #8";
            bb_statements :=
              [BStmt_Assign (BVar "R4" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "SP_EL0" (BType_Imm Bit64)))
                    (BExp_Const (Imm64 8w)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 B1000021 (adds x1, x1, #0) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[33w; 0w; 0w; 177w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[33w; 0w; 0w; 177w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "adds x1, x1, #0";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "adds x1, x1, #0";
            bb_statements :=
              [BStmt_Assign (BVar "ProcState_C" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "ProcState_N" BType_Bool)
@@ -969,59 +975,59 @@ B1000021 (adds x1, x1, #0) @ 0x10030 - OK
                    (BExp_Den (BVar "R1" (BType_Imm Bit64)))
                    (BExp_Const (Imm64 0w)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 D345FC41 (lsr x1, x2, #5) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 252w; 69w; 211w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 252w; 69w; 211w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "lsr x1, x2, #5";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "lsr x1, x2, #5";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_And
-                   (BExp_Const (Imm64 576460752303423487w))
+                   (BExp_Const (Imm64 0x7FFFFFFFFFFFFFFw))
                    (BExp_BinExp BIExp_And
-                      (BExp_Const (Imm64 18446744073709551615w))
+                      (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
                       (BExp_ror Bit64
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))) 5)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 D340FC41 (lsr x1, x2, #0) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 252w; 64w; 211w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 252w; 64w; 211w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "lsr x1, x2, #0";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "lsr x1, x2, #0";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_And
-                   (BExp_Const (Imm64 18446744073709551615w))
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 D340FC21 (lsr x1, x1, #0) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[33w; 252w; 64w; 211w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[33w; 252w; 64w; 211w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "lsr x1, x1, #0";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "lsr x1, x1, #0";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_And
-                   (BExp_Const (Imm64 18446744073709551615w))
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
                    (BExp_Den (BVar "R1" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9AC32441 (lsr x1, x2, x3) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 36w; 195w; 154w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 36w; 195w; 154w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "lsr x1, x2, x3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "lsr x1, x2, x3";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_RightShift
@@ -1029,58 +1035,58 @@ D340FC21 (lsr x1, x1, #0) @ 0x10030 - OK
                    (BExp_BinExp BIExp_And (BExp_Const (Imm64 63w))
                       (BExp_Den (BVar "R3" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 D37BE841 (lsl x1, x2, #5) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 232w; 123w; 211w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 232w; 123w; 211w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "lsl x1, x2, #5";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "lsl x1, x2, #5";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_And
-                   (BExp_Const (Imm64 18446744073709551615w))
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
                    (BExp_BinExp BIExp_LeftShift
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))
                       (BExp_Const (Imm64 5w))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 D340FC41 (lsl x1, x2, #0) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 252w; 64w; 211w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 252w; 64w; 211w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "lsl x1, x2, #0";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "lsl x1, x2, #0";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_And
-                   (BExp_Const (Imm64 18446744073709551615w))
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 D340FC21 (lsl x1, x1, #0) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[33w; 252w; 64w; 211w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[33w; 252w; 64w; 211w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "lsl x1, x1, #0";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "lsl x1, x1, #0";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_And
-                   (BExp_Const (Imm64 18446744073709551615w))
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
                    (BExp_Den (BVar "R1" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9AC32041 (lsl x1, x2, x3) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 32w; 195w; 154w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 32w; 195w; 154w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "lsl x1, x2, x3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "lsl x1, x2, x3";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_LeftShift
@@ -1088,85 +1094,85 @@ D340FC21 (lsl x1, x1, #0) @ 0x10030 - OK
                    (BExp_BinExp BIExp_And (BExp_Const (Imm64 63w))
                       (BExp_Den (BVar "R3" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9345FC41 (asr x1, x2, #5) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 252w; 69w; 147w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 252w; 69w; 147w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "asr x1, x2, #5";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "asr x1, x2, #5";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Or
                    (BExp_BinExp BIExp_And
-                      (BExp_Const (Imm64 576460752303423487w))
+                      (BExp_Const (Imm64 0x7FFFFFFFFFFFFFFw))
                       (BExp_BinExp BIExp_And
-                         (BExp_Const (Imm64 18446744073709551615w))
+                         (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
                          (BExp_ror Bit64
                             (BExp_Den (BVar "R2" (BType_Imm Bit64))) 5)))
                    (BExp_BinExp BIExp_And
-                      (BExp_Const (Imm64 17870283321406128128w))
+                      (BExp_Const (Imm64 0xF800000000000000w))
                       (BExp_IfThenElse
                          (BExp_MSB Bit64
                             (BExp_Den (BVar "R2" (BType_Imm Bit64))))
-                         (BExp_Const (Imm64 18446744073709551615w))
+                         (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
                          (BExp_Const (Imm64 0w)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9340FC41 (asr x1, x2, #0) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 252w; 64w; 147w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 252w; 64w; 147w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "asr x1, x2, #0";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "asr x1, x2, #0";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Or
                    (BExp_BinExp BIExp_And
-                      (BExp_Const (Imm64 18446744073709551615w))
+                      (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
                       (BExp_Den (BVar "R2" (BType_Imm Bit64))))
                    (BExp_BinExp BIExp_And
                       (BExp_UnaryExp BIExp_Not
-                         (BExp_Const (Imm64 18446744073709551615w)))
+                         (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw)))
                       (BExp_IfThenElse
                          (BExp_MSB Bit64
                             (BExp_Den (BVar "R2" (BType_Imm Bit64))))
-                         (BExp_Const (Imm64 18446744073709551615w))
+                         (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
                          (BExp_Const (Imm64 0w)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9340FC21 (asr x1, x1, #0) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[33w; 252w; 64w; 147w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[33w; 252w; 64w; 147w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "asr x1, x1, #0";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "asr x1, x1, #0";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Or
                    (BExp_BinExp BIExp_And
-                      (BExp_Const (Imm64 18446744073709551615w))
+                      (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
                       (BExp_Den (BVar "R1" (BType_Imm Bit64))))
                    (BExp_BinExp BIExp_And
                       (BExp_UnaryExp BIExp_Not
-                         (BExp_Const (Imm64 18446744073709551615w)))
+                         (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw)))
                       (BExp_IfThenElse
                          (BExp_MSB Bit64
                             (BExp_Den (BVar "R1" (BType_Imm Bit64))))
-                         (BExp_Const (Imm64 18446744073709551615w))
+                         (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
                          (BExp_Const (Imm64 0w)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9AC32841 (asr x1, x2, x3) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 40w; 195w; 154w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 40w; 195w; 154w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "asr x1, x2, x3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "asr x1, x2, x3";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_SignedRightShift
@@ -1174,89 +1180,89 @@ D340FC21 (lsl x1, x1, #0) @ 0x10030 - OK
                    (BExp_BinExp BIExp_And (BExp_Const (Imm64 63w))
                       (BExp_Den (BVar "R3" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9AC32C41 (ror x1, x2, x3) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 44w; 195w; 154w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 44w; 195w; 154w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ror x1, x2, x3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ror x1, x2, x3";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_ror_exp Bit64 (BExp_Den (BVar "R2" (BType_Imm Bit64)))
                    (BExp_Den (BVar "R3" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 93C20041 (ror x1, x2, #0) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 0w; 194w; 147w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 0w; 194w; 147w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ror x1, x2, #0";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ror x1, x2, #0";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Den (BVar "R2" (BType_Imm Bit64)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 93C20841 (ror x1, x2, #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 8w; 194w; 147w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 8w; 194w; 147w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ror x1, x2, #2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ror x1, x2, #2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_ror Bit64 (BExp_Den (BVar "R2" (BType_Imm Bit64))) 2)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 93C28041 (ror x1, x2, #32) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 128w; 194w; 147w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 128w; 194w; 147w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ror x1, x2, #32";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ror x1, x2, #32";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_ror Bit64 (BExp_Den (BVar "R2" (BType_Imm Bit64))) 32)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 93C2FC41 (ror x1, x2, #63) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 252w; 194w; 147w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 252w; 194w; 147w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ror x1, x2, #63";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ror x1, x2, #63";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_ror Bit64 (BExp_Den (BVar "R2" (BType_Imm Bit64))) 63)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 13820041 (ror w1, w2, #0) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 0w; 130w; 19w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 0w; 130w; 19w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ror w1, w2, #0";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ror w1, w2, #0";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Cast BIExp_LowCast
                       (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 13820841 (ror w1, w2, #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 8w; 130w; 19w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 8w; 130w; 19w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ror w1, w2, #2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ror w1, w2, #2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -1265,26 +1271,26 @@ D340FC21 (lsl x1, x1, #0) @ 0x10030 - OK
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32) 2)
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 54000000 (l: b.eq l) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[0w; 0w; 0w; 84w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[0w; 0w; 0w; 84w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "l: b.eq l";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "l: b.eq l";
            bb_statements := [];
            bb_last_statement :=
              BStmt_CJmp (BExp_Den (BVar "ProcState_Z" BType_Bool))
-               (BLE_Label (BL_Address (Imm64 65584w)))
-               (BLE_Label (BL_Address (Imm64 65588w)))|>])
+               (BLE_Label (BL_Address (Imm64 0x10030w)))
+               (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 35000000 (l: cbnz w0, l) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[0w; 0w; 0w; 53w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[0w; 0w; 0w; 53w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "l: cbnz w0, l";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "l: cbnz w0, l";
            bb_statements := [];
            bb_last_statement :=
              BStmt_CJmp
@@ -1292,60 +1298,60 @@ D340FC21 (lsl x1, x1, #0) @ 0x10030 - OK
                   (BExp_Cast BIExp_LowCast
                      (BExp_Den (BVar "R0" (BType_Imm Bit64))) Bit32)
                   (BExp_Const (Imm32 0w)))
-               (BLE_Label (BL_Address (Imm64 65584w)))
-               (BLE_Label (BL_Address (Imm64 65588w)))|>])
+               (BLE_Label (BL_Address (Imm64 0x10030w)))
+               (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 B5000000 (l: cbnz x0, l) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[0w; 0w; 0w; 181w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[0w; 0w; 0w; 181w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "l: cbnz x0, l";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "l: cbnz x0, l";
            bb_statements := [];
            bb_last_statement :=
              BStmt_CJmp
                (BExp_BinPred BIExp_Equal
                   (BExp_Den (BVar "R0" (BType_Imm Bit64)))
                   (BExp_Const (Imm64 0w)))
-               (BLE_Label (BL_Address (Imm64 65584w)))
-               (BLE_Label (BL_Address (Imm64 65588w)))|>])
+               (BLE_Label (BL_Address (Imm64 0x10030w)))
+               (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 37180000 (l: tbnz w0, #3, l) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[0w; 0w; 24w; 55w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[0w; 0w; 24w; 55w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "l: tbnz w0, #3, l";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "l: tbnz w0, #3, l";
            bb_statements := [];
            bb_last_statement :=
              BStmt_CJmp
                (BExp_word_bit Bit32
                   (BExp_Cast BIExp_LowCast
                      (BExp_Den (BVar "R0" (BType_Imm Bit64))) Bit32) 3)
-               (BLE_Label (BL_Address (Imm64 65584w)))
-               (BLE_Label (BL_Address (Imm64 65588w)))|>])
+               (BLE_Label (BL_Address (Imm64 0x10030w)))
+               (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 37180000 (l: tbnz x0, #3, l) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[0w; 0w; 24w; 55w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[0w; 0w; 24w; 55w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "l: tbnz x0, #3, l";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "l: tbnz x0, #3, l";
            bb_statements := [];
            bb_last_statement :=
              BStmt_CJmp
                (BExp_word_bit Bit32
                   (BExp_Cast BIExp_LowCast
                      (BExp_Den (BVar "R0" (BType_Imm Bit64))) Bit32) 3)
-               (BLE_Label (BL_Address (Imm64 65584w)))
-               (BLE_Label (BL_Address (Imm64 65588w)))|>])
+               (BLE_Label (BL_Address (Imm64 0x10030w)))
+               (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 34000000 (l: cbz w0, l) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[0w; 0w; 0w; 52w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[0w; 0w; 0w; 52w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "l: cbz w0, l";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "l: cbz w0, l";
            bb_statements := [];
            bb_last_statement :=
              BStmt_CJmp
@@ -1353,60 +1359,60 @@ B5000000 (l: cbnz x0, l) @ 0x10030 - OK
                   (BExp_Cast BIExp_LowCast
                      (BExp_Den (BVar "R0" (BType_Imm Bit64))) Bit32)
                   (BExp_Const (Imm32 0w)))
-               (BLE_Label (BL_Address (Imm64 65584w)))
-               (BLE_Label (BL_Address (Imm64 65588w)))|>])
+               (BLE_Label (BL_Address (Imm64 0x10030w)))
+               (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 B4000000 (l: cbz x0, l) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[0w; 0w; 0w; 180w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[0w; 0w; 0w; 180w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "l: cbz x0, l";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "l: cbz x0, l";
            bb_statements := [];
            bb_last_statement :=
              BStmt_CJmp
                (BExp_BinPred BIExp_Equal
                   (BExp_Den (BVar "R0" (BType_Imm Bit64)))
                   (BExp_Const (Imm64 0w)))
-               (BLE_Label (BL_Address (Imm64 65584w)))
-               (BLE_Label (BL_Address (Imm64 65588w)))|>])
+               (BLE_Label (BL_Address (Imm64 0x10030w)))
+               (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 36180000 (l: tbz w0, #3, l) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[0w; 0w; 24w; 54w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[0w; 0w; 24w; 54w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "l: tbz w0, #3, l";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "l: tbz w0, #3, l";
            bb_statements := [];
            bb_last_statement :=
              BStmt_CJmp
                (BExp_word_bit Bit32
                   (BExp_Cast BIExp_LowCast
                      (BExp_Den (BVar "R0" (BType_Imm Bit64))) Bit32) 3)
-               (BLE_Label (BL_Address (Imm64 65588w)))
-               (BLE_Label (BL_Address (Imm64 65584w)))|>])
+               (BLE_Label (BL_Address (Imm64 0x10034w)))
+               (BLE_Label (BL_Address (Imm64 0x10030w)))|>])
 
 36180000 (l: tbz x0, #3, l) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[0w; 0w; 24w; 54w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[0w; 0w; 24w; 54w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "l: tbz x0, #3, l";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "l: tbz x0, #3, l";
            bb_statements := [];
            bb_last_statement :=
              BStmt_CJmp
                (BExp_word_bit Bit32
                   (BExp_Cast BIExp_LowCast
                      (BExp_Den (BVar "R0" (BType_Imm Bit64))) Bit32) 3)
-               (BLE_Label (BL_Address (Imm64 65588w)))
-               (BLE_Label (BL_Address (Imm64 65584w)))|>])
+               (BLE_Label (BL_Address (Imm64 0x10034w)))
+               (BLE_Label (BL_Address (Imm64 0x10030w)))|>])
 
 F9400040 (ldr x0, [x2, #0]) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[64w; 0w; 64w; 249w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[64w; 0w; 64w; 249w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ldr x0, [x2, #0]";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ldr x0, [x2, #0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_Aligned Bit64 3
@@ -1416,63 +1422,62 @@ F9400040 (ldr x0, [x2, #0]) @ 0x10030 - OK
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))) BEnd_LittleEndian
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 D378DC40 (lsl x0, x2, #8) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[64w; 220w; 120w; 211w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[64w; 220w; 120w; 211w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "lsl x0, x2, #8";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "lsl x0, x2, #8";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_And
-                   (BExp_Const (Imm64 18446744073709551615w))
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
                    (BExp_BinExp BIExp_LeftShift
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))
                       (BExp_Const (Imm64 8w))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 D378DC40 (lsl x0, x2, #8) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[64w; 220w; 120w; 211w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[64w; 220w; 120w; 211w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "lsl x0, x2, #8";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "lsl x0, x2, #8";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_And
-                   (BExp_Const (Imm64 18446744073709551615w))
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
                    (BExp_BinExp BIExp_LeftShift
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))
                       (BExp_Const (Imm64 8w))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 D348FC40 (lsr x0, x2, #8) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[64w; 252w; 72w; 211w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[64w; 252w; 72w; 211w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "lsr x0, x2, #8";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "lsr x0, x2, #8";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
-                (BExp_BinExp BIExp_And
-                   (BExp_Const (Imm64 72057594037927935w))
+                (BExp_BinExp BIExp_And (BExp_Const (Imm64 0xFFFFFFFFFFFFFFw))
                    (BExp_BinExp BIExp_And
-                      (BExp_Const (Imm64 18446744073709551615w))
+                      (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
                       (BExp_ror Bit64
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))) 8)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 F9000440 (str x0, [x2, #8]) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[64w; 4w; 0w; 249w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[64w; 4w; 0w; 249w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "str x0, [x2, #8]";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "str x0, [x2, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_Aligned Bit64 3
@@ -1489,14 +1494,14 @@ F9000440 (str x0, [x2, #8]) @ 0x10030 - OK
                       (BExp_Const (Imm64 8w))) BEnd_LittleEndian
                    (BExp_Den (BVar "R0" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 A9400861 (ldp x1, x2, [x3]) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[97w; 8w; 64w; 169w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[97w; 8w; 64w; 169w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ldp x1, x2, [x3]";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ldp x1, x2, [x3]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_Aligned Bit64 3
@@ -1511,14 +1516,14 @@ A9400861 (ldp x1, x2, [x3]) @ 0x10030 - OK
                       (BExp_Den (BVar "R3" (BType_Imm Bit64)))
                       (BExp_Const (Imm64 8w))) BEnd_LittleEndian Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 29400861 (ldp w1, w2, [x3]) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[97w; 8w; 64w; 41w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[97w; 8w; 64w; 41w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ldp w1, w2, [x3]";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ldp w1, w2, [x3]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_Aligned Bit64 2
@@ -1536,14 +1541,14 @@ A9400861 (ldp x1, x2, [x3]) @ 0x10030 - OK
                          (BExp_Const (Imm64 4w))) BEnd_LittleEndian Bit32)
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 A9000861 (stp x1, x2, [x3]) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[97w; 8w; 0w; 169w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[97w; 8w; 0w; 169w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "stp x1, x2, [x3]";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "stp x1, x2, [x3]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_Aligned Bit64 3
@@ -1562,14 +1567,14 @@ A9000861 (stp x1, x2, [x3]) @ 0x10030 - OK
                       (BExp_Const (Imm64 8w))) BEnd_LittleEndian
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 29000861 (stp w1, w2, [x3]) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[97w; 8w; 0w; 41w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[97w; 8w; 0w; 41w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "stp w1, w2, [x3]";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "stp w1, w2, [x3]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_Aligned Bit64 2
@@ -1590,14 +1595,14 @@ A9000861 (stp x1, x2, [x3]) @ 0x10030 - OK
                    (BExp_Cast BIExp_LowCast
                       (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 69400861 (ldpsw x1, x2, [x3]) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[97w; 8w; 64w; 105w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[97w; 8w; 64w; 105w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ldpsw x1, x2, [x3]";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ldpsw x1, x2, [x3]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_Aligned Bit64 2
@@ -1615,182 +1620,182 @@ A9000861 (stp x1, x2, [x3]) @ 0x10030 - OK
                          (BExp_Const (Imm64 4w))) BEnd_LittleEndian Bit32)
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 52800080 (movz w0, #4) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[128w; 0w; 128w; 82w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[128w; 0w; 128w; 82w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "movz w0, #4";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "movz w0, #4";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_Const (Imm64 4w))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 D2800080 (movz x0, #4) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[128w; 0w; 128w; 210w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[128w; 0w; 128w; 210w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "movz x0, #4";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "movz x0, #4";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_Const (Imm64 4w))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 92800080 (movn x0, #4) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[128w; 0w; 128w; 146w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[128w; 0w; 128w; 146w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "movn x0, #4";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "movn x0, #4";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
-                (BExp_Const (Imm64 18446744073709551611w))];
+                (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFBw))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 12800080 (movn w0, #4) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[128w; 0w; 128w; 18w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[128w; 0w; 128w; 18w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "movn w0, #4";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "movn w0, #4";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
-                (BExp_Const (Imm64 4294967291w))];
+                (BExp_Const (Imm64 0xFFFFFFFBw))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 72800080 (movk w0, #4) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[128w; 0w; 128w; 114w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[128w; 0w; 128w; 114w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "movk w0, #4";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "movk w0, #4";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_BinExp BIExp_Or
-                      (BExp_BinExp BIExp_And (BExp_Const (Imm32 4294901760w))
+                      (BExp_BinExp BIExp_And (BExp_Const (Imm32 0xFFFF0000w))
                          (BExp_Cast BIExp_LowCast
                             (BExp_Den (BVar "R0" (BType_Imm Bit64))) Bit32))
                       (BExp_Const (Imm32 4w))) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 F2800080 (movk x0, #4) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[128w; 0w; 128w; 242w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[128w; 0w; 128w; 242w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "movk x0, #4";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "movk x0, #4";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Or
                    (BExp_BinExp BIExp_And
-                      (BExp_Const (Imm64 18446744073709486080w))
+                      (BExp_Const (Imm64 0xFFFFFFFFFFFF0000w))
                       (BExp_Den (BVar "R0" (BType_Imm Bit64))))
                    (BExp_Const (Imm64 4w)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 33021041 (bfm w1, w2, #2, #4) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 16w; 2w; 51w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 16w; 2w; 51w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "bfm w1, w2, #2, #4";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "bfm w1, w2, #2, #4";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_BinExp BIExp_Or
-                      (BExp_BinExp BIExp_And (BExp_Const (Imm32 4294967288w))
+                      (BExp_BinExp BIExp_And (BExp_Const (Imm32 0xFFFFFFF8w))
                          (BExp_Cast BIExp_LowCast
                             (BExp_Den (BVar "R1" (BType_Imm Bit64))) Bit32))
                       (BExp_BinExp BIExp_And (BExp_Const (Imm32 7w))
                          (BExp_BinExp BIExp_Or
                             (BExp_BinExp BIExp_And
-                               (BExp_Const (Imm32 1073741816w))
+                               (BExp_Const (Imm32 0x3FFFFFF8w))
                                (BExp_Cast BIExp_LowCast
                                   (BExp_Den (BVar "R1" (BType_Imm Bit64)))
                                   Bit32))
                             (BExp_BinExp BIExp_And
-                               (BExp_Const (Imm32 3221225479w))
+                               (BExp_Const (Imm32 0xC0000007w))
                                (BExp_ror Bit32
                                   (BExp_Cast BIExp_LowCast
                                      (BExp_Den (BVar "R2" (BType_Imm Bit64)))
                                      Bit32) 2))))) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 33022041 (bfm w1, w2, #2, #8) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 32w; 2w; 51w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 32w; 2w; 51w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "bfm w1, w2, #2, #8";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "bfm w1, w2, #2, #8";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_BinExp BIExp_Or
-                      (BExp_BinExp BIExp_And (BExp_Const (Imm32 4294967168w))
+                      (BExp_BinExp BIExp_And (BExp_Const (Imm32 0xFFFFFF80w))
                          (BExp_Cast BIExp_LowCast
                             (BExp_Den (BVar "R1" (BType_Imm Bit64))) Bit32))
                       (BExp_BinExp BIExp_And (BExp_Const (Imm32 127w))
                          (BExp_BinExp BIExp_Or
                             (BExp_BinExp BIExp_And
-                               (BExp_Const (Imm32 1073741696w))
+                               (BExp_Const (Imm32 0x3FFFFF80w))
                                (BExp_Cast BIExp_LowCast
                                   (BExp_Den (BVar "R1" (BType_Imm Bit64)))
                                   Bit32))
                             (BExp_BinExp BIExp_And
-                               (BExp_Const (Imm32 3221225599w))
+                               (BExp_Const (Imm32 0xC000007Fw))
                                (BExp_ror Bit32
                                   (BExp_Cast BIExp_LowCast
                                      (BExp_Den (BVar "R2" (BType_Imm Bit64)))
                                      Bit32) 2))))) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 33080841 (bfm w1, w2, #8, #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 8w; 8w; 51w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 8w; 8w; 51w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "bfm w1, w2, #8, #2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "bfm w1, w2, #8, #2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_BinExp BIExp_Or
-                      (BExp_BinExp BIExp_And (BExp_Const (Imm32 4160749568w))
+                      (BExp_BinExp BIExp_And (BExp_Const (Imm32 0xF8000000w))
                          (BExp_Cast BIExp_LowCast
                             (BExp_Den (BVar "R1" (BType_Imm Bit64))) Bit32))
-                      (BExp_BinExp BIExp_And (BExp_Const (Imm32 134217727w))
+                      (BExp_BinExp BIExp_And (BExp_Const (Imm32 0x7FFFFFFw))
                          (BExp_BinExp BIExp_Or
                             (BExp_BinExp BIExp_And
-                               (BExp_Const (Imm32 4177526783w))
+                               (BExp_Const (Imm32 0xF8FFFFFFw))
                                (BExp_Cast BIExp_LowCast
                                   (BExp_Den (BVar "R1" (BType_Imm Bit64)))
                                   Bit32))
                             (BExp_BinExp BIExp_And
-                               (BExp_Const (Imm32 117440512w))
+                               (BExp_Const (Imm32 0x7000000w))
                                (BExp_ror Bit32
                                   (BExp_Cast BIExp_LowCast
                                      (BExp_Den (BVar "R2" (BType_Imm Bit64)))
                                      Bit32) 8))))) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 13021041 (sbfm w1, w2, #2, #4) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 16w; 2w; 19w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 16w; 2w; 19w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "sbfm w1, w2, #2, #4";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "sbfm w1, w2, #2, #4";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -1800,22 +1805,22 @@ F2800080 (movk x0, #4) @ 0x10030 - OK
                             (BExp_Cast BIExp_LowCast
                                (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)
                             2))
-                      (BExp_BinExp BIExp_And (BExp_Const (Imm32 4294967288w))
+                      (BExp_BinExp BIExp_And (BExp_Const (Imm32 0xFFFFFFF8w))
                          (BExp_IfThenElse
                             (BExp_word_bit Bit32
                                (BExp_Cast BIExp_LowCast
                                   (BExp_Den (BVar "R2" (BType_Imm Bit64)))
-                                  Bit32) 4) (BExp_Const (Imm32 4294967295w))
+                                  Bit32) 4) (BExp_Const (Imm32 0xFFFFFFFFw))
                             (BExp_Const (Imm32 0w))))) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 13022041 (sbfm w1, w2, #2, #8) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 32w; 2w; 19w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 32w; 2w; 19w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "sbfm w1, w2, #2, #8";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "sbfm w1, w2, #2, #8";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -1825,47 +1830,47 @@ F2800080 (movk x0, #4) @ 0x10030 - OK
                             (BExp_Cast BIExp_LowCast
                                (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)
                             2))
-                      (BExp_BinExp BIExp_And (BExp_Const (Imm32 4294967168w))
+                      (BExp_BinExp BIExp_And (BExp_Const (Imm32 0xFFFFFF80w))
                          (BExp_IfThenElse
                             (BExp_word_bit Bit32
                                (BExp_Cast BIExp_LowCast
                                   (BExp_Den (BVar "R2" (BType_Imm Bit64)))
-                                  Bit32) 8) (BExp_Const (Imm32 4294967295w))
+                                  Bit32) 8) (BExp_Const (Imm32 0xFFFFFFFFw))
                             (BExp_Const (Imm32 0w))))) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 13080841 (sbfm w1, w2, #8, #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 8w; 8w; 19w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 8w; 8w; 19w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "sbfm w1, w2, #8, #2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "sbfm w1, w2, #8, #2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_BinExp BIExp_Or
-                      (BExp_BinExp BIExp_And (BExp_Const (Imm32 117440512w))
+                      (BExp_BinExp BIExp_And (BExp_Const (Imm32 0x7000000w))
                          (BExp_ror Bit32
                             (BExp_Cast BIExp_LowCast
                                (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)
                             8))
-                      (BExp_BinExp BIExp_And (BExp_Const (Imm32 4160749568w))
+                      (BExp_BinExp BIExp_And (BExp_Const (Imm32 0xF8000000w))
                          (BExp_IfThenElse
                             (BExp_word_bit Bit32
                                (BExp_Cast BIExp_LowCast
                                   (BExp_Den (BVar "R2" (BType_Imm Bit64)))
-                                  Bit32) 2) (BExp_Const (Imm32 4294967295w))
+                                  Bit32) 2) (BExp_Const (Imm32 0xFFFFFFFFw))
                             (BExp_Const (Imm32 0w))))) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 53021041 (ubfm w1, w2, #2, #4) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 16w; 2w; 83w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 16w; 2w; 83w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ubfm w1, w2, #2, #4";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ubfm w1, w2, #2, #4";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -1875,14 +1880,14 @@ F2800080 (movk x0, #4) @ 0x10030 - OK
                             (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32) 2))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 53022041 (ubfm w1, w2, #2, #8) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 32w; 2w; 83w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 32w; 2w; 83w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ubfm w1, w2, #2, #8";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ubfm w1, w2, #2, #8";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -1892,31 +1897,31 @@ F2800080 (movk x0, #4) @ 0x10030 - OK
                             (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32) 2))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 53080841 (ubfm w1, w2, #8, #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 8w; 8w; 83w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 8w; 8w; 83w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ubfm w1, w2, #8, #2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ubfm w1, w2, #8, #2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
-                   (BExp_BinExp BIExp_And (BExp_Const (Imm32 117440512w))
+                   (BExp_BinExp BIExp_And (BExp_Const (Imm32 0x7000000w))
                       (BExp_ror Bit32
                          (BExp_Cast BIExp_LowCast
                             (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32) 8))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 13830841 (extr w1, w2, w3, #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 8w; 131w; 19w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 8w; 131w; 19w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "extr w1, w2, w3, #2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "extr w1, w2, w3, #2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -1927,40 +1932,40 @@ F2800080 (movk x0, #4) @ 0x10030 - OK
                          (BExp_Den (BVar "R3" (BType_Imm Bit64))) Bit32) 2)
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 93C30841 (extr x1, x2, x3, #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 8w; 195w; 147w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 8w; 195w; 147w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "extr x1, x2, x3, #2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "extr x1, x2, x3, #2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_extr Bit64 (BExp_Den (BVar "R2" (BType_Imm Bit64)))
                    (BExp_Den (BVar "R3" (BType_Imm Bit64))) 2)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 93C20861 (extr x1, x3, x2, #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[97w; 8w; 194w; 147w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[97w; 8w; 194w; 147w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "extr x1, x3, x2, #2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "extr x1, x3, x2, #2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_extr Bit64 (BExp_Den (BVar "R3" (BType_Imm Bit64)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))) 2)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 13003C41 (sxth w1, w2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 60w; 0w; 19w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 60w; 0w; 19w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "sxth w1, w2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "sxth w1, w2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -1969,14 +1974,14 @@ F2800080 (movk x0, #4) @ 0x10030 - OK
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit16)
                       Bit32) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 13001C41 (sxtb w1, w2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 28w; 0w; 19w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 28w; 0w; 19w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "sxtb w1, w2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "sxtb w1, w2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -1984,43 +1989,43 @@ F2800080 (movk x0, #4) @ 0x10030 - OK
                       (BExp_BinExp BIExp_And (BExp_Const (Imm32 255w))
                          (BExp_Cast BIExp_LowCast
                             (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32))
-                      (BExp_BinExp BIExp_And (BExp_Const (Imm32 4294967040w))
+                      (BExp_BinExp BIExp_And (BExp_Const (Imm32 0xFFFFFF00w))
                          (BExp_IfThenElse
                             (BExp_word_bit Bit32
                                (BExp_Cast BIExp_LowCast
                                   (BExp_Den (BVar "R2" (BType_Imm Bit64)))
-                                  Bit32) 7) (BExp_Const (Imm32 4294967295w))
+                                  Bit32) 7) (BExp_Const (Imm32 0xFFFFFFFFw))
                             (BExp_Const (Imm32 0w))))) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 93407C41 (sxtw x1, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 124w; 64w; 147w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 124w; 64w; 147w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "sxtw x1, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "sxtw x1, x2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Or
-                   (BExp_BinExp BIExp_And (BExp_Const (Imm64 4294967295w))
+                   (BExp_BinExp BIExp_And (BExp_Const (Imm64 0xFFFFFFFFw))
                       (BExp_Den (BVar "R2" (BType_Imm Bit64))))
                    (BExp_BinExp BIExp_And
-                      (BExp_Const (Imm64 18446744069414584320w))
+                      (BExp_Const (Imm64 0xFFFFFFFF00000000w))
                       (BExp_IfThenElse
                          (BExp_word_bit Bit64
                             (BExp_Den (BVar "R2" (BType_Imm Bit64))) 31)
-                         (BExp_Const (Imm64 18446744073709551615w))
+                         (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
                          (BExp_Const (Imm64 0w)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 53003C41 (uxth w1, w2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 60w; 0w; 83w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 60w; 0w; 83w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "uxth w1, w2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "uxth w1, w2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -2029,14 +2034,14 @@ F2800080 (movk x0, #4) @ 0x10030 - OK
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 53001C41 (uxtb w1, w2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 28w; 0w; 83w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 28w; 0w; 83w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "uxtb w1, w2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "uxtb w1, w2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -2045,14 +2050,15 @@ F2800080 (movk x0, #4) @ 0x10030 - OK
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 8B230820 (add x0, x1, w3, UXTB #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 8w; 35w; 139w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 8w; 35w; 139w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "add x0, x1, w3, UXTB #2";
+        [<|bb_label :=
+             BL_Address_HC (Imm64 0x10030w) "add x0, x1, w3, UXTB #2";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
@@ -2063,14 +2069,15 @@ F2800080 (movk x0, #4) @ 0x10030 - OK
                             (BExp_Den (BVar "R3" (BType_Imm Bit64))) Bit8)
                          Bit64) (BExp_Const (Imm64 2w))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 8B238820 (add x0, x1, w3, SXTB #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 136w; 35w; 139w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 136w; 35w; 139w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "add x0, x1, w3, SXTB #2";
+        [<|bb_label :=
+             BL_Address_HC (Imm64 0x10030w) "add x0, x1, w3, SXTB #2";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
@@ -2081,15 +2088,15 @@ F2800080 (movk x0, #4) @ 0x10030 - OK
                             (BExp_Den (BVar "R3" (BType_Imm Bit64))) Bit8)
                          Bit64) (BExp_Const (Imm64 2w))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 AB239020 (adds x0, x1, w3, SXTB #4) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 144w; 35w; 171w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 144w; 35w; 171w])
      (BirProgram
         [<|bb_label :=
-             BL_Address_HC (Imm64 65584w) "adds x0, x1, w3, SXTB #4";
+             BL_Address_HC (Imm64 0x10030w) "adds x0, x1, w3, SXTB #4";
            bb_statements :=
              [BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit64)))
@@ -2130,15 +2137,15 @@ AB239020 (adds x0, x1, w3, SXTB #4) @ 0x10030 - OK
                             (BExp_Den (BVar "R3" (BType_Imm Bit64))) Bit8)
                          Bit64) (BExp_Const (Imm64 4w))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 AB238020 (adds x0, x1, w3, SXTB #0) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 128w; 35w; 171w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 128w; 35w; 171w])
      (BirProgram
         [<|bb_label :=
-             BL_Address_HC (Imm64 65584w) "adds x0, x1, w3, SXTB #0";
+             BL_Address_HC (Imm64 0x10030w) "adds x0, x1, w3, SXTB #0";
            bb_statements :=
              [BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit64)))
@@ -2179,14 +2186,15 @@ AB238020 (adds x0, x1, w3, SXTB #0) @ 0x10030 - OK
                             (BExp_Den (BVar "R3" (BType_Imm Bit64))) Bit8)
                          Bit64) (BExp_Const (Imm64 0w))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 CB230820 (sub x0, x1, w3, UXTB #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 8w; 35w; 203w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 8w; 35w; 203w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "sub x0, x1, w3, UXTB #2";
+        [<|bb_label :=
+             BL_Address_HC (Imm64 0x10030w) "sub x0, x1, w3, UXTB #2";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Minus
@@ -2197,14 +2205,15 @@ CB230820 (sub x0, x1, w3, UXTB #2) @ 0x10030 - OK
                             (BExp_Den (BVar "R3" (BType_Imm Bit64))) Bit8)
                          Bit64) (BExp_Const (Imm64 2w))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 CB238820 (sub x0, x1, w3, SXTB #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 136w; 35w; 203w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 136w; 35w; 203w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "sub x0, x1, w3, SXTB #2";
+        [<|bb_label :=
+             BL_Address_HC (Imm64 0x10030w) "sub x0, x1, w3, SXTB #2";
            bb_statements :=
              [BStmt_Assign (BVar "R0" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Minus
@@ -2215,15 +2224,15 @@ CB238820 (sub x0, x1, w3, SXTB #2) @ 0x10030 - OK
                             (BExp_Den (BVar "R3" (BType_Imm Bit64))) Bit8)
                          Bit64) (BExp_Const (Imm64 2w))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 EB239020 (subs x0, x1, w3, SXTB #4) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 144w; 35w; 235w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 144w; 35w; 235w])
      (BirProgram
         [<|bb_label :=
-             BL_Address_HC (Imm64 65584w) "subs x0, x1, w3, SXTB #4";
+             BL_Address_HC (Imm64 0x10030w) "subs x0, x1, w3, SXTB #4";
            bb_statements :=
              [BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R1" (BType_Imm Bit64)))
@@ -2264,15 +2273,15 @@ EB239020 (subs x0, x1, w3, SXTB #4) @ 0x10030 - OK
                             (BExp_Den (BVar "R3" (BType_Imm Bit64))) Bit8)
                          Bit64) (BExp_Const (Imm64 4w))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 EB238020 (subs x0, x1, w3, SXTB #0) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 128w; 35w; 235w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 128w; 35w; 235w])
      (BirProgram
         [<|bb_label :=
-             BL_Address_HC (Imm64 65584w) "subs x0, x1, w3, SXTB #0";
+             BL_Address_HC (Imm64 0x10030w) "subs x0, x1, w3, SXTB #0";
            bb_statements :=
              [BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R1" (BType_Imm Bit64)))
@@ -2313,14 +2322,15 @@ EB238020 (subs x0, x1, w3, SXTB #0) @ 0x10030 - OK
                             (BExp_Den (BVar "R3" (BType_Imm Bit64))) Bit8)
                          Bit64) (BExp_Const (Imm64 0w))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 8A230841 (bic x1, x2, x3, LSL #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 8w; 35w; 138w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 8w; 35w; 138w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "bic x1, x2, x3, LSL #2";
+        [<|bb_label :=
+             BL_Address_HC (Imm64 0x10030w) "bic x1, x2, x3, LSL #2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_And
@@ -2330,14 +2340,15 @@ EB238020 (subs x0, x1, w3, SXTB #0) @ 0x10030 - OK
                          (BExp_Const (Imm64 2w))))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 8A630841 (bic x1, x2, x3, LSR #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 8w; 99w; 138w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 8w; 99w; 138w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "bic x1, x2, x3, LSR #2";
+        [<|bb_label :=
+             BL_Address_HC (Imm64 0x10030w) "bic x1, x2, x3, LSR #2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_And
@@ -2347,14 +2358,15 @@ EB238020 (subs x0, x1, w3, SXTB #0) @ 0x10030 - OK
                          (BExp_Const (Imm64 2w))))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 8AA30841 (bic x1, x2, x3, ASR #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 8w; 163w; 138w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 8w; 163w; 138w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "bic x1, x2, x3, ASR #2";
+        [<|bb_label :=
+             BL_Address_HC (Imm64 0x10030w) "bic x1, x2, x3, ASR #2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_And
@@ -2364,26 +2376,27 @@ EB238020 (subs x0, x1, w3, SXTB #0) @ 0x10030 - OK
                          (BExp_Const (Imm64 2w))))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 8A220041 (bic x1, x2, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 0w; 34w; 138w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 0w; 34w; 138w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "bic x1, x2, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "bic x1, x2, x2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Const (Imm64 0w))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 EA230841 (bics x1, x2, x3, LSL #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 8w; 35w; 234w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 8w; 35w; 234w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "bics x1, x2, x3, LSL #2";
+        [<|bb_label :=
+             BL_Address_HC (Imm64 0x10030w) "bics x1, x2, x3, LSL #2";
            bb_statements :=
              [BStmt_Assign (BVar "ProcState_C" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "ProcState_N" BType_Bool)
@@ -2412,14 +2425,15 @@ EA230841 (bics x1, x2, x3, LSL #2) @ 0x10030 - OK
                          (BExp_Const (Imm64 2w))))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 EA630841 (bics x1, x2, x3, LSR #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 8w; 99w; 234w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 8w; 99w; 234w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "bics x1, x2, x3, LSR #2";
+        [<|bb_label :=
+             BL_Address_HC (Imm64 0x10030w) "bics x1, x2, x3, LSR #2";
            bb_statements :=
              [BStmt_Assign (BVar "ProcState_C" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "ProcState_N" BType_Bool)
@@ -2448,14 +2462,15 @@ EA630841 (bics x1, x2, x3, LSR #2) @ 0x10030 - OK
                          (BExp_Const (Imm64 2w))))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 EAA30841 (bics x1, x2, x3, ASR #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 8w; 163w; 234w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 8w; 163w; 234w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "bics x1, x2, x3, ASR #2";
+        [<|bb_label :=
+             BL_Address_HC (Imm64 0x10030w) "bics x1, x2, x3, ASR #2";
            bb_statements :=
              [BStmt_Assign (BVar "ProcState_C" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "ProcState_N" BType_Bool)
@@ -2484,14 +2499,14 @@ EAA30841 (bics x1, x2, x3, ASR #2) @ 0x10030 - OK
                          (BExp_Const (Imm64 2w))))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 EA220041 (bics x1, x2, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 0w; 34w; 234w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 0w; 34w; 234w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "bics x1, x2, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "bics x1, x2, x2";
            bb_statements :=
              [BStmt_Assign (BVar "ProcState_C" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "ProcState_N" BType_Bool)
@@ -2501,14 +2516,15 @@ EA220041 (bics x1, x2, x2) @ 0x10030 - OK
               BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Const (Imm64 0w))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 CA230841 (eon x1, x2, x3, LSL #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 8w; 35w; 202w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 8w; 35w; 202w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "eon x1, x2, x3, LSL #2";
+        [<|bb_label :=
+             BL_Address_HC (Imm64 0x10030w) "eon x1, x2, x3, LSL #2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_UnaryExp BIExp_Not
@@ -2518,14 +2534,15 @@ CA230841 (eon x1, x2, x3, LSL #2) @ 0x10030 - OK
                          (BExp_Den (BVar "R3" (BType_Imm Bit64)))
                          (BExp_Const (Imm64 2w)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 CA630841 (eon x1, x2, x3, LSR #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 8w; 99w; 202w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 8w; 99w; 202w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "eon x1, x2, x3, LSR #2";
+        [<|bb_label :=
+             BL_Address_HC (Imm64 0x10030w) "eon x1, x2, x3, LSR #2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_UnaryExp BIExp_Not
@@ -2535,14 +2552,15 @@ CA630841 (eon x1, x2, x3, LSR #2) @ 0x10030 - OK
                          (BExp_Den (BVar "R3" (BType_Imm Bit64)))
                          (BExp_Const (Imm64 2w)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 CAA30841 (eon x1, x2, x3, ASR #2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 8w; 163w; 202w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 8w; 163w; 202w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "eon x1, x2, x3, ASR #2";
+        [<|bb_label :=
+             BL_Address_HC (Imm64 0x10030w) "eon x1, x2, x3, ASR #2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_UnaryExp BIExp_Not
@@ -2552,26 +2570,26 @@ CAA30841 (eon x1, x2, x3, ASR #2) @ 0x10030 - OK
                          (BExp_Den (BVar "R3" (BType_Imm Bit64)))
                          (BExp_Const (Imm64 2w)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 CA220041 (eon x1, x2, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 0w; 34w; 202w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 0w; 34w; 202w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "eon x1, x2, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "eon x1, x2, x2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_UnaryExp BIExp_ChangeSign (BExp_Const (Imm64 1w)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 1AC32041 (lslv w1, w2, w3) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 32w; 195w; 26w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 32w; 195w; 26w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "lslv w1, w2, w3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "lslv w1, w2, w3";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -2583,14 +2601,14 @@ CA220041 (eon x1, x2, x2) @ 0x10030 - OK
                             (BExp_Den (BVar "R3" (BType_Imm Bit64))) Bit32)))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9AC32041 (lslv x1, x2, x3) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 32w; 195w; 154w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 32w; 195w; 154w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "lslv x1, x2, x3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "lslv x1, x2, x3";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_LeftShift
@@ -2598,14 +2616,14 @@ CA220041 (eon x1, x2, x2) @ 0x10030 - OK
                    (BExp_BinExp BIExp_And (BExp_Const (Imm64 63w))
                       (BExp_Den (BVar "R3" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 1AC32441 (lsrv w1, w2, w3) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 36w; 195w; 26w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 36w; 195w; 26w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "lsrv w1, w2, w3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "lsrv w1, w2, w3";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -2617,14 +2635,14 @@ CA220041 (eon x1, x2, x2) @ 0x10030 - OK
                             (BExp_Den (BVar "R3" (BType_Imm Bit64))) Bit32)))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9AC32441 (lsrv x1, x2, x3) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 36w; 195w; 154w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 36w; 195w; 154w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "lsrv x1, x2, x3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "lsrv x1, x2, x3";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_RightShift
@@ -2632,14 +2650,14 @@ CA220041 (eon x1, x2, x2) @ 0x10030 - OK
                    (BExp_BinExp BIExp_And (BExp_Const (Imm64 63w))
                       (BExp_Den (BVar "R3" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 1AC32841 (asrv w1, w2, w3) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 40w; 195w; 26w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 40w; 195w; 26w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "asrv w1, w2, w3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "asrv w1, w2, w3";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -2651,14 +2669,14 @@ CA220041 (eon x1, x2, x2) @ 0x10030 - OK
                             (BExp_Den (BVar "R3" (BType_Imm Bit64))) Bit32)))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9AC32841 (asrv x1, x2, x3) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 40w; 195w; 154w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 40w; 195w; 154w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "asrv x1, x2, x3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "asrv x1, x2, x3";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_SignedRightShift
@@ -2666,14 +2684,14 @@ CA220041 (eon x1, x2, x2) @ 0x10030 - OK
                    (BExp_BinExp BIExp_And (BExp_Const (Imm64 63w))
                       (BExp_Den (BVar "R3" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 1AC32C41 (rorv w1, w2, w3) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 44w; 195w; 26w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 44w; 195w; 26w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "rorv w1, w2, w3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "rorv w1, w2, w3";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -2684,27 +2702,27 @@ CA220041 (eon x1, x2, x2) @ 0x10030 - OK
                          (BExp_Den (BVar "R3" (BType_Imm Bit64))) Bit32))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9AC32C41 (rorv x1, x2, x3) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 44w; 195w; 154w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 44w; 195w; 154w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "rorv x1, x2, x3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "rorv x1, x2, x3";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_ror_exp Bit64 (BExp_Den (BVar "R2" (BType_Imm Bit64)))
                    (BExp_Den (BVar "R3" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 5AC01041 (cls w1, w2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 16w; 192w; 90w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 16w; 192w; 90w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "cls w1, w2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "cls w1, w2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -2713,27 +2731,27 @@ CA220041 (eon x1, x2, x2) @ 0x10030 - OK
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 DAC01041 (cls x1, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 16w; 192w; 218w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 16w; 192w; 218w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "cls x1, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "cls x1, x2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_UnaryExp BIExp_CLS
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 5AC01441 (clz w1, w2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 20w; 192w; 90w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 20w; 192w; 90w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "clz w1, w2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "clz w1, w2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -2742,40 +2760,40 @@ DAC01041 (cls x1, x2) @ 0x10030 - OK
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 DAC01441 (clz x1, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 20w; 192w; 218w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 20w; 192w; 218w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "clz x1, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "clz x1, x2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_UnaryExp BIExp_CLZ
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 DAC00041 (rbit x1, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 0w; 192w; 218w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 0w; 192w; 218w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "rbit x1, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "rbit x1, x2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_word_reverse_1_64
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 5AC00041 (rbit w1, w2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 0w; 192w; 90w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 0w; 192w; 90w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "rbit w1, w2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "rbit w1, w2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -2784,14 +2802,14 @@ DAC00041 (rbit x1, x2) @ 0x10030 - OK
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 5AC00841 (rev w1, w2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 8w; 192w; 90w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 8w; 192w; 90w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "rev w1, w2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "rev w1, w2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -2800,27 +2818,27 @@ DAC00041 (rbit x1, x2) @ 0x10030 - OK
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 DAC00C41 (rev x1, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 12w; 192w; 218w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 12w; 192w; 218w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "rev x1, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "rev x1, x2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_word_reverse_8_64
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 5AC00441 (rev16 w1, w2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 4w; 192w; 90w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 4w; 192w; 90w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "rev16 w1, w2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "rev16 w1, w2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -2830,42 +2848,42 @@ DAC00C41 (rev x1, x2) @ 0x10030 - OK
                             (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 DAC00441 (rev16 x1, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 4w; 192w; 218w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 4w; 192w; 218w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "rev16 x1, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "rev16 x1, x2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_word_reverse_16_64
                    (BExp_word_reverse_8_64
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 DAC00841 (rev32 x1, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 8w; 192w; 218w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 8w; 192w; 218w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "rev32 x1, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "rev32 x1, x2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_word_reverse_32_64
                    (BExp_word_reverse_8_64
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 1A830041 (csel w1, w2, w3, EQ) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 0w; 131w; 26w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 0w; 131w; 26w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "csel w1, w2, w3, EQ";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "csel w1, w2, w3, EQ";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -2877,48 +2895,47 @@ DAC00841 (rev32 x1, x2) @ 0x10030 - OK
                          (BExp_Den (BVar "R3" (BType_Imm Bit64))) Bit32))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9A830041 (csel x1, x2, x3, EQ) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 0w; 131w; 154w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 0w; 131w; 154w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "csel x1, x2, x3, EQ";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "csel x1, x2, x3, EQ";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_IfThenElse (BExp_Den (BVar "ProcState_Z" BType_Bool))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64)))
                    (BExp_Den (BVar "R3" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9A83D041 (csel x1, x2, x3, LE) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 208w; 131w; 154w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 208w; 131w; 154w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "csel x1, x2, x3, LE";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "csel x1, x2, x3, LE";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_IfThenElse
-                   (BExp_BinExp BIExp_Or
-                      (BExp_UnaryExp BIExp_Not
-                         (BExp_BinPred BIExp_Equal
-                            (BExp_Den (BVar "ProcState_N" BType_Bool))
-                            (BExp_Den (BVar "ProcState_V" BType_Bool))))
+                   (BExp_BinPred BIExp_LessOrEqual
+                      (BExp_BinPred BIExp_Equal
+                         (BExp_Den (BVar "ProcState_N" BType_Bool))
+                         (BExp_Den (BVar "ProcState_V" BType_Bool)))
                       (BExp_Den (BVar "ProcState_Z" BType_Bool)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64)))
                    (BExp_Den (BVar "R3" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9A83B041 (csel x1, x2, x3, LT) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 176w; 131w; 154w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 176w; 131w; 154w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "csel x1, x2, x3, LT";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "csel x1, x2, x3, LT";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_IfThenElse
@@ -2929,14 +2946,14 @@ DAC00841 (rev32 x1, x2) @ 0x10030 - OK
                    (BExp_Den (BVar "R2" (BType_Imm Bit64)))
                    (BExp_Den (BVar "R3" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9A831041 (csel x1, x2, x3, NE) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 16w; 131w; 154w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 16w; 131w; 154w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "csel x1, x2, x3, NE";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "csel x1, x2, x3, NE";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_IfThenElse
@@ -2945,23 +2962,22 @@ DAC00841 (rev32 x1, x2) @ 0x10030 - OK
                    (BExp_Den (BVar "R2" (BType_Imm Bit64)))
                    (BExp_Den (BVar "R3" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 1A83D441 (csinc w1, w2, w3, LE) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 212w; 131w; 26w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 212w; 131w; 26w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "csinc w1, w2, w3, LE";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "csinc w1, w2, w3, LE";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_IfThenElse
-                      (BExp_BinExp BIExp_Or
-                         (BExp_UnaryExp BIExp_Not
-                            (BExp_BinPred BIExp_Equal
-                               (BExp_Den (BVar "ProcState_N" BType_Bool))
-                               (BExp_Den (BVar "ProcState_V" BType_Bool))))
+                      (BExp_BinPred BIExp_LessOrEqual
+                         (BExp_BinPred BIExp_Equal
+                            (BExp_Den (BVar "ProcState_N" BType_Bool))
+                            (BExp_Den (BVar "ProcState_V" BType_Bool)))
                          (BExp_Den (BVar "ProcState_Z" BType_Bool)))
                       (BExp_Cast BIExp_LowCast
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)
@@ -2970,14 +2986,14 @@ DAC00841 (rev32 x1, x2) @ 0x10030 - OK
                             (BExp_Den (BVar "R3" (BType_Imm Bit64))) Bit32)
                          (BExp_Const (Imm32 1w)))) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9A830441 (csinc x1, x2, x3, EQ) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 4w; 131w; 154w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 4w; 131w; 154w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "csinc x1, x2, x3, EQ";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "csinc x1, x2, x3, EQ";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_IfThenElse (BExp_Den (BVar "ProcState_Z" BType_Bool))
@@ -2986,23 +3002,22 @@ DAC00841 (rev32 x1, x2) @ 0x10030 - OK
                       (BExp_Den (BVar "R3" (BType_Imm Bit64)))
                       (BExp_Const (Imm64 1w))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 5A83D041 (csinv w1, w2, w3, LE) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 208w; 131w; 90w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 208w; 131w; 90w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "csinv w1, w2, w3, LE";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "csinv w1, w2, w3, LE";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_IfThenElse
-                      (BExp_BinExp BIExp_Or
-                         (BExp_UnaryExp BIExp_Not
-                            (BExp_BinPred BIExp_Equal
-                               (BExp_Den (BVar "ProcState_N" BType_Bool))
-                               (BExp_Den (BVar "ProcState_V" BType_Bool))))
+                      (BExp_BinPred BIExp_LessOrEqual
+                         (BExp_BinPred BIExp_Equal
+                            (BExp_Den (BVar "ProcState_N" BType_Bool))
+                            (BExp_Den (BVar "ProcState_V" BType_Bool)))
                          (BExp_Den (BVar "ProcState_Z" BType_Bool)))
                       (BExp_Cast BIExp_LowCast
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)
@@ -3011,14 +3026,14 @@ DAC00841 (rev32 x1, x2) @ 0x10030 - OK
                             (BExp_Den (BVar "R3" (BType_Imm Bit64))) Bit32)))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 DA830041 (csinv x1, x2, x3, EQ) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 0w; 131w; 218w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 0w; 131w; 218w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "csinv x1, x2, x3, EQ";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "csinv x1, x2, x3, EQ";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_IfThenElse (BExp_Den (BVar "ProcState_Z" BType_Bool))
@@ -3026,23 +3041,22 @@ DA830041 (csinv x1, x2, x3, EQ) @ 0x10030 - OK
                    (BExp_UnaryExp BIExp_Not
                       (BExp_Den (BVar "R3" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 5A83D441 (csneg w1, w2, w3, LE) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 212w; 131w; 90w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 212w; 131w; 90w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "csneg w1, w2, w3, LE";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "csneg w1, w2, w3, LE";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_IfThenElse
-                      (BExp_BinExp BIExp_Or
-                         (BExp_UnaryExp BIExp_Not
-                            (BExp_BinPred BIExp_Equal
-                               (BExp_Den (BVar "ProcState_N" BType_Bool))
-                               (BExp_Den (BVar "ProcState_V" BType_Bool))))
+                      (BExp_BinPred BIExp_LessOrEqual
+                         (BExp_BinPred BIExp_Equal
+                            (BExp_Den (BVar "ProcState_N" BType_Bool))
+                            (BExp_Den (BVar "ProcState_V" BType_Bool)))
                          (BExp_Den (BVar "ProcState_Z" BType_Bool)))
                       (BExp_Cast BIExp_LowCast
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)
@@ -3052,14 +3066,14 @@ DA830041 (csinv x1, x2, x3, EQ) @ 0x10030 - OK
                                (BExp_Den (BVar "R3" (BType_Imm Bit64))) Bit32))
                          (BExp_Const (Imm32 1w)))) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 DA830441 (csneg x1, x2, x3, EQ) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 4w; 131w; 218w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 4w; 131w; 218w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "csneg x1, x2, x3, EQ";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "csneg x1, x2, x3, EQ";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_IfThenElse (BExp_Den (BVar "ProcState_Z" BType_Bool))
@@ -3069,14 +3083,14 @@ DA830441 (csneg x1, x2, x3, EQ) @ 0x10030 - OK
                          (BExp_Den (BVar "R3" (BType_Imm Bit64))))
                       (BExp_Const (Imm64 1w))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 1A9FC7E1 (cset w1, LE) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[225w; 199w; 159w; 26w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[225w; 199w; 159w; 26w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "cset w1, LE";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "cset w1, LE";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -3089,14 +3103,14 @@ DA830441 (csneg x1, x2, x3, EQ) @ 0x10030 - OK
                             (BExp_Den (BVar "ProcState_Z" BType_Bool))))
                       (BExp_Const (Imm32 0w)) (BExp_Const (Imm32 1w))) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9A9FC7E1 (cset x1, LE) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[225w; 199w; 159w; 154w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[225w; 199w; 159w; 154w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "cset x1, LE";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "cset x1, LE";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_IfThenElse
@@ -3108,14 +3122,14 @@ DA830441 (csneg x1, x2, x3, EQ) @ 0x10030 - OK
                          (BExp_Den (BVar "ProcState_Z" BType_Bool))))
                    (BExp_Const (Imm64 0w)) (BExp_Const (Imm64 1w)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 5A9FC3E1 (csetm w1, LE) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[225w; 195w; 159w; 90w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[225w; 195w; 159w; 90w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "csetm w1, LE";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "csetm w1, LE";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -3127,16 +3141,16 @@ DA830441 (csneg x1, x2, x3, EQ) @ 0x10030 - OK
                          (BExp_UnaryExp BIExp_Not
                             (BExp_Den (BVar "ProcState_Z" BType_Bool))))
                       (BExp_Const (Imm32 0w))
-                      (BExp_Const (Imm32 4294967295w))) Bit64)];
+                      (BExp_Const (Imm32 0xFFFFFFFFw))) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 DA9FC3E1 (csetm x1, LE) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[225w; 195w; 159w; 218w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[225w; 195w; 159w; 218w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "csetm x1, LE";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "csetm x1, LE";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_IfThenElse
@@ -3147,16 +3161,16 @@ DA9FC3E1 (csetm x1, LE) @ 0x10030 - OK
                       (BExp_UnaryExp BIExp_Not
                          (BExp_Den (BVar "ProcState_Z" BType_Bool))))
                    (BExp_Const (Imm64 0w))
-                   (BExp_Const (Imm64 18446744073709551615w)))];
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 1A82C441 (cinc w1, w2, LE) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 196w; 130w; 26w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 196w; 130w; 26w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "cinc w1, w2, LE";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "cinc w1, w2, LE";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -3174,14 +3188,14 @@ DA9FC3E1 (csetm x1, LE) @ 0x10030 - OK
                             (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)
                          (BExp_Const (Imm32 1w)))) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9A821441 (cinc x1, x2, EQ) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 20w; 130w; 154w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 20w; 130w; 154w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "cinc x1, x2, EQ";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "cinc x1, x2, EQ";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_IfThenElse
@@ -3192,14 +3206,14 @@ DA9FC3E1 (csetm x1, LE) @ 0x10030 - OK
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))
                       (BExp_Const (Imm64 1w))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 5A82C041 (cinv w1, w2, LE) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 192w; 130w; 90w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 192w; 130w; 90w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "cinv w1, w2, LE";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "cinv w1, w2, LE";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -3217,14 +3231,14 @@ DA9FC3E1 (csetm x1, LE) @ 0x10030 - OK
                             (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 DA821041 (cinv x1, x2, EQ) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 16w; 130w; 218w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 16w; 130w; 218w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "cinv x1, x2, EQ";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "cinv x1, x2, EQ";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_IfThenElse
@@ -3234,14 +3248,14 @@ DA821041 (cinv x1, x2, EQ) @ 0x10030 - OK
                    (BExp_UnaryExp BIExp_Not
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 5A82C441 (cneg w1, w2, LE) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 196w; 130w; 90w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 196w; 130w; 90w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "cneg w1, w2, LE";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "cneg w1, w2, LE";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -3260,14 +3274,14 @@ DA821041 (cinv x1, x2, EQ) @ 0x10030 - OK
                                (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32))
                          (BExp_Const (Imm32 1w)))) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 DA821441 (cneg x1, x2, EQ) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 20w; 130w; 218w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 20w; 130w; 218w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "cneg x1, x2, EQ";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "cneg x1, x2, EQ";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_IfThenElse
@@ -3279,14 +3293,14 @@ DA821441 (cneg x1, x2, EQ) @ 0x10030 - OK
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))))
                       (BExp_Const (Imm64 1w))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 5A0203E1 (ngc w1, w2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[225w; 3w; 2w; 90w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[225w; 3w; 2w; 90w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ngc w1, w2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ngc w1, w2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -3299,14 +3313,14 @@ DA821441 (cneg x1, x2, EQ) @ 0x10030 - OK
                          (BExp_Const (Imm32 1w)) (BExp_Const (Imm32 0w))))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 DA0203E1 (ngc x1, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[225w; 3w; 2w; 218w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[225w; 3w; 2w; 218w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ngc x1, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ngc x1, x2";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Minus
@@ -3316,14 +3330,14 @@ DA0203E1 (ngc x1, x2) @ 0x10030 - OK
                       (BExp_UnaryExp BIExp_ChangeSign (BExp_Const (Imm64 1w))))
                    (BExp_Den (BVar "R2" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 7A0203E1 (ngcs w1, w2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[225w; 3w; 2w; 122w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[225w; 3w; 2w; 122w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ngcs w1, w2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ngcs w1, w2";
            bb_statements :=
              [BStmt_Assign (BVar "tmp_ProcState_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C (BExp_Const (Imm32 0w))
@@ -3362,14 +3376,14 @@ DA0203E1 (ngc x1, x2) @ 0x10030 - OK
               BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_Den (BVar "tmp_ProcState_C" BType_Bool))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 FA0203E1 (ngcs x1, x2) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[225w; 3w; 2w; 250w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[225w; 3w; 2w; 250w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ngcs x1, x2";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ngcs x1, x2";
            bb_statements :=
              [BStmt_Assign (BVar "tmp_ProcState_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C (BExp_Const (Imm64 0w))
@@ -3401,22 +3415,21 @@ FA0203E1 (ngcs x1, x2) @ 0x10030 - OK
               BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_Den (BVar "tmp_ProcState_C" BType_Bool))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 3A42D023 (ccmn w1, w2, #3, le) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[35w; 208w; 66w; 58w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[35w; 208w; 66w; 58w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ccmn w1, w2, #3, le";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ccmn w1, w2, #3, le";
            bb_statements :=
              [BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_BinPred BIExp_LessOrEqual
-                   (BExp_BinExp BIExp_Or
-                      (BExp_UnaryExp BIExp_Not
-                         (BExp_BinPred BIExp_Equal
-                            (BExp_Den (BVar "ProcState_N" BType_Bool))
-                            (BExp_Den (BVar "ProcState_V" BType_Bool))))
+                   (BExp_BinPred BIExp_LessOrEqual
+                      (BExp_BinPred BIExp_Equal
+                         (BExp_Den (BVar "ProcState_N" BType_Bool))
+                         (BExp_Den (BVar "ProcState_V" BType_Bool)))
                       (BExp_Den (BVar "ProcState_Z" BType_Bool)))
                    (BExp_nzcv_ADD_C
                       (BExp_Cast BIExp_LowCast
@@ -3425,11 +3438,10 @@ FA0203E1 (ngcs x1, x2) @ 0x10030 - OK
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)));
               BStmt_Assign (BVar "tmp_ProcState_N" BType_Bool)
                 (BExp_BinExp BIExp_And
-                   (BExp_BinExp BIExp_Or
-                      (BExp_UnaryExp BIExp_Not
-                         (BExp_BinPred BIExp_Equal
-                            (BExp_Den (BVar "ProcState_N" BType_Bool))
-                            (BExp_Den (BVar "ProcState_V" BType_Bool))))
+                   (BExp_BinPred BIExp_LessOrEqual
+                      (BExp_BinPred BIExp_Equal
+                         (BExp_Den (BVar "ProcState_N" BType_Bool))
+                         (BExp_Den (BVar "ProcState_V" BType_Bool)))
                       (BExp_Den (BVar "ProcState_Z" BType_Bool)))
                    (BExp_nzcv_ADD_N Bit32
                       (BExp_Cast BIExp_LowCast
@@ -3438,11 +3450,10 @@ FA0203E1 (ngcs x1, x2) @ 0x10030 - OK
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)));
               BStmt_Assign (BVar "tmp_ProcState_V" BType_Bool)
                 (BExp_BinPred BIExp_LessOrEqual
-                   (BExp_BinExp BIExp_Or
-                      (BExp_UnaryExp BIExp_Not
-                         (BExp_BinPred BIExp_Equal
-                            (BExp_Den (BVar "ProcState_N" BType_Bool))
-                            (BExp_Den (BVar "ProcState_V" BType_Bool))))
+                   (BExp_BinPred BIExp_LessOrEqual
+                      (BExp_BinPred BIExp_Equal
+                         (BExp_Den (BVar "ProcState_N" BType_Bool))
+                         (BExp_Den (BVar "ProcState_V" BType_Bool)))
                       (BExp_Den (BVar "ProcState_Z" BType_Bool)))
                    (BExp_nzcv_ADD_V Bit32
                       (BExp_Cast BIExp_LowCast
@@ -3451,11 +3462,10 @@ FA0203E1 (ngcs x1, x2) @ 0x10030 - OK
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)));
               BStmt_Assign (BVar "ProcState_Z" BType_Bool)
                 (BExp_BinExp BIExp_And
-                   (BExp_BinExp BIExp_Or
-                      (BExp_UnaryExp BIExp_Not
-                         (BExp_BinPred BIExp_Equal
-                            (BExp_Den (BVar "ProcState_N" BType_Bool))
-                            (BExp_Den (BVar "ProcState_V" BType_Bool))))
+                   (BExp_BinPred BIExp_LessOrEqual
+                      (BExp_BinPred BIExp_Equal
+                         (BExp_Den (BVar "ProcState_N" BType_Bool))
+                         (BExp_Den (BVar "ProcState_V" BType_Bool)))
                       (BExp_Den (BVar "ProcState_Z" BType_Bool)))
                    (BExp_nzcv_ADD_Z
                       (BExp_Cast BIExp_LowCast
@@ -3467,22 +3477,21 @@ FA0203E1 (ngcs x1, x2) @ 0x10030 - OK
               BStmt_Assign (BVar "ProcState_V" BType_Bool)
                 (BExp_Den (BVar "tmp_ProcState_V" BType_Bool))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 7A42D023 (ccmp w1, w2, #3, le) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[35w; 208w; 66w; 122w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[35w; 208w; 66w; 122w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ccmp w1, w2, #3, le";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ccmp w1, w2, #3, le";
            bb_statements :=
              [BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_BinPred BIExp_LessOrEqual
-                   (BExp_BinExp BIExp_Or
-                      (BExp_UnaryExp BIExp_Not
-                         (BExp_BinPred BIExp_Equal
-                            (BExp_Den (BVar "ProcState_N" BType_Bool))
-                            (BExp_Den (BVar "ProcState_V" BType_Bool))))
+                   (BExp_BinPred BIExp_LessOrEqual
+                      (BExp_BinPred BIExp_Equal
+                         (BExp_Den (BVar "ProcState_N" BType_Bool))
+                         (BExp_Den (BVar "ProcState_V" BType_Bool)))
                       (BExp_Den (BVar "ProcState_Z" BType_Bool)))
                    (BExp_nzcv_SUB_C
                       (BExp_Cast BIExp_LowCast
@@ -3491,11 +3500,10 @@ FA0203E1 (ngcs x1, x2) @ 0x10030 - OK
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)));
               BStmt_Assign (BVar "tmp_ProcState_N" BType_Bool)
                 (BExp_BinExp BIExp_And
-                   (BExp_BinExp BIExp_Or
-                      (BExp_UnaryExp BIExp_Not
-                         (BExp_BinPred BIExp_Equal
-                            (BExp_Den (BVar "ProcState_N" BType_Bool))
-                            (BExp_Den (BVar "ProcState_V" BType_Bool))))
+                   (BExp_BinPred BIExp_LessOrEqual
+                      (BExp_BinPred BIExp_Equal
+                         (BExp_Den (BVar "ProcState_N" BType_Bool))
+                         (BExp_Den (BVar "ProcState_V" BType_Bool)))
                       (BExp_Den (BVar "ProcState_Z" BType_Bool)))
                    (BExp_nzcv_SUB_N Bit32
                       (BExp_Cast BIExp_LowCast
@@ -3504,11 +3512,10 @@ FA0203E1 (ngcs x1, x2) @ 0x10030 - OK
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)));
               BStmt_Assign (BVar "tmp_ProcState_V" BType_Bool)
                 (BExp_BinPred BIExp_LessOrEqual
-                   (BExp_BinExp BIExp_Or
-                      (BExp_UnaryExp BIExp_Not
-                         (BExp_BinPred BIExp_Equal
-                            (BExp_Den (BVar "ProcState_N" BType_Bool))
-                            (BExp_Den (BVar "ProcState_V" BType_Bool))))
+                   (BExp_BinPred BIExp_LessOrEqual
+                      (BExp_BinPred BIExp_Equal
+                         (BExp_Den (BVar "ProcState_N" BType_Bool))
+                         (BExp_Den (BVar "ProcState_V" BType_Bool)))
                       (BExp_Den (BVar "ProcState_Z" BType_Bool)))
                    (BExp_nzcv_SUB_V Bit32
                       (BExp_Cast BIExp_LowCast
@@ -3517,11 +3524,10 @@ FA0203E1 (ngcs x1, x2) @ 0x10030 - OK
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)));
               BStmt_Assign (BVar "ProcState_Z" BType_Bool)
                 (BExp_BinExp BIExp_And
-                   (BExp_BinExp BIExp_Or
-                      (BExp_UnaryExp BIExp_Not
-                         (BExp_BinPred BIExp_Equal
-                            (BExp_Den (BVar "ProcState_N" BType_Bool))
-                            (BExp_Den (BVar "ProcState_V" BType_Bool))))
+                   (BExp_BinPred BIExp_LessOrEqual
+                      (BExp_BinPred BIExp_Equal
+                         (BExp_Den (BVar "ProcState_N" BType_Bool))
+                         (BExp_Den (BVar "ProcState_V" BType_Bool)))
                       (BExp_Den (BVar "ProcState_Z" BType_Bool)))
                    (BExp_nzcv_SUB_Z
                       (BExp_Cast BIExp_LowCast
@@ -3533,54 +3539,50 @@ FA0203E1 (ngcs x1, x2) @ 0x10030 - OK
               BStmt_Assign (BVar "ProcState_V" BType_Bool)
                 (BExp_Den (BVar "tmp_ProcState_V" BType_Bool))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 BA42D023 (ccmn x1, x2, #3, le) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[35w; 208w; 66w; 186w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[35w; 208w; 66w; 186w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ccmn x1, x2, #3, le";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ccmn x1, x2, #3, le";
            bb_statements :=
              [BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_BinPred BIExp_LessOrEqual
-                   (BExp_BinExp BIExp_Or
-                      (BExp_UnaryExp BIExp_Not
-                         (BExp_BinPred BIExp_Equal
-                            (BExp_Den (BVar "ProcState_N" BType_Bool))
-                            (BExp_Den (BVar "ProcState_V" BType_Bool))))
+                   (BExp_BinPred BIExp_LessOrEqual
+                      (BExp_BinPred BIExp_Equal
+                         (BExp_Den (BVar "ProcState_N" BType_Bool))
+                         (BExp_Den (BVar "ProcState_V" BType_Bool)))
                       (BExp_Den (BVar "ProcState_Z" BType_Bool)))
                    (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit64)))
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))));
               BStmt_Assign (BVar "tmp_ProcState_N" BType_Bool)
                 (BExp_BinExp BIExp_And
-                   (BExp_BinExp BIExp_Or
-                      (BExp_UnaryExp BIExp_Not
-                         (BExp_BinPred BIExp_Equal
-                            (BExp_Den (BVar "ProcState_N" BType_Bool))
-                            (BExp_Den (BVar "ProcState_V" BType_Bool))))
+                   (BExp_BinPred BIExp_LessOrEqual
+                      (BExp_BinPred BIExp_Equal
+                         (BExp_Den (BVar "ProcState_N" BType_Bool))
+                         (BExp_Den (BVar "ProcState_V" BType_Bool)))
                       (BExp_Den (BVar "ProcState_Z" BType_Bool)))
                    (BExp_nzcv_ADD_N Bit64
                       (BExp_Den (BVar "R1" (BType_Imm Bit64)))
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))));
               BStmt_Assign (BVar "tmp_ProcState_V" BType_Bool)
                 (BExp_BinPred BIExp_LessOrEqual
-                   (BExp_BinExp BIExp_Or
-                      (BExp_UnaryExp BIExp_Not
-                         (BExp_BinPred BIExp_Equal
-                            (BExp_Den (BVar "ProcState_N" BType_Bool))
-                            (BExp_Den (BVar "ProcState_V" BType_Bool))))
+                   (BExp_BinPred BIExp_LessOrEqual
+                      (BExp_BinPred BIExp_Equal
+                         (BExp_Den (BVar "ProcState_N" BType_Bool))
+                         (BExp_Den (BVar "ProcState_V" BType_Bool)))
                       (BExp_Den (BVar "ProcState_Z" BType_Bool)))
                    (BExp_nzcv_ADD_V Bit64
                       (BExp_Den (BVar "R1" (BType_Imm Bit64)))
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))));
               BStmt_Assign (BVar "ProcState_Z" BType_Bool)
                 (BExp_BinExp BIExp_And
-                   (BExp_BinExp BIExp_Or
-                      (BExp_UnaryExp BIExp_Not
-                         (BExp_BinPred BIExp_Equal
-                            (BExp_Den (BVar "ProcState_N" BType_Bool))
-                            (BExp_Den (BVar "ProcState_V" BType_Bool))))
+                   (BExp_BinPred BIExp_LessOrEqual
+                      (BExp_BinPred BIExp_Equal
+                         (BExp_Den (BVar "ProcState_N" BType_Bool))
+                         (BExp_Den (BVar "ProcState_V" BType_Bool)))
                       (BExp_Den (BVar "ProcState_Z" BType_Bool)))
                    (BExp_nzcv_ADD_Z (BExp_Den (BVar "R1" (BType_Imm Bit64)))
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))));
@@ -3589,54 +3591,50 @@ BA42D023 (ccmn x1, x2, #3, le) @ 0x10030 - OK
               BStmt_Assign (BVar "ProcState_V" BType_Bool)
                 (BExp_Den (BVar "tmp_ProcState_V" BType_Bool))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 FA42D023 (ccmp x1, x2, #3, le) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[35w; 208w; 66w; 250w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[35w; 208w; 66w; 250w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "ccmp x1, x2, #3, le";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "ccmp x1, x2, #3, le";
            bb_statements :=
              [BStmt_Assign (BVar "ProcState_C" BType_Bool)
                 (BExp_BinPred BIExp_LessOrEqual
-                   (BExp_BinExp BIExp_Or
-                      (BExp_UnaryExp BIExp_Not
-                         (BExp_BinPred BIExp_Equal
-                            (BExp_Den (BVar "ProcState_N" BType_Bool))
-                            (BExp_Den (BVar "ProcState_V" BType_Bool))))
+                   (BExp_BinPred BIExp_LessOrEqual
+                      (BExp_BinPred BIExp_Equal
+                         (BExp_Den (BVar "ProcState_N" BType_Bool))
+                         (BExp_Den (BVar "ProcState_V" BType_Bool)))
                       (BExp_Den (BVar "ProcState_Z" BType_Bool)))
                    (BExp_nzcv_SUB_C (BExp_Den (BVar "R1" (BType_Imm Bit64)))
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))));
               BStmt_Assign (BVar "tmp_ProcState_N" BType_Bool)
                 (BExp_BinExp BIExp_And
-                   (BExp_BinExp BIExp_Or
-                      (BExp_UnaryExp BIExp_Not
-                         (BExp_BinPred BIExp_Equal
-                            (BExp_Den (BVar "ProcState_N" BType_Bool))
-                            (BExp_Den (BVar "ProcState_V" BType_Bool))))
+                   (BExp_BinPred BIExp_LessOrEqual
+                      (BExp_BinPred BIExp_Equal
+                         (BExp_Den (BVar "ProcState_N" BType_Bool))
+                         (BExp_Den (BVar "ProcState_V" BType_Bool)))
                       (BExp_Den (BVar "ProcState_Z" BType_Bool)))
                    (BExp_nzcv_SUB_N Bit64
                       (BExp_Den (BVar "R1" (BType_Imm Bit64)))
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))));
               BStmt_Assign (BVar "tmp_ProcState_V" BType_Bool)
                 (BExp_BinPred BIExp_LessOrEqual
-                   (BExp_BinExp BIExp_Or
-                      (BExp_UnaryExp BIExp_Not
-                         (BExp_BinPred BIExp_Equal
-                            (BExp_Den (BVar "ProcState_N" BType_Bool))
-                            (BExp_Den (BVar "ProcState_V" BType_Bool))))
+                   (BExp_BinPred BIExp_LessOrEqual
+                      (BExp_BinPred BIExp_Equal
+                         (BExp_Den (BVar "ProcState_N" BType_Bool))
+                         (BExp_Den (BVar "ProcState_V" BType_Bool)))
                       (BExp_Den (BVar "ProcState_Z" BType_Bool)))
                    (BExp_nzcv_SUB_V Bit64
                       (BExp_Den (BVar "R1" (BType_Imm Bit64)))
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))));
               BStmt_Assign (BVar "ProcState_Z" BType_Bool)
                 (BExp_BinExp BIExp_And
-                   (BExp_BinExp BIExp_Or
-                      (BExp_UnaryExp BIExp_Not
-                         (BExp_BinPred BIExp_Equal
-                            (BExp_Den (BVar "ProcState_N" BType_Bool))
-                            (BExp_Den (BVar "ProcState_V" BType_Bool))))
+                   (BExp_BinPred BIExp_LessOrEqual
+                      (BExp_BinPred BIExp_Equal
+                         (BExp_Den (BVar "ProcState_N" BType_Bool))
+                         (BExp_Den (BVar "ProcState_V" BType_Bool)))
                       (BExp_Den (BVar "ProcState_Z" BType_Bool)))
                    (BExp_nzcv_SUB_Z (BExp_Den (BVar "R1" (BType_Imm Bit64)))
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))));
@@ -3645,14 +3643,14 @@ FA42D023 (ccmp x1, x2, #3, le) @ 0x10030 - OK
               BStmt_Assign (BVar "ProcState_V" BType_Bool)
                 (BExp_Den (BVar "tmp_ProcState_V" BType_Bool))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 1B031041 (madd w1, w2, w3, w4) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 16w; 3w; 27w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 16w; 3w; 27w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "madd w1, w2, w3, w4";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "madd w1, w2, w3, w4";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -3666,14 +3664,14 @@ FA42D023 (ccmp x1, x2, #3, le) @ 0x10030 - OK
                             (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9B031041 (madd x1, x2, x3, x4) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 16w; 3w; 155w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 16w; 3w; 155w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "madd x1, x2, x3, x4";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "madd x1, x2, x3, x4";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
@@ -3682,14 +3680,14 @@ FA42D023 (ccmp x1, x2, #3, le) @ 0x10030 - OK
                       (BExp_Den (BVar "R3" (BType_Imm Bit64)))
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 1B039041 (msub w1, w2, w3, w4) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 144w; 3w; 27w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 144w; 3w; 27w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "msub w1, w2, w3, w4";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "msub w1, w2, w3, w4";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -3703,14 +3701,14 @@ FA42D023 (ccmp x1, x2, #3, le) @ 0x10030 - OK
                             (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9B039041 (msub x1, x2, x3, x4) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 144w; 3w; 155w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 144w; 3w; 155w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "msub x1, x2, x3, x4";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "msub x1, x2, x3, x4";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Minus
@@ -3719,14 +3717,14 @@ FA42D023 (ccmp x1, x2, #3, le) @ 0x10030 - OK
                       (BExp_Den (BVar "R3" (BType_Imm Bit64)))
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9B03FC41 (msub x1, x2, x3, xzr) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 252w; 3w; 155w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 252w; 3w; 155w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "msub x1, x2, x3, xzr";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "msub x1, x2, x3, xzr";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_UnaryExp BIExp_ChangeSign
@@ -3734,14 +3732,14 @@ FA42D023 (ccmp x1, x2, #3, le) @ 0x10030 - OK
                       (BExp_Den (BVar "R3" (BType_Imm Bit64)))
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 1B03FC41 (mneg w1, w2, w3) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 252w; 3w; 27w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 252w; 3w; 27w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "mneg w1, w2, w3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "mneg w1, w2, w3";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -3753,14 +3751,14 @@ FA42D023 (ccmp x1, x2, #3, le) @ 0x10030 - OK
                             (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9B03FC41 (mneg x1, x2, x3) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 252w; 3w; 155w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 252w; 3w; 155w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "mneg x1, x2, x3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "mneg x1, x2, x3";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_UnaryExp BIExp_ChangeSign
@@ -3768,14 +3766,14 @@ FA42D023 (ccmp x1, x2, #3, le) @ 0x10030 - OK
                       (BExp_Den (BVar "R3" (BType_Imm Bit64)))
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9B231041 (smaddl x1, w2, w3, x4) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 16w; 35w; 155w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 16w; 35w; 155w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "smaddl x1, w2, w3, x4";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "smaddl x1, w2, w3, x4";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
@@ -3790,14 +3788,14 @@ FA42D023 (ccmp x1, x2, #3, le) @ 0x10030 - OK
                             (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)
                          Bit64)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9B239041 (smsubl x1, w2, w3, x4) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 144w; 35w; 155w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 144w; 35w; 155w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "smsubl x1, w2, w3, x4";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "smsubl x1, w2, w3, x4";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Minus
@@ -3812,14 +3810,14 @@ FA42D023 (ccmp x1, x2, #3, le) @ 0x10030 - OK
                             (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)
                          Bit64)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9B237C41 (smull x1, w2, w3) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 124w; 35w; 155w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 124w; 35w; 155w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "smull x1, w2, w3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "smull x1, w2, w3";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Mult
@@ -3832,17 +3830,17 @@ FA42D023 (ccmp x1, x2, #3, le) @ 0x10030 - OK
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)
                       Bit64))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9B437C41 (smulh x1, x2, x3) @ 0x10030 - FAILED
    lifting of ``Imm64 ((127 >< 64) (sw2sw (ms.REG 3w) * sw2sw (ms.REG 2w)))`` failed
 
 9BA31041 (umaddl x1, w2, w3, x4) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 16w; 163w; 155w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 16w; 163w; 155w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "umaddl x1, w2, w3, x4";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "umaddl x1, w2, w3, x4";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
@@ -3857,14 +3855,14 @@ FA42D023 (ccmp x1, x2, #3, le) @ 0x10030 - OK
                             (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)
                          Bit64)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9BA39041 (umsubl x1, w2, w3, x4) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 144w; 163w; 155w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 144w; 163w; 155w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "umsubl x1, w2, w3, x4";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "umsubl x1, w2, w3, x4";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Minus
@@ -3879,14 +3877,14 @@ FA42D023 (ccmp x1, x2, #3, le) @ 0x10030 - OK
                             (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)
                          Bit64)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9BA37C41 (umull x1, w2, w3) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 124w; 163w; 155w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 124w; 163w; 155w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "umull x1, w2, w3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "umull x1, w2, w3";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Mult
@@ -3899,17 +3897,17 @@ FA42D023 (ccmp x1, x2, #3, le) @ 0x10030 - OK
                          (BExp_Den (BVar "R2" (BType_Imm Bit64))) Bit32)
                       Bit64))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9BC37C41 (umulh x1, x2, x3) @ 0x10030 - FAILED
    lifting of ``Imm64 ((127 >< 64) (w2w (ms.REG 3w) * w2w (ms.REG 2w)))`` failed
 
 1AC30C41 (sdiv w1, w2, w3) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 12w; 195w; 26w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 12w; 195w; 26w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "sdiv w1, w2, w3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "sdiv w1, w2, w3";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -3925,14 +3923,14 @@ FA42D023 (ccmp x1, x2, #3, le) @ 0x10030 - OK
                             (BExp_Den (BVar "R3" (BType_Imm Bit64))) Bit32)))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9AC30C41 (sdiv x1, x2, x3) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 12w; 195w; 154w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 12w; 195w; 154w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "sdiv x1, x2, x3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "sdiv x1, x2, x3";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_IfThenElse
@@ -3943,14 +3941,14 @@ FA42D023 (ccmp x1, x2, #3, le) @ 0x10030 - OK
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))
                       (BExp_Den (BVar "R3" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 1AC30841 (udiv w1, w2, w3) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 8w; 195w; 26w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 8w; 195w; 26w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "udiv w1, w2, w3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "udiv w1, w2, w3";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -3966,14 +3964,14 @@ FA42D023 (ccmp x1, x2, #3, le) @ 0x10030 - OK
                             (BExp_Den (BVar "R3" (BType_Imm Bit64))) Bit32)))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 9AC30841 (udiv x1, x2, x3) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[65w; 8w; 195w; 154w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[65w; 8w; 195w; 154w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "udiv x1, x2, x3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "udiv x1, x2, x3";
            bb_statements :=
              [BStmt_Assign (BVar "R1" (BType_Imm Bit64))
                 (BExp_IfThenElse
@@ -3984,61 +3982,61 @@ FA42D023 (ccmp x1, x2, #3, le) @ 0x10030 - OK
                       (BExp_Den (BVar "R2" (BType_Imm Bit64)))
                       (BExp_Den (BVar "R3" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 D61F0220 (br  x17) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 2w; 31w; 214w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 2w; 31w; 214w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "br  x17";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "br  x17";
            bb_statements := [];
            bb_last_statement :=
              BStmt_Jmp (BLE_Exp (BExp_Den (BVar "R17" (BType_Imm Bit64))))|>])
 
 D503201F (nop) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[31w; 32w; 3w; 213w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[31w; 32w; 3w; 213w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "nop";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "nop";
            bb_statements := [];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 D63F0020 (blr x1) @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[32w; 0w; 63w; 214w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[32w; 0w; 63w; 214w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "blr x1";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "blr x1";
            bb_statements :=
              [BStmt_Assign (BVar "R30" (BType_Imm Bit64))
-                (BExp_Const (Imm64 65588w))];
+                (BExp_Const (Imm64 0x10034w))];
            bb_last_statement :=
              BStmt_Jmp (BLE_Exp (BExp_Den (BVar "R1" (BType_Imm Bit64))))|>])
 
 B4000040 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[64w; 0w; 0w; 180w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[64w; 0w; 0w; 180w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "B4000040";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "B4000040";
            bb_statements := [];
            bb_last_statement :=
              BStmt_CJmp
                (BExp_BinPred BIExp_Equal
                   (BExp_Den (BVar "R0" (BType_Imm Bit64)))
                   (BExp_Const (Imm64 0w)))
-               (BLE_Label (BL_Address (Imm64 65592w)))
-               (BLE_Label (BL_Address (Imm64 65588w)))|>])
+               (BLE_Label (BL_Address (Imm64 0x10038w)))
+               (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 35000080 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[128w; 0w; 0w; 53w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[128w; 0w; 0w; 53w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "35000080";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "35000080";
            bb_statements := [];
            bb_last_statement :=
              BStmt_CJmp
@@ -4046,15 +4044,15 @@ B4000040 @ 0x10030 - OK
                   (BExp_Cast BIExp_LowCast
                      (BExp_Den (BVar "R0" (BType_Imm Bit64))) Bit32)
                   (BExp_Const (Imm32 0w)))
-               (BLE_Label (BL_Address (Imm64 65600w)))
-               (BLE_Label (BL_Address (Imm64 65588w)))|>])
+               (BLE_Label (BL_Address (Imm64 0x10040w)))
+               (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 B8617801 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog arm8_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[1w; 120w; 97w; 184w])
+|- bir_is_lifted_inst_prog arm8_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[1w; 120w; 97w; 184w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "B8617801";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "B8617801";
            bb_statements :=
              [BStmt_Assert
                 (BExp_Aligned Bit64 2
@@ -4073,7 +4071,7 @@ B8617801 @ 0x10030 - OK
                             (BExp_Const (Imm64 2w)))) BEnd_LittleEndian Bit32)
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 
 

--- a/src/tools/lifter/selftest_arm8.log
+++ b/src/tools/lifter/selftest_arm8.log
@@ -4085,12 +4085,8 @@ Instructions FAILED: 2/537
    "9B437C41" (* smulh x1, x2, x3; lifting of ``Imm64 ((127 >< 64) (sw2sw (ms.REG 3w) * sw2sw (ms.REG 2w)))`` failed *)
 ]
 
-Instructions FIXED: 4
+Instructions FIXED: 0
 
-   DAC01441
-   5AC01441
-   DAC01041
-   5AC01041
 
 
 Instructions BROKEN: 0

--- a/src/tools/lifter/selftest_m0_be_main.log
+++ b/src/tools/lifter/selftest_m0_be_main.log
@@ -1,6 +1,6 @@
 4608 (mov r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[70w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mov r0, r1";
@@ -12,7 +12,7 @@
 
 0008 (movs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[0w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "movs r0, r1";
@@ -30,7 +30,7 @@
 
 468F (mov pc, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[70w; 143w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mov pc, r1";
@@ -43,7 +43,7 @@
 
 1C08 (adds r0, r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[28w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, #0";
@@ -63,7 +63,7 @@
 
 1C88 (adds r0, r1, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[28w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, #2";
@@ -91,7 +91,7 @@
 
 1888 (adds r0, r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[24w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, r2";
@@ -119,7 +119,7 @@
 
 4408 (add r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[68w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add r0, r1";
@@ -133,7 +133,7 @@
 
 448F (add pc, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[68w; 143w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add pc, r1";
@@ -148,7 +148,7 @@
 
 3080 (adds r0, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[48w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, #128";
@@ -176,7 +176,7 @@
 
 4148 (adcs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 72w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adcs r0, r1";
@@ -215,7 +215,7 @@
 
 B020 (add sp, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[176w; 32w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add sp, #128";
@@ -230,7 +230,7 @@ B020 (add sp, #128) @ 0x130 - OK
 
 A820 (add r0, sp, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[168w; 32w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add r0, sp, #128";
@@ -244,7 +244,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1A88 (subs r0, r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[26w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, r2";
@@ -272,7 +272,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1EC8 (subs r0, r1, #3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[30w; 200w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, #3";
@@ -300,7 +300,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1A48 (subs r0, r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[26w; 72w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, r1";
@@ -316,7 +316,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1E08 (subs r0, r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[30w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, #0";
@@ -336,7 +336,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 3880 (subs r0, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[56w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, #128";
@@ -364,7 +364,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1E00 (subs r0, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[30w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, #0";
@@ -382,7 +382,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 4198 (sbcs r0, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 152w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sbcs r0, r3";
@@ -425,7 +425,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 B082 (sub sp, #8) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[176w; 130w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sub sp, #8";
@@ -440,7 +440,7 @@ B082 (sub sp, #8) @ 0x130 - OK
 
 B084 (sub sp, #16) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[176w; 132w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sub sp, #16";
@@ -455,7 +455,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4251 (rsbs r1, r2, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[66w; 81w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rsbs r1, r2, #0";
@@ -483,7 +483,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4359 (muls r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[67w; 89w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "muls r1, r3";
@@ -508,7 +508,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4299 (cmp r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[66w; 153w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, r3";
@@ -532,7 +532,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4289 (cmp r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[66w; 137w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, r1";
@@ -546,7 +546,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 2900 (cmp r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[41w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, #0";
@@ -564,7 +564,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 290C (cmp r1, #12) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[41w; 12w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, #12";
@@ -588,7 +588,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 42D9 (cmn r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[66w; 217w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmn r1, r3";
@@ -612,7 +612,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 42C9 (cmn r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[66w; 201w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmn r1, r1";
@@ -636,7 +636,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4009 (ands r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[64w; 9w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ands r1, r1";
@@ -652,7 +652,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4011 (ands r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[64w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ands r1, r2";
@@ -677,7 +677,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4051 (eors r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[64w; 81w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "eors r1, r2";
@@ -702,7 +702,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4049 (eors r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[64w; 73w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "eors r1, r1";
@@ -716,7 +716,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4311 (orrs r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[67w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "orrs r1, r2";
@@ -741,7 +741,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4309 (orrs r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[67w; 9w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "orrs r1, r1";
@@ -757,7 +757,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4391 (bics r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[67w; 145w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bics r1, r2";
@@ -785,7 +785,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4389 (bics r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[67w; 137w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bics r1, r1";
@@ -799,7 +799,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 43D1 (mvns r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[67w; 209w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mvns r1, r2";
@@ -821,7 +821,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 43C9 (mvns r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[67w; 201w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mvns r1, r1";
@@ -843,7 +843,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4211 (tst r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[66w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "tst r1, r2";
@@ -864,7 +864,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4209 (tst r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[66w; 9w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "tst r1, r1";
@@ -880,7 +880,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4088 (lsls r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[64w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, r1";
@@ -926,7 +926,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0080 (lsls r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[0w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, #2";
@@ -951,7 +951,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0000 (lsls r0, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[0w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, #0";
@@ -967,7 +967,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 40C8 (lsrs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[64w; 200w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsrs r0, r1";
@@ -1018,7 +1018,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0880 (lsrs r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[8w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsrs r0, #2";
@@ -1045,7 +1045,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4108 (asrs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "asrs r0, r1";
@@ -1098,7 +1098,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 1080 (asrs r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[16w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "asrs r0, #2";
@@ -1125,7 +1125,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 41C8 (rors r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 200w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rors r0, r1";
@@ -1160,7 +1160,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6801 (ldr r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[104w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0]";
@@ -1177,7 +1177,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6841 (ldr r1, [r0, #4]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[104w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, #4]";
@@ -1195,7 +1195,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6881 (ldr r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[104w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, #8]";
@@ -1213,7 +1213,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8901 (ldrh r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[137w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #8]";
@@ -1232,7 +1232,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8801 (ldrh r1, [r0, #0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[136w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #0]";
@@ -1250,7 +1250,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8841 (ldrh r1, [r0, #2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[136w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #2]";
@@ -1269,7 +1269,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7801 (ldrb r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[120w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0]";
@@ -1284,7 +1284,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7841 (ldrb r1, [r0, #1]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[120w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, #1]";
@@ -1300,7 +1300,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7CC1 (ldrb r1, [r0, #19]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[124w; 193w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, #19]";
@@ -1316,7 +1316,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5881 (ldr r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[88w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, r2]";
@@ -1337,7 +1337,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5A81 (ldrh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[90w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, r2]";
@@ -1359,7 +1359,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5E81 (ldrsh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[94w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrsh r1, [r0, r2]";
@@ -1381,7 +1381,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5C81 (ldrb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[92w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, r2]";
@@ -1398,7 +1398,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5681 (ldrsb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[86w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrsb r1, [r0, r2]";
@@ -1415,7 +1415,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4902 (ldr r1, [pc, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[73w; 2w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [pc, #8]";
@@ -1428,7 +1428,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 9902 (ldr r1, [sp, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[153w; 2w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [sp, #8]";
@@ -1446,7 +1446,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[203w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldm r3, {r1, r2, r3}";
@@ -1473,7 +1473,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6001 (str r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[96w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0]";
@@ -1493,7 +1493,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6041 (str r1, [r0, #4]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[96w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, #4]";
@@ -1517,7 +1517,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6081 (str r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[96w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, #8]";
@@ -1541,7 +1541,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8101 (strh r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #8]";
@@ -1566,7 +1566,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8001 (strh r1, [r0, #0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[128w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #0]";
@@ -1587,7 +1587,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8041 (strh r1, [r0, #2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[128w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #2]";
@@ -1612,7 +1612,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 7001 (strb r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[112w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0]";
@@ -1630,7 +1630,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 7041 (strb r1, [r0, #1]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[112w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, #1]";
@@ -1652,7 +1652,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 74C1 (strb r1, [r0, #19]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[116w; 193w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, #19]";
@@ -1674,7 +1674,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5081 (str r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[80w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, r2]";
@@ -1700,7 +1700,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5281 (strh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[82w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, r2]";
@@ -1728,7 +1728,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5481 (strb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[84w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, r2]";
@@ -1751,7 +1751,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 9102 (str r1, [sp, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[145w; 2w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [sp, #8]";
@@ -1775,7 +1775,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 C10E (stm r1!, {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[193w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "stm r1!, {r1, r2, r3}";
@@ -1813,7 +1813,7 @@ C10E (stm r1!, {r1, r2, r3}) @ 0x130 - OK
 
 B40E (push {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[180w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "push {r1, r2, r3}";
@@ -1854,7 +1854,7 @@ B40E (push {r1, r2, r3}) @ 0x130 - OK
 
 BC0E (pop {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[188w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "pop {r1, r2, r3}";
@@ -1885,7 +1885,7 @@ BC0E (pop {r1, r2, r3}) @ 0x130 - OK
 
 B50E (push {r1, r2, r3, lr}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[181w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "push {r1, r2, r3, lr}";
@@ -1931,7 +1931,7 @@ B50E (push {r1, r2, r3, lr}) @ 0x130 - OK
 
 BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[189w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "pop {r1, r2, r3, pc}";
@@ -1979,7 +1979,7 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 4708 (bx r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[71w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bx r1";
@@ -1997,7 +1997,7 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 4788 (blx r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[71w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "blx r1";
@@ -2014,7 +2014,7 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 B211 (sxth r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[178w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sxth r1, r2";
@@ -2028,7 +2028,7 @@ B211 (sxth r1, r2) @ 0x130 - OK
 
 B251 (sxtb r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[178w; 81w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sxtb r1, r2";
@@ -2042,7 +2042,7 @@ B251 (sxtb r1, r2) @ 0x130 - OK
 
 B291 (uxth r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[178w; 145w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "uxth r1, r2";
@@ -2056,7 +2056,7 @@ B291 (uxth r1, r2) @ 0x130 - OK
 
 B2D1 (uxtb r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[178w; 209w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "uxtb r1, r2";
@@ -2070,7 +2070,7 @@ B2D1 (uxtb r1, r2) @ 0x130 - OK
 
 BA11 (rev r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[186w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rev r1, r2";
@@ -2083,7 +2083,7 @@ BA11 (rev r1, r2) @ 0x130 - OK
 
 BA51 (rev16 r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[186w; 81w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rev16 r1, r2";
@@ -2097,7 +2097,7 @@ BA51 (rev16 r1, r2) @ 0x130 - OK
 
 BAD1 (revsh r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[186w; 209w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "revsh r1, r2";
@@ -2113,7 +2113,7 @@ BAD1 (revsh r1, r2) @ 0x130 - OK
 
 3104 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[49w; 4w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "3104";
@@ -2141,7 +2141,7 @@ BAD1 (revsh r1, r2) @ 0x130 - OK
 
 B007 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[176w; 7w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B007";
@@ -2156,7 +2156,7 @@ B007 @ 0x130 - OK
 
 4A15 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[74w; 21w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4A15";
@@ -2169,7 +2169,7 @@ B007 @ 0x130 - OK
 
 4011 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[64w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4011";
@@ -2194,7 +2194,7 @@ B007 @ 0x130 - OK
 
 B510 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[181w; 16w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B510";
@@ -2229,7 +2229,7 @@ B510 @ 0x130 - OK
 
 BA18 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[186w; 24w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "BA18";
@@ -2242,7 +2242,7 @@ BA18 @ 0x130 - OK
 
 F000F858 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[240w; 0w; 248w; 88w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "F000F858";
@@ -2257,7 +2257,7 @@ F000F858 @ 0x130 - OK
 
 BDF7 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[189w; 247w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "BDF7";
@@ -2325,7 +2325,7 @@ BDF7 @ 0x130 - OK
 
 3202 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[50w; 2w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "3202";
@@ -2353,7 +2353,7 @@ BDF7 @ 0x130 - OK
 
 635C @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[99w; 92w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "635C";
@@ -2377,7 +2377,7 @@ BDF7 @ 0x130 - OK
 
 70E8 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[112w; 232w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "70E8";
@@ -2399,7 +2399,7 @@ BDF7 @ 0x130 - OK
 
 B285 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[178w; 133w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B285";
@@ -2413,7 +2413,7 @@ B285 @ 0x130 - OK
 
 8028 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[128w; 40w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "8028";
@@ -2440,7 +2440,7 @@ A1BC @ 0x130 - FAILED
 
 4182 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 130w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4182";
@@ -2483,7 +2483,7 @@ A1BC @ 0x130 - FAILED
 
 1000 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[16w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "1000";
@@ -2509,7 +2509,7 @@ A1BC @ 0x130 - FAILED
 
 4088 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[64w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4088";
@@ -2555,7 +2555,7 @@ A1BC @ 0x130 - FAILED
 
 B5F7 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[181w; 247w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B5F7";
@@ -2630,7 +2630,7 @@ B5F7 @ 0x130 - OK
 
 C29C @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[194w; 156w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "C29C";

--- a/src/tools/lifter/selftest_m0_be_proc.log
+++ b/src/tools/lifter/selftest_m0_be_proc.log
@@ -1,6 +1,6 @@
 4608 (mov r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[70w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mov r0, r1";
@@ -12,7 +12,7 @@
 
 0008 (movs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[0w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "movs r0, r1";
@@ -30,7 +30,7 @@
 
 468F (mov pc, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[70w; 143w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mov pc, r1";
@@ -43,7 +43,7 @@
 
 1C08 (adds r0, r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[28w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, #0";
@@ -63,7 +63,7 @@
 
 1C88 (adds r0, r1, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[28w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, #2";
@@ -91,7 +91,7 @@
 
 1888 (adds r0, r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[24w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, r2";
@@ -119,7 +119,7 @@
 
 4408 (add r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[68w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add r0, r1";
@@ -133,7 +133,7 @@
 
 448F (add pc, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[68w; 143w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add pc, r1";
@@ -148,7 +148,7 @@
 
 3080 (adds r0, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[48w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, #128";
@@ -176,7 +176,7 @@
 
 4148 (adcs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 72w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adcs r0, r1";
@@ -215,7 +215,7 @@
 
 B020 (add sp, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[176w; 32w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add sp, #128";
@@ -230,7 +230,7 @@ B020 (add sp, #128) @ 0x130 - OK
 
 A820 (add r0, sp, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[168w; 32w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add r0, sp, #128";
@@ -244,7 +244,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1A88 (subs r0, r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[26w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, r2";
@@ -272,7 +272,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1EC8 (subs r0, r1, #3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[30w; 200w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, #3";
@@ -300,7 +300,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1A48 (subs r0, r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[26w; 72w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, r1";
@@ -316,7 +316,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1E08 (subs r0, r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[30w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, #0";
@@ -336,7 +336,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 3880 (subs r0, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[56w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, #128";
@@ -364,7 +364,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1E00 (subs r0, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[30w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, #0";
@@ -382,7 +382,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 4198 (sbcs r0, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 152w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sbcs r0, r3";
@@ -425,7 +425,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 B082 (sub sp, #8) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[176w; 130w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sub sp, #8";
@@ -440,7 +440,7 @@ B082 (sub sp, #8) @ 0x130 - OK
 
 B084 (sub sp, #16) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[176w; 132w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sub sp, #16";
@@ -455,7 +455,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4251 (rsbs r1, r2, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[66w; 81w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rsbs r1, r2, #0";
@@ -483,7 +483,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4359 (muls r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[67w; 89w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "muls r1, r3";
@@ -508,7 +508,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4299 (cmp r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[66w; 153w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, r3";
@@ -532,7 +532,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4289 (cmp r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[66w; 137w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, r1";
@@ -546,7 +546,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 2900 (cmp r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[41w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, #0";
@@ -564,7 +564,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 290C (cmp r1, #12) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[41w; 12w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, #12";
@@ -588,7 +588,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 42D9 (cmn r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[66w; 217w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmn r1, r3";
@@ -612,7 +612,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 42C9 (cmn r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[66w; 201w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmn r1, r1";
@@ -636,7 +636,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4009 (ands r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[64w; 9w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ands r1, r1";
@@ -652,7 +652,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4011 (ands r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[64w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ands r1, r2";
@@ -677,7 +677,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4051 (eors r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[64w; 81w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "eors r1, r2";
@@ -702,7 +702,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4049 (eors r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[64w; 73w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "eors r1, r1";
@@ -716,7 +716,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4311 (orrs r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[67w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "orrs r1, r2";
@@ -741,7 +741,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4309 (orrs r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[67w; 9w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "orrs r1, r1";
@@ -757,7 +757,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4391 (bics r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[67w; 145w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bics r1, r2";
@@ -785,7 +785,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4389 (bics r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[67w; 137w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bics r1, r1";
@@ -799,7 +799,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 43D1 (mvns r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[67w; 209w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mvns r1, r2";
@@ -821,7 +821,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 43C9 (mvns r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[67w; 201w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mvns r1, r1";
@@ -843,7 +843,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4211 (tst r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[66w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "tst r1, r2";
@@ -864,7 +864,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4209 (tst r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[66w; 9w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "tst r1, r1";
@@ -880,7 +880,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4088 (lsls r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[64w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, r1";
@@ -926,7 +926,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0080 (lsls r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[0w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, #2";
@@ -951,7 +951,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0000 (lsls r0, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[0w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, #0";
@@ -967,7 +967,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 40C8 (lsrs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[64w; 200w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsrs r0, r1";
@@ -1018,7 +1018,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0880 (lsrs r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[8w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsrs r0, #2";
@@ -1045,7 +1045,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4108 (asrs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "asrs r0, r1";
@@ -1098,7 +1098,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 1080 (asrs r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[16w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "asrs r0, #2";
@@ -1125,7 +1125,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 41C8 (rors r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 200w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rors r0, r1";
@@ -1160,7 +1160,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6801 (ldr r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[104w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0]";
@@ -1177,7 +1177,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6841 (ldr r1, [r0, #4]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[104w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, #4]";
@@ -1195,7 +1195,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6881 (ldr r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[104w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, #8]";
@@ -1213,7 +1213,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8901 (ldrh r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[137w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #8]";
@@ -1232,7 +1232,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8801 (ldrh r1, [r0, #0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[136w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #0]";
@@ -1250,7 +1250,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8841 (ldrh r1, [r0, #2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[136w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #2]";
@@ -1269,7 +1269,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7801 (ldrb r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[120w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0]";
@@ -1284,7 +1284,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7841 (ldrb r1, [r0, #1]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[120w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, #1]";
@@ -1300,7 +1300,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7CC1 (ldrb r1, [r0, #19]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[124w; 193w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, #19]";
@@ -1316,7 +1316,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5881 (ldr r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[88w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, r2]";
@@ -1337,7 +1337,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5A81 (ldrh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[90w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, r2]";
@@ -1359,7 +1359,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5E81 (ldrsh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[94w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrsh r1, [r0, r2]";
@@ -1381,7 +1381,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5C81 (ldrb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[92w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, r2]";
@@ -1398,7 +1398,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5681 (ldrsb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[86w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrsb r1, [r0, r2]";
@@ -1415,7 +1415,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4902 (ldr r1, [pc, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[73w; 2w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [pc, #8]";
@@ -1428,7 +1428,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 9902 (ldr r1, [sp, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[153w; 2w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [sp, #8]";
@@ -1446,7 +1446,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[203w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldm r3, {r1, r2, r3}";
@@ -1473,7 +1473,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6001 (str r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[96w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0]";
@@ -1493,7 +1493,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6041 (str r1, [r0, #4]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[96w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, #4]";
@@ -1517,7 +1517,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6081 (str r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[96w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, #8]";
@@ -1541,7 +1541,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8101 (strh r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #8]";
@@ -1566,7 +1566,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8001 (strh r1, [r0, #0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[128w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #0]";
@@ -1587,7 +1587,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8041 (strh r1, [r0, #2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[128w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #2]";
@@ -1612,7 +1612,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 7001 (strb r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[112w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0]";
@@ -1630,7 +1630,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 7041 (strb r1, [r0, #1]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[112w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, #1]";
@@ -1652,7 +1652,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 74C1 (strb r1, [r0, #19]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[116w; 193w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, #19]";
@@ -1674,7 +1674,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5081 (str r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[80w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, r2]";
@@ -1700,7 +1700,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5281 (strh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[82w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, r2]";
@@ -1728,7 +1728,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5481 (strb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[84w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, r2]";
@@ -1751,7 +1751,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 9102 (str r1, [sp, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[145w; 2w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [sp, #8]";
@@ -1775,7 +1775,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 C10E (stm r1!, {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[193w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "stm r1!, {r1, r2, r3}";
@@ -1813,7 +1813,7 @@ C10E (stm r1!, {r1, r2, r3}) @ 0x130 - OK
 
 B40E (push {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[180w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "push {r1, r2, r3}";
@@ -1854,7 +1854,7 @@ B40E (push {r1, r2, r3}) @ 0x130 - OK
 
 BC0E (pop {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[188w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "pop {r1, r2, r3}";
@@ -1885,7 +1885,7 @@ BC0E (pop {r1, r2, r3}) @ 0x130 - OK
 
 B50E (push {r1, r2, r3, lr}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[181w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "push {r1, r2, r3, lr}";
@@ -1932,7 +1932,7 @@ B50E (push {r1, r2, r3, lr}) @ 0x130 - OK
 
 BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[189w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "pop {r1, r2, r3, pc}";
@@ -1980,7 +1980,7 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 4708 (bx r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[71w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bx r1";
@@ -1998,7 +1998,7 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 4788 (blx r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[71w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "blx r1";
@@ -2015,7 +2015,7 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 B211 (sxth r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[178w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sxth r1, r2";
@@ -2029,7 +2029,7 @@ B211 (sxth r1, r2) @ 0x130 - OK
 
 B251 (sxtb r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[178w; 81w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sxtb r1, r2";
@@ -2043,7 +2043,7 @@ B251 (sxtb r1, r2) @ 0x130 - OK
 
 B291 (uxth r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[178w; 145w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "uxth r1, r2";
@@ -2057,7 +2057,7 @@ B291 (uxth r1, r2) @ 0x130 - OK
 
 B2D1 (uxtb r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[178w; 209w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "uxtb r1, r2";
@@ -2071,7 +2071,7 @@ B2D1 (uxtb r1, r2) @ 0x130 - OK
 
 BA11 (rev r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[186w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rev r1, r2";
@@ -2084,7 +2084,7 @@ BA11 (rev r1, r2) @ 0x130 - OK
 
 BA51 (rev16 r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[186w; 81w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rev16 r1, r2";
@@ -2098,7 +2098,7 @@ BA51 (rev16 r1, r2) @ 0x130 - OK
 
 BAD1 (revsh r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[186w; 209w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "revsh r1, r2";
@@ -2114,7 +2114,7 @@ BAD1 (revsh r1, r2) @ 0x130 - OK
 
 3104 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[49w; 4w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "3104";
@@ -2142,7 +2142,7 @@ BAD1 (revsh r1, r2) @ 0x130 - OK
 
 B007 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[176w; 7w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B007";
@@ -2157,7 +2157,7 @@ B007 @ 0x130 - OK
 
 4A15 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[74w; 21w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4A15";
@@ -2170,7 +2170,7 @@ B007 @ 0x130 - OK
 
 4011 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[64w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4011";
@@ -2195,7 +2195,7 @@ B007 @ 0x130 - OK
 
 B510 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[181w; 16w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B510";
@@ -2230,7 +2230,7 @@ B510 @ 0x130 - OK
 
 BA18 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[186w; 24w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "BA18";
@@ -2243,7 +2243,7 @@ BA18 @ 0x130 - OK
 
 F000F858 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[240w; 0w; 248w; 88w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "F000F858";
@@ -2258,7 +2258,7 @@ F000F858 @ 0x130 - OK
 
 BDF7 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[189w; 247w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "BDF7";
@@ -2326,7 +2326,7 @@ BDF7 @ 0x130 - OK
 
 3202 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[50w; 2w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "3202";
@@ -2354,7 +2354,7 @@ BDF7 @ 0x130 - OK
 
 635C @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[99w; 92w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "635C";
@@ -2378,7 +2378,7 @@ BDF7 @ 0x130 - OK
 
 70E8 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[112w; 232w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "70E8";
@@ -2400,7 +2400,7 @@ BDF7 @ 0x130 - OK
 
 B285 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[178w; 133w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B285";
@@ -2414,7 +2414,7 @@ B285 @ 0x130 - OK
 
 8028 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[128w; 40w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "8028";
@@ -2441,7 +2441,7 @@ A1BC @ 0x130 - FAILED
 
 4182 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 130w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4182";
@@ -2484,7 +2484,7 @@ A1BC @ 0x130 - FAILED
 
 1000 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[16w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "1000";
@@ -2510,7 +2510,7 @@ A1BC @ 0x130 - FAILED
 
 4088 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[64w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4088";
@@ -2556,7 +2556,7 @@ A1BC @ 0x130 - FAILED
 
 B5F7 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[181w; 247w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B5F7";
@@ -2633,7 +2633,7 @@ B5F7 @ 0x130 - OK
 
 C29C @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (T,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[194w; 156w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "C29C";

--- a/src/tools/lifter/selftest_m0_le_main.log
+++ b/src/tools/lifter/selftest_m0_le_main.log
@@ -1,6 +1,6 @@
 4608 (mov r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[8w; 70w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mov r0, r1";
@@ -12,7 +12,7 @@
 
 0008 (movs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[8w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "movs r0, r1";
@@ -30,7 +30,7 @@
 
 468F (mov pc, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[143w; 70w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mov pc, r1";
@@ -43,7 +43,7 @@
 
 1C08 (adds r0, r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[8w; 28w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, #0";
@@ -63,7 +63,7 @@
 
 1C88 (adds r0, r1, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[136w; 28w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, #2";
@@ -91,7 +91,7 @@
 
 1888 (adds r0, r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[136w; 24w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, r2";
@@ -119,7 +119,7 @@
 
 4408 (add r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[8w; 68w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add r0, r1";
@@ -133,7 +133,7 @@
 
 448F (add pc, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[143w; 68w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add pc, r1";
@@ -148,7 +148,7 @@
 
 3080 (adds r0, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[128w; 48w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, #128";
@@ -176,7 +176,7 @@
 
 4148 (adcs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[72w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adcs r0, r1";
@@ -215,7 +215,7 @@
 
 B020 (add sp, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[32w; 176w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add sp, #128";
@@ -230,7 +230,7 @@ B020 (add sp, #128) @ 0x130 - OK
 
 A820 (add r0, sp, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[32w; 168w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add r0, sp, #128";
@@ -244,7 +244,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1A88 (subs r0, r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[136w; 26w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, r2";
@@ -272,7 +272,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1EC8 (subs r0, r1, #3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[200w; 30w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, #3";
@@ -300,7 +300,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1A48 (subs r0, r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[72w; 26w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, r1";
@@ -316,7 +316,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1E08 (subs r0, r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[8w; 30w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, #0";
@@ -336,7 +336,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 3880 (subs r0, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[128w; 56w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, #128";
@@ -364,7 +364,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1E00 (subs r0, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[0w; 30w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, #0";
@@ -382,7 +382,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 4198 (sbcs r0, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[152w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sbcs r0, r3";
@@ -425,7 +425,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 B082 (sub sp, #8) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[130w; 176w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sub sp, #8";
@@ -440,7 +440,7 @@ B082 (sub sp, #8) @ 0x130 - OK
 
 B084 (sub sp, #16) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[132w; 176w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sub sp, #16";
@@ -455,7 +455,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4251 (rsbs r1, r2, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[81w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rsbs r1, r2, #0";
@@ -483,7 +483,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4359 (muls r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[89w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "muls r1, r3";
@@ -508,7 +508,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4299 (cmp r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[153w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, r3";
@@ -532,7 +532,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4289 (cmp r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[137w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, r1";
@@ -546,7 +546,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 2900 (cmp r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[0w; 41w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, #0";
@@ -564,7 +564,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 290C (cmp r1, #12) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[12w; 41w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, #12";
@@ -588,7 +588,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 42D9 (cmn r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[217w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmn r1, r3";
@@ -612,7 +612,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 42C9 (cmn r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[201w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmn r1, r1";
@@ -636,7 +636,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4009 (ands r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[9w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ands r1, r1";
@@ -652,7 +652,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4011 (ands r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[17w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ands r1, r2";
@@ -677,7 +677,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4051 (eors r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[81w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "eors r1, r2";
@@ -702,7 +702,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4049 (eors r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[73w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "eors r1, r1";
@@ -716,7 +716,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4311 (orrs r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[17w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "orrs r1, r2";
@@ -741,7 +741,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4309 (orrs r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[9w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "orrs r1, r1";
@@ -757,7 +757,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4391 (bics r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[145w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bics r1, r2";
@@ -785,7 +785,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4389 (bics r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[137w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bics r1, r1";
@@ -799,7 +799,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 43D1 (mvns r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[209w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mvns r1, r2";
@@ -821,7 +821,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 43C9 (mvns r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[201w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mvns r1, r1";
@@ -843,7 +843,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4211 (tst r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[17w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "tst r1, r2";
@@ -864,7 +864,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4209 (tst r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[9w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "tst r1, r1";
@@ -880,7 +880,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4088 (lsls r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[136w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, r1";
@@ -926,7 +926,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0080 (lsls r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[128w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, #2";
@@ -951,7 +951,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0000 (lsls r0, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[0w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, #0";
@@ -967,7 +967,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 40C8 (lsrs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[200w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsrs r0, r1";
@@ -1018,7 +1018,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0880 (lsrs r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[128w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsrs r0, #2";
@@ -1045,7 +1045,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4108 (asrs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[8w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "asrs r0, r1";
@@ -1098,7 +1098,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 1080 (asrs r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[128w; 16w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "asrs r0, #2";
@@ -1125,7 +1125,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 41C8 (rors r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[200w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rors r0, r1";
@@ -1160,7 +1160,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6801 (ldr r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[1w; 104w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0]";
@@ -1177,7 +1177,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6841 (ldr r1, [r0, #4]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 104w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, #4]";
@@ -1195,7 +1195,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6881 (ldr r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 104w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, #8]";
@@ -1213,7 +1213,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8901 (ldrh r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[1w; 137w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #8]";
@@ -1233,7 +1233,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8801 (ldrh r1, [r0, #0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[1w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #0]";
@@ -1251,7 +1251,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8841 (ldrh r1, [r0, #2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #2]";
@@ -1271,7 +1271,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7801 (ldrb r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[1w; 120w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0]";
@@ -1286,7 +1286,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7841 (ldrb r1, [r0, #1]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 120w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, #1]";
@@ -1303,7 +1303,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7CC1 (ldrb r1, [r0, #19]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[193w; 124w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, #19]";
@@ -1320,7 +1320,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5881 (ldr r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 88w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, r2]";
@@ -1341,7 +1341,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5A81 (ldrh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 90w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, r2]";
@@ -1363,7 +1363,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5E81 (ldrsh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 94w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrsh r1, [r0, r2]";
@@ -1385,7 +1385,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5C81 (ldrb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 92w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, r2]";
@@ -1402,7 +1402,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5681 (ldrsb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 86w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrsb r1, [r0, r2]";
@@ -1419,7 +1419,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4902 (ldr r1, [pc, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[2w; 73w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [pc, #8]";
@@ -1432,7 +1432,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 9902 (ldr r1, [sp, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[2w; 153w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [sp, #8]";
@@ -1450,7 +1450,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[14w; 203w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldm r3, {r1, r2, r3}";
@@ -1477,7 +1477,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6001 (str r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[1w; 96w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0]";
@@ -1497,7 +1497,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6041 (str r1, [r0, #4]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 96w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, #4]";
@@ -1521,7 +1521,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6081 (str r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 96w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, #8]";
@@ -1545,7 +1545,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8101 (strh r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[1w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #8]";
@@ -1570,7 +1570,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8001 (strh r1, [r0, #0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[1w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #0]";
@@ -1591,7 +1591,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8041 (strh r1, [r0, #2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #2]";
@@ -1616,7 +1616,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 7001 (strb r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[1w; 112w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0]";
@@ -1634,7 +1634,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 7041 (strb r1, [r0, #1]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 112w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, #1]";
@@ -1656,7 +1656,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 74C1 (strb r1, [r0, #19]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[193w; 116w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, #19]";
@@ -1678,7 +1678,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5081 (str r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 80w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, r2]";
@@ -1704,7 +1704,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5281 (strh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 82w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, r2]";
@@ -1732,7 +1732,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5481 (strb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 84w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, r2]";
@@ -1755,7 +1755,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 9102 (str r1, [sp, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[2w; 145w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [sp, #8]";
@@ -1779,7 +1779,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 C10E (stm r1!, {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[14w; 193w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "stm r1!, {r1, r2, r3}";
@@ -1817,7 +1817,7 @@ C10E (stm r1!, {r1, r2, r3}) @ 0x130 - OK
 
 B40E (push {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[14w; 180w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "push {r1, r2, r3}";
@@ -1858,7 +1858,7 @@ B40E (push {r1, r2, r3}) @ 0x130 - OK
 
 BC0E (pop {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[14w; 188w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "pop {r1, r2, r3}";
@@ -1889,7 +1889,7 @@ BC0E (pop {r1, r2, r3}) @ 0x130 - OK
 
 B50E (push {r1, r2, r3, lr}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[14w; 181w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "push {r1, r2, r3, lr}";
@@ -1935,7 +1935,7 @@ B50E (push {r1, r2, r3, lr}) @ 0x130 - OK
 
 BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[14w; 189w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "pop {r1, r2, r3, pc}";
@@ -1983,7 +1983,7 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 4708 (bx r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[8w; 71w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bx r1";
@@ -2001,7 +2001,7 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 4788 (blx r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[136w; 71w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "blx r1";
@@ -2018,7 +2018,7 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 B211 (sxth r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[17w; 178w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sxth r1, r2";
@@ -2032,7 +2032,7 @@ B211 (sxth r1, r2) @ 0x130 - OK
 
 B251 (sxtb r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[81w; 178w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sxtb r1, r2";
@@ -2046,7 +2046,7 @@ B251 (sxtb r1, r2) @ 0x130 - OK
 
 B291 (uxth r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[145w; 178w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "uxth r1, r2";
@@ -2060,7 +2060,7 @@ B291 (uxth r1, r2) @ 0x130 - OK
 
 B2D1 (uxtb r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[209w; 178w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "uxtb r1, r2";
@@ -2074,7 +2074,7 @@ B2D1 (uxtb r1, r2) @ 0x130 - OK
 
 BA11 (rev r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[17w; 186w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rev r1, r2";
@@ -2087,7 +2087,7 @@ BA11 (rev r1, r2) @ 0x130 - OK
 
 BA51 (rev16 r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[81w; 186w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rev16 r1, r2";
@@ -2101,7 +2101,7 @@ BA51 (rev16 r1, r2) @ 0x130 - OK
 
 BAD1 (revsh r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[209w; 186w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "revsh r1, r2";
@@ -2117,7 +2117,7 @@ BAD1 (revsh r1, r2) @ 0x130 - OK
 
 3104 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[4w; 49w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "3104";
@@ -2145,7 +2145,7 @@ BAD1 (revsh r1, r2) @ 0x130 - OK
 
 B007 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[7w; 176w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B007";
@@ -2160,7 +2160,7 @@ B007 @ 0x130 - OK
 
 4A15 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[21w; 74w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4A15";
@@ -2173,7 +2173,7 @@ B007 @ 0x130 - OK
 
 4011 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[17w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4011";
@@ -2198,7 +2198,7 @@ B007 @ 0x130 - OK
 
 B510 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[16w; 181w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B510";
@@ -2233,7 +2233,7 @@ B510 @ 0x130 - OK
 
 BA18 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[24w; 186w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "BA18";
@@ -2246,7 +2246,7 @@ BA18 @ 0x130 - OK
 
 F000F858 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[0w; 240w; 88w; 248w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "F000F858";
@@ -2261,7 +2261,7 @@ F000F858 @ 0x130 - OK
 
 BDF7 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[247w; 189w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "BDF7";
@@ -2329,7 +2329,7 @@ BDF7 @ 0x130 - OK
 
 3202 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[2w; 50w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "3202";
@@ -2357,7 +2357,7 @@ BDF7 @ 0x130 - OK
 
 635C @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[92w; 99w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "635C";
@@ -2381,7 +2381,7 @@ BDF7 @ 0x130 - OK
 
 70E8 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[232w; 112w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "70E8";
@@ -2403,7 +2403,7 @@ BDF7 @ 0x130 - OK
 
 B285 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[133w; 178w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B285";
@@ -2417,7 +2417,7 @@ B285 @ 0x130 - OK
 
 8028 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[40w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "8028";
@@ -2444,7 +2444,7 @@ A1BC @ 0x130 - FAILED
 
 4182 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[130w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4182";
@@ -2487,7 +2487,7 @@ A1BC @ 0x130 - FAILED
 
 1000 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[0w; 16w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "1000";
@@ -2513,7 +2513,7 @@ A1BC @ 0x130 - FAILED
 
 4088 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[136w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4088";
@@ -2559,7 +2559,7 @@ A1BC @ 0x130 - FAILED
 
 B5F7 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[247w; 181w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B5F7";
@@ -2635,7 +2635,7 @@ B5F7 @ 0x130 - OK
 
 C29C @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,F)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[156w; 194w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "C29C";

--- a/src/tools/lifter/selftest_m0_le_proc.log
+++ b/src/tools/lifter/selftest_m0_le_proc.log
@@ -3,7 +3,7 @@ MANUAL TESTS - M0
 
 4608 (mov r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[8w; 70w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mov r0, r1";
@@ -15,7 +15,7 @@ MANUAL TESTS - M0
 
 0008 (movs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[8w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "movs r0, r1";
@@ -33,7 +33,7 @@ MANUAL TESTS - M0
 
 468F (mov pc, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[143w; 70w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mov pc, r1";
@@ -46,7 +46,7 @@ MANUAL TESTS - M0
 
 1C08 (adds r0, r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[8w; 28w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, #0";
@@ -66,7 +66,7 @@ MANUAL TESTS - M0
 
 1C88 (adds r0, r1, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[136w; 28w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, #2";
@@ -94,7 +94,7 @@ MANUAL TESTS - M0
 
 1888 (adds r0, r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[136w; 24w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, r2";
@@ -122,7 +122,7 @@ MANUAL TESTS - M0
 
 4408 (add r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[8w; 68w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add r0, r1";
@@ -136,7 +136,7 @@ MANUAL TESTS - M0
 
 448F (add pc, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[143w; 68w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add pc, r1";
@@ -151,7 +151,7 @@ MANUAL TESTS - M0
 
 3080 (adds r0, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[128w; 48w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, #128";
@@ -179,7 +179,7 @@ MANUAL TESTS - M0
 
 4148 (adcs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[72w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adcs r0, r1";
@@ -218,7 +218,7 @@ MANUAL TESTS - M0
 
 B020 (add sp, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[32w; 176w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add sp, #128";
@@ -233,7 +233,7 @@ B020 (add sp, #128) @ 0x130 - OK
 
 A820 (add r0, sp, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[32w; 168w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add r0, sp, #128";
@@ -247,7 +247,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1A88 (subs r0, r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[136w; 26w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, r2";
@@ -275,7 +275,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1EC8 (subs r0, r1, #3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[200w; 30w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, #3";
@@ -303,7 +303,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1A48 (subs r0, r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[72w; 26w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, r1";
@@ -319,7 +319,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1E08 (subs r0, r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[8w; 30w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, #0";
@@ -339,7 +339,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 3880 (subs r0, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[128w; 56w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, #128";
@@ -367,7 +367,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1E00 (subs r0, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[0w; 30w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, #0";
@@ -385,7 +385,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 4198 (sbcs r0, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[152w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sbcs r0, r3";
@@ -428,7 +428,7 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 B082 (sub sp, #8) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[130w; 176w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sub sp, #8";
@@ -443,7 +443,7 @@ B082 (sub sp, #8) @ 0x130 - OK
 
 B084 (sub sp, #16) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[132w; 176w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sub sp, #16";
@@ -458,7 +458,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4251 (rsbs r1, r2, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[81w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rsbs r1, r2, #0";
@@ -486,7 +486,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4359 (muls r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[89w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "muls r1, r3";
@@ -511,7 +511,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4299 (cmp r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[153w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, r3";
@@ -535,7 +535,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4289 (cmp r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[137w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, r1";
@@ -549,7 +549,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 2900 (cmp r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[0w; 41w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, #0";
@@ -567,7 +567,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 290C (cmp r1, #12) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[12w; 41w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, #12";
@@ -591,7 +591,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 42D9 (cmn r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[217w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmn r1, r3";
@@ -615,7 +615,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 42C9 (cmn r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[201w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmn r1, r1";
@@ -639,7 +639,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4009 (ands r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[9w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ands r1, r1";
@@ -655,7 +655,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4011 (ands r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[17w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ands r1, r2";
@@ -680,7 +680,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4051 (eors r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[81w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "eors r1, r2";
@@ -705,7 +705,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4049 (eors r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[73w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "eors r1, r1";
@@ -719,7 +719,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4311 (orrs r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[17w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "orrs r1, r2";
@@ -744,7 +744,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4309 (orrs r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[9w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "orrs r1, r1";
@@ -760,7 +760,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4391 (bics r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[145w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bics r1, r2";
@@ -788,7 +788,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4389 (bics r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[137w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bics r1, r1";
@@ -802,7 +802,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 43D1 (mvns r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[209w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mvns r1, r2";
@@ -824,7 +824,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 43C9 (mvns r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[201w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mvns r1, r1";
@@ -846,7 +846,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4211 (tst r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[17w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "tst r1, r2";
@@ -867,7 +867,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4209 (tst r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[9w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "tst r1, r1";
@@ -883,7 +883,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4088 (lsls r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[136w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, r1";
@@ -929,7 +929,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0080 (lsls r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[128w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, #2";
@@ -954,7 +954,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0000 (lsls r0, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[0w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, #0";
@@ -970,7 +970,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 40C8 (lsrs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[200w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsrs r0, r1";
@@ -1021,7 +1021,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0880 (lsrs r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[128w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsrs r0, #2";
@@ -1048,7 +1048,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4108 (asrs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[8w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "asrs r0, r1";
@@ -1101,7 +1101,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 1080 (asrs r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[128w; 16w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "asrs r0, #2";
@@ -1128,7 +1128,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 41C8 (rors r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[200w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rors r0, r1";
@@ -1163,7 +1163,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6801 (ldr r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[1w; 104w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0]";
@@ -1180,7 +1180,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6841 (ldr r1, [r0, #4]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 104w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, #4]";
@@ -1198,7 +1198,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6881 (ldr r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 104w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, #8]";
@@ -1216,7 +1216,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8901 (ldrh r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[1w; 137w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #8]";
@@ -1236,7 +1236,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8801 (ldrh r1, [r0, #0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[1w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #0]";
@@ -1254,7 +1254,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8841 (ldrh r1, [r0, #2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #2]";
@@ -1274,7 +1274,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7801 (ldrb r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[1w; 120w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0]";
@@ -1289,7 +1289,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7841 (ldrb r1, [r0, #1]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 120w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, #1]";
@@ -1306,7 +1306,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7CC1 (ldrb r1, [r0, #19]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[193w; 124w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, #19]";
@@ -1323,7 +1323,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5881 (ldr r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 88w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, r2]";
@@ -1344,7 +1344,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5A81 (ldrh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 90w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, r2]";
@@ -1366,7 +1366,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5E81 (ldrsh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 94w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrsh r1, [r0, r2]";
@@ -1388,7 +1388,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5C81 (ldrb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 92w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, r2]";
@@ -1405,7 +1405,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5681 (ldrsb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 86w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrsb r1, [r0, r2]";
@@ -1422,7 +1422,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4902 (ldr r1, [pc, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[2w; 73w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [pc, #8]";
@@ -1435,7 +1435,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 9902 (ldr r1, [sp, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[2w; 153w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [sp, #8]";
@@ -1453,7 +1453,7 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[14w; 203w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldm r3, {r1, r2, r3}";
@@ -1480,7 +1480,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6001 (str r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[1w; 96w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0]";
@@ -1500,7 +1500,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6041 (str r1, [r0, #4]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 96w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, #4]";
@@ -1524,7 +1524,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6081 (str r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 96w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, #8]";
@@ -1548,7 +1548,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8101 (strh r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[1w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #8]";
@@ -1573,7 +1573,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8001 (strh r1, [r0, #0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[1w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #0]";
@@ -1594,7 +1594,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8041 (strh r1, [r0, #2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #2]";
@@ -1619,7 +1619,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 7001 (strb r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[1w; 112w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0]";
@@ -1637,7 +1637,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 7041 (strb r1, [r0, #1]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[65w; 112w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, #1]";
@@ -1659,7 +1659,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 74C1 (strb r1, [r0, #19]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[193w; 116w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, #19]";
@@ -1681,7 +1681,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5081 (str r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 80w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, r2]";
@@ -1707,7 +1707,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5281 (strh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 82w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, r2]";
@@ -1735,7 +1735,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5481 (strb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[129w; 84w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, r2]";
@@ -1758,7 +1758,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 9102 (str r1, [sp, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[2w; 145w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [sp, #8]";
@@ -1782,7 +1782,7 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 C10E (stm r1!, {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[14w; 193w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "stm r1!, {r1, r2, r3}";
@@ -1820,7 +1820,7 @@ C10E (stm r1!, {r1, r2, r3}) @ 0x130 - OK
 
 B40E (push {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[14w; 180w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "push {r1, r2, r3}";
@@ -1861,7 +1861,7 @@ B40E (push {r1, r2, r3}) @ 0x130 - OK
 
 BC0E (pop {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[14w; 188w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "pop {r1, r2, r3}";
@@ -1892,7 +1892,7 @@ BC0E (pop {r1, r2, r3}) @ 0x130 - OK
 
 B50E (push {r1, r2, r3, lr}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[14w; 181w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "push {r1, r2, r3, lr}";
@@ -1939,7 +1939,7 @@ B50E (push {r1, r2, r3, lr}) @ 0x130 - OK
 
 BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[14w; 189w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "pop {r1, r2, r3, pc}";
@@ -1987,7 +1987,7 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 4708 (bx r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[8w; 71w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bx r1";
@@ -2005,7 +2005,7 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 4788 (blx r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[136w; 71w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "blx r1";
@@ -2022,7 +2022,7 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 B211 (sxth r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[17w; 178w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sxth r1, r2";
@@ -2036,7 +2036,7 @@ B211 (sxth r1, r2) @ 0x130 - OK
 
 B251 (sxtb r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[81w; 178w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sxtb r1, r2";
@@ -2050,7 +2050,7 @@ B251 (sxtb r1, r2) @ 0x130 - OK
 
 B291 (uxth r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[145w; 178w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "uxth r1, r2";
@@ -2064,7 +2064,7 @@ B291 (uxth r1, r2) @ 0x130 - OK
 
 B2D1 (uxtb r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[209w; 178w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "uxtb r1, r2";
@@ -2078,7 +2078,7 @@ B2D1 (uxtb r1, r2) @ 0x130 - OK
 
 BA11 (rev r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[17w; 186w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rev r1, r2";
@@ -2091,7 +2091,7 @@ BA11 (rev r1, r2) @ 0x130 - OK
 
 BA51 (rev16 r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[81w; 186w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rev16 r1, r2";
@@ -2105,7 +2105,7 @@ BA51 (rev16 r1, r2) @ 0x130 - OK
 
 BAD1 (revsh r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[209w; 186w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "revsh r1, r2";
@@ -2121,7 +2121,7 @@ BAD1 (revsh r1, r2) @ 0x130 - OK
 
 3104 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[4w; 49w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "3104";
@@ -2149,7 +2149,7 @@ BAD1 (revsh r1, r2) @ 0x130 - OK
 
 B007 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[7w; 176w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B007";
@@ -2164,7 +2164,7 @@ B007 @ 0x130 - OK
 
 4A15 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[21w; 74w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4A15";
@@ -2177,7 +2177,7 @@ B007 @ 0x130 - OK
 
 4011 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[17w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4011";
@@ -2202,7 +2202,7 @@ B007 @ 0x130 - OK
 
 B510 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[16w; 181w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B510";
@@ -2237,7 +2237,7 @@ B510 @ 0x130 - OK
 
 BA18 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[24w; 186w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "BA18";
@@ -2250,7 +2250,7 @@ BA18 @ 0x130 - OK
 
 F000F858 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[0w; 240w; 88w; 248w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "F000F858";
@@ -2265,7 +2265,7 @@ F000F858 @ 0x130 - OK
 
 BDF7 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[247w; 189w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "BDF7";
@@ -2333,7 +2333,7 @@ BDF7 @ 0x130 - OK
 
 3202 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[2w; 50w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "3202";
@@ -2361,7 +2361,7 @@ BDF7 @ 0x130 - OK
 
 635C @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[92w; 99w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "635C";
@@ -2385,7 +2385,7 @@ BDF7 @ 0x130 - OK
 
 70E8 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[232w; 112w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "70E8";
@@ -2407,7 +2407,7 @@ BDF7 @ 0x130 - OK
 
 B285 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[133w; 178w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B285";
@@ -2421,7 +2421,7 @@ B285 @ 0x130 - OK
 
 8028 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[40w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "8028";
@@ -2448,7 +2448,7 @@ A1BC @ 0x130 - FAILED
 
 4182 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[130w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4182";
@@ -2491,7 +2491,7 @@ A1BC @ 0x130 - FAILED
 
 1000 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[0w; 16w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "1000";
@@ -2517,7 +2517,7 @@ A1BC @ 0x130 - FAILED
 
 4088 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[136w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4088";
@@ -2563,7 +2563,7 @@ A1BC @ 0x130 - FAILED
 
 B5F7 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[247w; 181w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B5F7";
@@ -2641,7 +2641,7 @@ B5F7 @ 0x130 - OK
 
 C29C @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
+|- bir_is_lifted_inst_prog (m0_bmr (F,T)) (Imm32 304w) (WI_end 0w 0x10000w)
      (304w,[156w; 194w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "C29C";

--- a/src/tools/lifter/selftest_m0_mod_be_main.log
+++ b/src/tools/lifter/selftest_m0_mod_be_main.log
@@ -1,14 +1,14 @@
 4608 (mov r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[70w; 8w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[70w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mov r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R0" (BType_Imm Bit32))
                 (BExp_Den (BVar "R1" (BType_Imm Bit32)));
               BStmt_Assign (BVar "countw" (BType_Imm Bit64))
@@ -20,15 +20,15 @@
 
 0008 (movs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[0w; 8w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[0w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "movs r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_Z" BType_Bool)
@@ -46,15 +46,15 @@
 
 468F (mov pc, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[70w; 143w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[70w; 143w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mov pc, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551612w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFCw)));
               BStmt_Assign (BVar "countw" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
@@ -67,15 +67,15 @@
 
 1C08 (adds r0, r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[28w; 8w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[28w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
@@ -95,15 +95,15 @@
 
 1C88 (adds r0, r1, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[28w; 136w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[28w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, #2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 2w)));
@@ -131,15 +131,15 @@
 
 1888 (adds r0, r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[24w; 136w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[24w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit32))));
@@ -167,15 +167,15 @@
 
 4408 (add r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[68w; 8w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[68w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R0" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "R0" (BType_Imm Bit32)))
@@ -189,15 +189,15 @@
 
 448F (add pc, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[68w; 143w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[68w; 143w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add pc, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551612w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFCw)));
               BStmt_Assign (BVar "countw" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
@@ -212,15 +212,15 @@
 
 3080 (adds r0, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[48w; 128w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[48w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, #128";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R0" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 128w)));
@@ -248,15 +248,15 @@
 
 4148 (adcs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 72w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 72w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adcs r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "tmp_PSR_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C
                    (BExp_Den (BVar "R0" (BType_Imm Bit32)))
@@ -295,15 +295,15 @@
 
 B020 (add sp, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[176w; 32w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[176w; 32w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add sp, #128";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "SP_main" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Align Bit32 2
@@ -318,15 +318,15 @@ B020 (add sp, #128) @ 0x130 - OK
 
 A820 (add r0, sp, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[168w; 32w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[168w; 32w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add r0, sp, #128";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R0" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "SP_main" (BType_Imm Bit32)))
@@ -340,15 +340,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1A88 (subs r0, r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[26w; 136w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[26w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit32))));
@@ -376,15 +376,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1EC8 (subs r0, r1, #3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[30w; 200w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[30w; 200w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, #3";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 3w)));
@@ -412,15 +412,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1A48 (subs r0, r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[26w; 72w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[26w; 72w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "PSR_N" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "PSR_V" BType_Bool) bir_exp_false;
@@ -436,15 +436,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1E08 (subs r0, r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[30w; 8w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[30w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
@@ -464,15 +464,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 3880 (subs r0, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[56w; 128w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[56w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, #128";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R0" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 128w)));
@@ -500,15 +500,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1E00 (subs r0, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[30w; 0w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[30w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -526,15 +526,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 4198 (sbcs r0, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 152w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 152w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sbcs r0, r3";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "tmp_PSR_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C
                    (BExp_Den (BVar "R0" (BType_Imm Bit32)))
@@ -577,15 +577,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 B082 (sub sp, #8) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[176w; 130w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[176w; 130w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sub sp, #8";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "SP_main" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Minus
                    (BExp_Align Bit32 2
@@ -600,15 +600,15 @@ B082 (sub sp, #8) @ 0x130 - OK
 
 B084 (sub sp, #16) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[176w; 132w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[176w; 132w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sub sp, #16";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "SP_main" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Minus
                    (BExp_Align Bit32 2
@@ -623,15 +623,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4251 (rsbs r1, r2, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[66w; 81w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[66w; 81w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rsbs r1, r2, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_BinPred BIExp_Equal
                    (BExp_Den (BVar "R2" (BType_Imm Bit32)))
@@ -659,15 +659,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4359 (muls r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[67w; 89w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[67w; 89w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "muls r1, r3";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_Mult
@@ -692,15 +692,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4299 (cmp r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[66w; 153w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[66w; 153w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, r3";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Den (BVar "R3" (BType_Imm Bit32))));
@@ -724,15 +724,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4289 (cmp r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[66w; 137w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[66w; 137w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "PSR_N" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "PSR_V" BType_Bool) bir_exp_false;
@@ -746,15 +746,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 2900 (cmp r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[41w; 0w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[41w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
@@ -772,15 +772,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 290C (cmp r1, #12) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[41w; 12w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[41w; 12w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, #12";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 12w)));
@@ -804,15 +804,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 42D9 (cmn r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[66w; 217w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[66w; 217w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmn r1, r3";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Den (BVar "R3" (BType_Imm Bit32))));
@@ -836,15 +836,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 42C9 (cmn r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[66w; 201w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[66w; 201w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmn r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Den (BVar "R1" (BType_Imm Bit32))));
@@ -868,15 +868,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4009 (ands r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[64w; 9w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[64w; 9w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ands r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_Z" BType_Bool)
@@ -892,15 +892,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4011 (ands r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[64w; 17w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[64w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ands r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_And
@@ -925,15 +925,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4051 (eors r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[64w; 81w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[64w; 81w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "eors r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_Xor
@@ -958,15 +958,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4049 (eors r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[64w; 73w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[64w; 73w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "eors r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "PSR_Z" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
@@ -980,15 +980,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4311 (orrs r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[67w; 17w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[67w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "orrs r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_Or
@@ -1013,15 +1013,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4309 (orrs r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[67w; 9w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[67w; 9w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "orrs r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_Z" BType_Bool)
@@ -1037,15 +1037,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4391 (bics r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[67w; 145w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[67w; 145w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bics r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_And
@@ -1073,15 +1073,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4389 (bics r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[67w; 137w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[67w; 137w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bics r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "PSR_Z" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
@@ -1095,15 +1095,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 43D1 (mvns r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[67w; 209w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[67w; 209w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mvns r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_UnaryExp BIExp_Not
@@ -1125,15 +1125,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 43C9 (mvns r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[67w; 201w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[67w; 201w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mvns r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_UnaryExp BIExp_Not
@@ -1155,15 +1155,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4211 (tst r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[66w; 17w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[66w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "tst r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_And
@@ -1184,15 +1184,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4209 (tst r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[66w; 9w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[66w; 9w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "tst r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_Z" BType_Bool)
@@ -1208,15 +1208,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4088 (lsls r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[64w; 136w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[64w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
@@ -1262,15 +1262,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0080 (lsls r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[0w; 128w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[0w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, #2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_word_bit Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32)))
                    30);
@@ -1295,15 +1295,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0000 (lsls r0, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[0w; 0w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[0w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_Z" BType_Bool)
@@ -1319,15 +1319,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 40C8 (lsrs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[64w; 200w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[64w; 200w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsrs r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
@@ -1378,15 +1378,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0880 (lsrs r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[8w; 128w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[8w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsrs r0, #2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_word_bit Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32)))
                    1);
@@ -1413,15 +1413,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4108 (asrs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 8w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "asrs r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
@@ -1474,15 +1474,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 1080 (asrs r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[16w; 128w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[16w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "asrs r0, #2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_word_bit Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32)))
                    1);
@@ -1509,15 +1509,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 41C8 (rors r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 200w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 200w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rors r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
@@ -1552,15 +1552,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6801 (ldr r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[104w; 1w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[104w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1577,15 +1577,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6841 (ldr r1, [r0, #4]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[104w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[104w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, #4]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1603,15 +1603,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6881 (ldr r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[104w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[104w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1629,15 +1629,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8901 (ldrh r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[137w; 1w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[137w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1656,15 +1656,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8801 (ldrh r1, [r0, #0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[136w; 1w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[136w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1682,15 +1682,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8841 (ldrh r1, [r0, #2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[136w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[136w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1709,15 +1709,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7801 (ldrb r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[120w; 1w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[120w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
@@ -1732,15 +1732,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7841 (ldrb r1, [r0, #1]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[120w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[120w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, #1]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
@@ -1756,15 +1756,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7CC1 (ldrb r1, [r0, #19]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[124w; 193w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[124w; 193w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, #19]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
@@ -1780,15 +1780,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5881 (ldr r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[88w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[88w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_BinExp BIExp_Plus
@@ -1809,15 +1809,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5A81 (ldrh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[90w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[90w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_BinExp BIExp_Plus
@@ -1839,15 +1839,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5E81 (ldrsh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[94w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[94w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrsh r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_BinExp BIExp_Plus
@@ -1869,15 +1869,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5C81 (ldrb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[92w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[92w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
@@ -1894,15 +1894,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5681 (ldrsb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[86w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[86w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrsb r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_SignedCast
                    (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
@@ -1919,15 +1919,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4902 (ldr r1, [pc, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[73w; 2w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[73w; 2w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [pc, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
                    (BExp_Const (Imm32 316w)) BEnd_BigEndian Bit32);
@@ -1940,15 +1940,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 9902 (ldr r1, [sp, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[153w; 2w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[153w; 2w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [sp, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_main" (BType_Imm Bit32))));
@@ -1966,15 +1966,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[203w; 14w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[203w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldm r3, {r1, r2, r3}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551611w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFBw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R3" (BType_Imm Bit32))));
@@ -2001,15 +2001,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6001 (str r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[96w; 1w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[96w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2029,15 +2029,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6041 (str r1, [r0, #4]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[96w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[96w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, #4]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2061,15 +2061,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6081 (str r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[96w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[96w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2093,15 +2093,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8101 (strh r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 1w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2126,15 +2126,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8001 (strh r1, [r0, #0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[128w; 1w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[128w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2155,15 +2155,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8041 (strh r1, [r0, #2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[128w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[128w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2188,15 +2188,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 7001 (strb r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[112w; 1w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[112w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_unchanged_mem_interval_distinct Bit32 0 65536
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))) 1);
@@ -2214,15 +2214,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 7041 (strb r1, [r0, #1]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[112w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[112w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, #1]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_unchanged_mem_interval_distinct Bit32 0 65536
                    (BExp_BinExp BIExp_Plus
@@ -2244,15 +2244,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 74C1 (strb r1, [r0, #19]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[116w; 193w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[116w; 193w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, #19]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_unchanged_mem_interval_distinct Bit32 0 65536
                    (BExp_BinExp BIExp_Plus
@@ -2274,15 +2274,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5081 (str r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[80w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[80w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_BinExp BIExp_Plus
@@ -2308,15 +2308,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5281 (strh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[82w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[82w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_BinExp BIExp_Plus
@@ -2344,15 +2344,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5481 (strb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[84w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[84w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_unchanged_mem_interval_distinct Bit32 0 65536
                    (BExp_BinExp BIExp_Plus
@@ -2375,15 +2375,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 9102 (str r1, [sp, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[145w; 2w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[145w; 2w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [sp, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_main" (BType_Imm Bit32))));
@@ -2407,15 +2407,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 C10E (stm r1!, {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[193w; 14w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[193w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "stm r1!, {r1, r2, r3}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551611w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFBw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R1" (BType_Imm Bit32))));
@@ -2453,15 +2453,15 @@ C10E (stm r1!, {r1, r2, r3}) @ 0x130 - OK
 
 B40E (push {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[180w; 14w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[180w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "push {r1, r2, r3}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551611w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFBw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_main" (BType_Imm Bit32))));
@@ -2502,15 +2502,15 @@ B40E (push {r1, r2, r3}) @ 0x130 - OK
 
 BC0E (pop {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[188w; 14w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[188w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "pop {r1, r2, r3}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551611w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFBw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_main" (BType_Imm Bit32))));
@@ -2541,15 +2541,15 @@ BC0E (pop {r1, r2, r3}) @ 0x130 - OK
 
 B50E (push {r1, r2, r3, lr}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[181w; 14w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[181w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "push {r1, r2, r3, lr}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551610w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFAw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_main" (BType_Imm Bit32))));
@@ -2595,15 +2595,15 @@ B50E (push {r1, r2, r3, lr}) @ 0x130 - OK
 
 BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[189w; 14w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[189w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "pop {r1, r2, r3, pc}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551607w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFF7w)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_main" (BType_Imm Bit32))));
@@ -2651,15 +2651,15 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 4708 (bx r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[71w; 8w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[71w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bx r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551612w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFCw)));
               BStmt_Assert
                 (BExp_LSB (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assert
@@ -2677,15 +2677,15 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 4788 (blx r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[71w; 136w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[71w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "blx r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551612w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFCw)));
               BStmt_Assert
                 (BExp_LSB (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assign (BVar "LR" (BType_Imm Bit32))
@@ -2702,15 +2702,15 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 B211 (sxth r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[178w; 17w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[178w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sxth r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_SignedCast
                    (BExp_Cast BIExp_LowCast
@@ -2724,15 +2724,15 @@ B211 (sxth r1, r2) @ 0x130 - OK
 
 B251 (sxtb r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[178w; 81w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[178w; 81w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sxtb r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_SignedCast
                    (BExp_Cast BIExp_LowCast
@@ -2746,15 +2746,15 @@ B251 (sxtb r1, r2) @ 0x130 - OK
 
 B291 (uxth r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[178w; 145w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[178w; 145w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "uxth r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Cast BIExp_LowCast
@@ -2768,15 +2768,15 @@ B291 (uxth r1, r2) @ 0x130 - OK
 
 B2D1 (uxtb r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[178w; 209w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[178w; 209w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "uxtb r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Cast BIExp_LowCast
@@ -2790,15 +2790,15 @@ B2D1 (uxtb r1, r2) @ 0x130 - OK
 
 BA11 (rev r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[186w; 17w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[186w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rev r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_word_reverse_8_32
                    (BExp_Den (BVar "R2" (BType_Imm Bit32))));
@@ -2811,15 +2811,15 @@ BA11 (rev r1, r2) @ 0x130 - OK
 
 BA51 (rev16 r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[186w; 81w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[186w; 81w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rev16 r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_word_reverse_16_32
                    (BExp_word_reverse_8_32
@@ -2833,15 +2833,15 @@ BA51 (rev16 r1, r2) @ 0x130 - OK
 
 BAD1 (revsh r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[186w; 209w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[186w; 209w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "revsh r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_SignedCast
                    (BExp_word_reverse_8_16
@@ -2857,15 +2857,15 @@ BAD1 (revsh r1, r2) @ 0x130 - OK
 
 3104 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[49w; 4w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[49w; 4w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "3104";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 4w)));
@@ -2893,15 +2893,15 @@ BAD1 (revsh r1, r2) @ 0x130 - OK
 
 B007 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[176w; 7w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[176w; 7w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B007";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "SP_main" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Align Bit32 2
@@ -2916,15 +2916,15 @@ B007 @ 0x130 - OK
 
 4A15 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[74w; 21w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[74w; 21w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4A15";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R2" (BType_Imm Bit32))
                 (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
                    (BExp_Const (Imm32 392w)) BEnd_BigEndian Bit32);
@@ -2937,15 +2937,15 @@ B007 @ 0x130 - OK
 
 4011 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[64w; 17w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[64w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4011";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_And
@@ -2970,15 +2970,15 @@ B007 @ 0x130 - OK
 
 B510 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[181w; 16w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[181w; 16w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B510";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551612w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFCw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_main" (BType_Imm Bit32))));
@@ -3013,15 +3013,15 @@ B510 @ 0x130 - OK
 
 BA18 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[186w; 24w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[186w; 24w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "BA18";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R0" (BType_Imm Bit32))
                 (BExp_word_reverse_8_32
                    (BExp_Den (BVar "R3" (BType_Imm Bit32))));
@@ -3034,15 +3034,15 @@ BA18 @ 0x130 - OK
 
 F000F858 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[240w; 0w; 248w; 88w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[240w; 0w; 248w; 88w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "F000F858";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551611w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFBw)));
               BStmt_Assign (BVar "LR" (BType_Imm Bit32))
                 (BExp_Const (Imm32 309w));
               BStmt_Assign (BVar "countw" (BType_Imm Bit64))
@@ -3057,15 +3057,15 @@ F000F858 @ 0x130 - OK
 
 BDF7 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[189w; 247w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[189w; 247w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "BDF7";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551603w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFF3w)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_main" (BType_Imm Bit32))));
@@ -3133,15 +3133,15 @@ BDF7 @ 0x130 - OK
 
 3202 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[50w; 2w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[50w; 2w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "3202";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R2" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 2w)));
@@ -3169,15 +3169,15 @@ BDF7 @ 0x130 - OK
 
 635C @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[99w; 92w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[99w; 92w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "635C";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R3" (BType_Imm Bit32))));
@@ -3201,15 +3201,15 @@ BDF7 @ 0x130 - OK
 
 70E8 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[112w; 232w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[112w; 232w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "70E8";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_unchanged_mem_interval_distinct Bit32 0 65536
                    (BExp_BinExp BIExp_Plus
@@ -3231,15 +3231,15 @@ BDF7 @ 0x130 - OK
 
 B285 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[178w; 133w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[178w; 133w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B285";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R5" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Cast BIExp_LowCast
@@ -3253,15 +3253,15 @@ B285 @ 0x130 - OK
 
 8028 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[128w; 40w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[128w; 40w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "8028";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R5" (BType_Imm Bit32))));
@@ -3288,15 +3288,15 @@ A1BC @ 0x130 - FAILED
 
 4182 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 130w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 130w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4182";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "tmp_PSR_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C
                    (BExp_Den (BVar "R2" (BType_Imm Bit32)))
@@ -3339,15 +3339,15 @@ A1BC @ 0x130 - FAILED
 
 1000 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[16w; 0w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[16w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "1000";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
@@ -3373,15 +3373,15 @@ A1BC @ 0x130 - FAILED
 
 4088 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[64w; 136w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[64w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4088";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
@@ -3427,15 +3427,15 @@ A1BC @ 0x130 - FAILED
 
 B5F7 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[181w; 247w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[181w; 247w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B5F7";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551606w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFF6w)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_main" (BType_Imm Bit32))));
@@ -3510,15 +3510,15 @@ B5F7 @ 0x130 - OK
 
 C29C @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[194w; 156w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[194w; 156w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "C29C";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551610w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFAw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R2" (BType_Imm Bit32))));

--- a/src/tools/lifter/selftest_m0_mod_be_proc.log
+++ b/src/tools/lifter/selftest_m0_mod_be_proc.log
@@ -1,14 +1,14 @@
 4608 (mov r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[70w; 8w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[70w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mov r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R0" (BType_Imm Bit32))
                 (BExp_Den (BVar "R1" (BType_Imm Bit32)));
               BStmt_Assign (BVar "countw" (BType_Imm Bit64))
@@ -20,15 +20,15 @@
 
 0008 (movs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[0w; 8w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[0w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "movs r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_Z" BType_Bool)
@@ -46,15 +46,15 @@
 
 468F (mov pc, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[70w; 143w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[70w; 143w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mov pc, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551612w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFCw)));
               BStmt_Assign (BVar "countw" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
@@ -67,15 +67,15 @@
 
 1C08 (adds r0, r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[28w; 8w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[28w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
@@ -95,15 +95,15 @@
 
 1C88 (adds r0, r1, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[28w; 136w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[28w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, #2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 2w)));
@@ -131,15 +131,15 @@
 
 1888 (adds r0, r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[24w; 136w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[24w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit32))));
@@ -167,15 +167,15 @@
 
 4408 (add r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[68w; 8w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[68w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R0" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "R0" (BType_Imm Bit32)))
@@ -189,15 +189,15 @@
 
 448F (add pc, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[68w; 143w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[68w; 143w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add pc, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551612w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFCw)));
               BStmt_Assign (BVar "countw" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
@@ -212,15 +212,15 @@
 
 3080 (adds r0, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[48w; 128w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[48w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, #128";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R0" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 128w)));
@@ -248,15 +248,15 @@
 
 4148 (adcs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 72w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 72w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adcs r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "tmp_PSR_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C
                    (BExp_Den (BVar "R0" (BType_Imm Bit32)))
@@ -295,15 +295,15 @@
 
 B020 (add sp, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[176w; 32w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[176w; 32w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add sp, #128";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "SP_process" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Align Bit32 2
@@ -318,15 +318,15 @@ B020 (add sp, #128) @ 0x130 - OK
 
 A820 (add r0, sp, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[168w; 32w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[168w; 32w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add r0, sp, #128";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R0" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "SP_process" (BType_Imm Bit32)))
@@ -340,15 +340,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1A88 (subs r0, r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[26w; 136w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[26w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit32))));
@@ -376,15 +376,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1EC8 (subs r0, r1, #3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[30w; 200w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[30w; 200w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, #3";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 3w)));
@@ -412,15 +412,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1A48 (subs r0, r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[26w; 72w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[26w; 72w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "PSR_N" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "PSR_V" BType_Bool) bir_exp_false;
@@ -436,15 +436,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1E08 (subs r0, r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[30w; 8w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[30w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
@@ -464,15 +464,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 3880 (subs r0, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[56w; 128w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[56w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, #128";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R0" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 128w)));
@@ -500,15 +500,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1E00 (subs r0, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[30w; 0w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[30w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -526,15 +526,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 4198 (sbcs r0, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 152w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 152w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sbcs r0, r3";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "tmp_PSR_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C
                    (BExp_Den (BVar "R0" (BType_Imm Bit32)))
@@ -577,15 +577,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 B082 (sub sp, #8) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[176w; 130w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[176w; 130w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sub sp, #8";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "SP_process" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Minus
                    (BExp_Align Bit32 2
@@ -600,15 +600,15 @@ B082 (sub sp, #8) @ 0x130 - OK
 
 B084 (sub sp, #16) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[176w; 132w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[176w; 132w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sub sp, #16";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "SP_process" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Minus
                    (BExp_Align Bit32 2
@@ -623,15 +623,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4251 (rsbs r1, r2, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[66w; 81w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[66w; 81w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rsbs r1, r2, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_BinPred BIExp_Equal
                    (BExp_Den (BVar "R2" (BType_Imm Bit32)))
@@ -659,15 +659,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4359 (muls r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[67w; 89w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[67w; 89w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "muls r1, r3";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_Mult
@@ -692,15 +692,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4299 (cmp r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[66w; 153w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[66w; 153w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, r3";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Den (BVar "R3" (BType_Imm Bit32))));
@@ -724,15 +724,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4289 (cmp r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[66w; 137w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[66w; 137w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "PSR_N" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "PSR_V" BType_Bool) bir_exp_false;
@@ -746,15 +746,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 2900 (cmp r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[41w; 0w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[41w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
@@ -772,15 +772,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 290C (cmp r1, #12) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[41w; 12w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[41w; 12w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, #12";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 12w)));
@@ -804,15 +804,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 42D9 (cmn r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[66w; 217w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[66w; 217w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmn r1, r3";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Den (BVar "R3" (BType_Imm Bit32))));
@@ -836,15 +836,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 42C9 (cmn r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[66w; 201w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[66w; 201w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmn r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Den (BVar "R1" (BType_Imm Bit32))));
@@ -868,15 +868,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4009 (ands r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[64w; 9w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[64w; 9w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ands r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_Z" BType_Bool)
@@ -892,15 +892,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4011 (ands r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[64w; 17w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[64w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ands r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_And
@@ -925,15 +925,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4051 (eors r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[64w; 81w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[64w; 81w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "eors r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_Xor
@@ -958,15 +958,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4049 (eors r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[64w; 73w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[64w; 73w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "eors r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "PSR_Z" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
@@ -980,15 +980,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4311 (orrs r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[67w; 17w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[67w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "orrs r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_Or
@@ -1013,15 +1013,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4309 (orrs r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[67w; 9w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[67w; 9w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "orrs r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_Z" BType_Bool)
@@ -1037,15 +1037,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4391 (bics r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[67w; 145w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[67w; 145w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bics r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_And
@@ -1073,15 +1073,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4389 (bics r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[67w; 137w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[67w; 137w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bics r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "PSR_Z" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
@@ -1095,15 +1095,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 43D1 (mvns r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[67w; 209w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[67w; 209w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mvns r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_UnaryExp BIExp_Not
@@ -1125,15 +1125,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 43C9 (mvns r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[67w; 201w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[67w; 201w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mvns r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_UnaryExp BIExp_Not
@@ -1155,15 +1155,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4211 (tst r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[66w; 17w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[66w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "tst r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_And
@@ -1184,15 +1184,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4209 (tst r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[66w; 9w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[66w; 9w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "tst r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_Z" BType_Bool)
@@ -1208,15 +1208,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4088 (lsls r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[64w; 136w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[64w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
@@ -1262,15 +1262,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0080 (lsls r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[0w; 128w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[0w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, #2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_word_bit Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32)))
                    30);
@@ -1295,15 +1295,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0000 (lsls r0, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[0w; 0w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[0w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_Z" BType_Bool)
@@ -1319,15 +1319,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 40C8 (lsrs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[64w; 200w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[64w; 200w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsrs r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
@@ -1378,15 +1378,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0880 (lsrs r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[8w; 128w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[8w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsrs r0, #2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_word_bit Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32)))
                    1);
@@ -1413,15 +1413,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4108 (asrs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 8w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "asrs r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
@@ -1474,15 +1474,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 1080 (asrs r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[16w; 128w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[16w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "asrs r0, #2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_word_bit Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32)))
                    1);
@@ -1509,15 +1509,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 41C8 (rors r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 200w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 200w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rors r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
@@ -1552,15 +1552,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6801 (ldr r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[104w; 1w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[104w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1577,15 +1577,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6841 (ldr r1, [r0, #4]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[104w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[104w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, #4]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1603,15 +1603,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6881 (ldr r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[104w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[104w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1629,15 +1629,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8901 (ldrh r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[137w; 1w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[137w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1656,15 +1656,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8801 (ldrh r1, [r0, #0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[136w; 1w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[136w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1682,15 +1682,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8841 (ldrh r1, [r0, #2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[136w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[136w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1709,15 +1709,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7801 (ldrb r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[120w; 1w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[120w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
@@ -1732,15 +1732,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7841 (ldrb r1, [r0, #1]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[120w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[120w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, #1]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
@@ -1756,15 +1756,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7CC1 (ldrb r1, [r0, #19]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[124w; 193w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[124w; 193w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, #19]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
@@ -1780,15 +1780,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5881 (ldr r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[88w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[88w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_BinExp BIExp_Plus
@@ -1809,15 +1809,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5A81 (ldrh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[90w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[90w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_BinExp BIExp_Plus
@@ -1839,15 +1839,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5E81 (ldrsh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[94w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[94w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrsh r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_BinExp BIExp_Plus
@@ -1869,15 +1869,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5C81 (ldrb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[92w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[92w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
@@ -1894,15 +1894,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5681 (ldrsb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[86w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[86w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrsb r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_SignedCast
                    (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
@@ -1919,15 +1919,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4902 (ldr r1, [pc, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[73w; 2w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[73w; 2w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [pc, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
                    (BExp_Const (Imm32 316w)) BEnd_BigEndian Bit32);
@@ -1940,15 +1940,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 9902 (ldr r1, [sp, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[153w; 2w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[153w; 2w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [sp, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_process" (BType_Imm Bit32))));
@@ -1966,15 +1966,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[203w; 14w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[203w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldm r3, {r1, r2, r3}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551611w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFBw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R3" (BType_Imm Bit32))));
@@ -2001,15 +2001,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6001 (str r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[96w; 1w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[96w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2029,15 +2029,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6041 (str r1, [r0, #4]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[96w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[96w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, #4]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2061,15 +2061,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6081 (str r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[96w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[96w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2093,15 +2093,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8101 (strh r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 1w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2126,15 +2126,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8001 (strh r1, [r0, #0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[128w; 1w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[128w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2155,15 +2155,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8041 (strh r1, [r0, #2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[128w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[128w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2188,15 +2188,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 7001 (strb r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[112w; 1w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[112w; 1w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_unchanged_mem_interval_distinct Bit32 0 65536
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))) 1);
@@ -2214,15 +2214,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 7041 (strb r1, [r0, #1]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[112w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[112w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, #1]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_unchanged_mem_interval_distinct Bit32 0 65536
                    (BExp_BinExp BIExp_Plus
@@ -2244,15 +2244,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 74C1 (strb r1, [r0, #19]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[116w; 193w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[116w; 193w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, #19]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_unchanged_mem_interval_distinct Bit32 0 65536
                    (BExp_BinExp BIExp_Plus
@@ -2274,15 +2274,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5081 (str r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[80w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[80w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_BinExp BIExp_Plus
@@ -2308,15 +2308,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5281 (strh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[82w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[82w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_BinExp BIExp_Plus
@@ -2344,15 +2344,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5481 (strb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[84w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[84w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_unchanged_mem_interval_distinct Bit32 0 65536
                    (BExp_BinExp BIExp_Plus
@@ -2375,15 +2375,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 9102 (str r1, [sp, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[145w; 2w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[145w; 2w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [sp, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_process" (BType_Imm Bit32))));
@@ -2407,15 +2407,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 C10E (stm r1!, {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[193w; 14w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[193w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "stm r1!, {r1, r2, r3}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551611w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFBw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R1" (BType_Imm Bit32))));
@@ -2453,15 +2453,15 @@ C10E (stm r1!, {r1, r2, r3}) @ 0x130 - OK
 
 B40E (push {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[180w; 14w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[180w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "push {r1, r2, r3}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551611w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFBw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_process" (BType_Imm Bit32))));
@@ -2502,15 +2502,15 @@ B40E (push {r1, r2, r3}) @ 0x130 - OK
 
 BC0E (pop {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[188w; 14w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[188w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "pop {r1, r2, r3}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551611w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFBw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_process" (BType_Imm Bit32))));
@@ -2541,15 +2541,15 @@ BC0E (pop {r1, r2, r3}) @ 0x130 - OK
 
 B50E (push {r1, r2, r3, lr}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[181w; 14w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[181w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "push {r1, r2, r3, lr}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551610w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFAw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_process" (BType_Imm Bit32))));
@@ -2596,15 +2596,15 @@ B50E (push {r1, r2, r3, lr}) @ 0x130 - OK
 
 BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[189w; 14w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[189w; 14w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "pop {r1, r2, r3, pc}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551607w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFF7w)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_process" (BType_Imm Bit32))));
@@ -2652,15 +2652,15 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 4708 (bx r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[71w; 8w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[71w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bx r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551612w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFCw)));
               BStmt_Assert
                 (BExp_LSB (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assert
@@ -2678,15 +2678,15 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 4788 (blx r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[71w; 136w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[71w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "blx r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551612w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFCw)));
               BStmt_Assert
                 (BExp_LSB (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assign (BVar "LR" (BType_Imm Bit32))
@@ -2703,15 +2703,15 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 B211 (sxth r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[178w; 17w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[178w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sxth r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_SignedCast
                    (BExp_Cast BIExp_LowCast
@@ -2725,15 +2725,15 @@ B211 (sxth r1, r2) @ 0x130 - OK
 
 B251 (sxtb r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[178w; 81w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[178w; 81w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sxtb r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_SignedCast
                    (BExp_Cast BIExp_LowCast
@@ -2747,15 +2747,15 @@ B251 (sxtb r1, r2) @ 0x130 - OK
 
 B291 (uxth r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[178w; 145w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[178w; 145w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "uxth r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Cast BIExp_LowCast
@@ -2769,15 +2769,15 @@ B291 (uxth r1, r2) @ 0x130 - OK
 
 B2D1 (uxtb r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[178w; 209w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[178w; 209w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "uxtb r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Cast BIExp_LowCast
@@ -2791,15 +2791,15 @@ B2D1 (uxtb r1, r2) @ 0x130 - OK
 
 BA11 (rev r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[186w; 17w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[186w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rev r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_word_reverse_8_32
                    (BExp_Den (BVar "R2" (BType_Imm Bit32))));
@@ -2812,15 +2812,15 @@ BA11 (rev r1, r2) @ 0x130 - OK
 
 BA51 (rev16 r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[186w; 81w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[186w; 81w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rev16 r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_word_reverse_16_32
                    (BExp_word_reverse_8_32
@@ -2834,15 +2834,15 @@ BA51 (rev16 r1, r2) @ 0x130 - OK
 
 BAD1 (revsh r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[186w; 209w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[186w; 209w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "revsh r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_SignedCast
                    (BExp_word_reverse_8_16
@@ -2858,15 +2858,15 @@ BAD1 (revsh r1, r2) @ 0x130 - OK
 
 3104 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[49w; 4w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[49w; 4w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "3104";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 4w)));
@@ -2894,15 +2894,15 @@ BAD1 (revsh r1, r2) @ 0x130 - OK
 
 B007 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[176w; 7w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[176w; 7w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B007";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "SP_process" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Align Bit32 2
@@ -2917,15 +2917,15 @@ B007 @ 0x130 - OK
 
 4A15 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[74w; 21w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[74w; 21w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4A15";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R2" (BType_Imm Bit32))
                 (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
                    (BExp_Const (Imm32 392w)) BEnd_BigEndian Bit32);
@@ -2938,15 +2938,15 @@ B007 @ 0x130 - OK
 
 4011 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[64w; 17w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[64w; 17w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4011";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_And
@@ -2971,15 +2971,15 @@ B007 @ 0x130 - OK
 
 B510 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[181w; 16w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[181w; 16w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B510";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551612w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFCw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_process" (BType_Imm Bit32))));
@@ -3014,15 +3014,15 @@ B510 @ 0x130 - OK
 
 BA18 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[186w; 24w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[186w; 24w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "BA18";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R0" (BType_Imm Bit32))
                 (BExp_word_reverse_8_32
                    (BExp_Den (BVar "R3" (BType_Imm Bit32))));
@@ -3035,15 +3035,15 @@ BA18 @ 0x130 - OK
 
 F000F858 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[240w; 0w; 248w; 88w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[240w; 0w; 248w; 88w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "F000F858";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551611w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFBw)));
               BStmt_Assign (BVar "LR" (BType_Imm Bit32))
                 (BExp_Const (Imm32 309w));
               BStmt_Assign (BVar "countw" (BType_Imm Bit64))
@@ -3058,15 +3058,15 @@ F000F858 @ 0x130 - OK
 
 BDF7 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[189w; 247w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[189w; 247w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "BDF7";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551603w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFF3w)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_process" (BType_Imm Bit32))));
@@ -3134,15 +3134,15 @@ BDF7 @ 0x130 - OK
 
 3202 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[50w; 2w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[50w; 2w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "3202";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R2" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 2w)));
@@ -3170,15 +3170,15 @@ BDF7 @ 0x130 - OK
 
 635C @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[99w; 92w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[99w; 92w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "635C";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R3" (BType_Imm Bit32))));
@@ -3202,15 +3202,15 @@ BDF7 @ 0x130 - OK
 
 70E8 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[112w; 232w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[112w; 232w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "70E8";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_unchanged_mem_interval_distinct Bit32 0 65536
                    (BExp_BinExp BIExp_Plus
@@ -3232,15 +3232,15 @@ BDF7 @ 0x130 - OK
 
 B285 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[178w; 133w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[178w; 133w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B285";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R5" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Cast BIExp_LowCast
@@ -3254,15 +3254,15 @@ B285 @ 0x130 - OK
 
 8028 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[128w; 40w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[128w; 40w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "8028";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R5" (BType_Imm Bit32))));
@@ -3289,15 +3289,15 @@ A1BC @ 0x130 - FAILED
 
 4182 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 130w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 130w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4182";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "tmp_PSR_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C
                    (BExp_Den (BVar "R2" (BType_Imm Bit32)))
@@ -3340,15 +3340,15 @@ A1BC @ 0x130 - FAILED
 
 1000 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[16w; 0w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[16w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "1000";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
@@ -3374,15 +3374,15 @@ A1BC @ 0x130 - FAILED
 
 4088 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[64w; 136w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[64w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4088";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
@@ -3428,15 +3428,15 @@ A1BC @ 0x130 - FAILED
 
 B5F7 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[181w; 247w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[181w; 247w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B5F7";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551606w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFF6w)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_process" (BType_Imm Bit32))));
@@ -3513,15 +3513,15 @@ B5F7 @ 0x130 - OK
 
 C29C @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[194w; 156w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (T,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[194w; 156w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "C29C";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551610w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFAw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R2" (BType_Imm Bit32))));

--- a/src/tools/lifter/selftest_m0_mod_le_main.log
+++ b/src/tools/lifter/selftest_m0_mod_le_main.log
@@ -1,14 +1,14 @@
 4608 (mov r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[8w; 70w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[8w; 70w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mov r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R0" (BType_Imm Bit32))
                 (BExp_Den (BVar "R1" (BType_Imm Bit32)));
               BStmt_Assign (BVar "countw" (BType_Imm Bit64))
@@ -20,15 +20,15 @@
 
 0008 (movs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[8w; 0w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[8w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "movs r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_Z" BType_Bool)
@@ -46,15 +46,15 @@
 
 468F (mov pc, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[143w; 70w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[143w; 70w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mov pc, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551612w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFCw)));
               BStmt_Assign (BVar "countw" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
@@ -67,15 +67,15 @@
 
 1C08 (adds r0, r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[8w; 28w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[8w; 28w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
@@ -95,15 +95,15 @@
 
 1C88 (adds r0, r1, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[136w; 28w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[136w; 28w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, #2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 2w)));
@@ -131,15 +131,15 @@
 
 1888 (adds r0, r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[136w; 24w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[136w; 24w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit32))));
@@ -167,15 +167,15 @@
 
 4408 (add r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[8w; 68w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[8w; 68w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R0" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "R0" (BType_Imm Bit32)))
@@ -189,15 +189,15 @@
 
 448F (add pc, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[143w; 68w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[143w; 68w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add pc, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551612w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFCw)));
               BStmt_Assign (BVar "countw" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
@@ -212,15 +212,15 @@
 
 3080 (adds r0, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[128w; 48w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[128w; 48w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, #128";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R0" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 128w)));
@@ -248,15 +248,15 @@
 
 4148 (adcs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[72w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[72w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adcs r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "tmp_PSR_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C
                    (BExp_Den (BVar "R0" (BType_Imm Bit32)))
@@ -295,15 +295,15 @@
 
 B020 (add sp, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[32w; 176w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[32w; 176w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add sp, #128";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "SP_main" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Align Bit32 2
@@ -318,15 +318,15 @@ B020 (add sp, #128) @ 0x130 - OK
 
 A820 (add r0, sp, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[32w; 168w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[32w; 168w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add r0, sp, #128";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R0" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "SP_main" (BType_Imm Bit32)))
@@ -340,15 +340,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1A88 (subs r0, r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[136w; 26w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[136w; 26w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit32))));
@@ -376,15 +376,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1EC8 (subs r0, r1, #3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[200w; 30w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[200w; 30w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, #3";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 3w)));
@@ -412,15 +412,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1A48 (subs r0, r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[72w; 26w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[72w; 26w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "PSR_N" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "PSR_V" BType_Bool) bir_exp_false;
@@ -436,15 +436,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1E08 (subs r0, r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[8w; 30w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[8w; 30w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
@@ -464,15 +464,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 3880 (subs r0, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[128w; 56w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[128w; 56w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, #128";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R0" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 128w)));
@@ -500,15 +500,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1E00 (subs r0, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[0w; 30w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[0w; 30w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -526,15 +526,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 4198 (sbcs r0, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[152w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[152w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sbcs r0, r3";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "tmp_PSR_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C
                    (BExp_Den (BVar "R0" (BType_Imm Bit32)))
@@ -577,15 +577,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 B082 (sub sp, #8) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[130w; 176w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[130w; 176w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sub sp, #8";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "SP_main" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Minus
                    (BExp_Align Bit32 2
@@ -600,15 +600,15 @@ B082 (sub sp, #8) @ 0x130 - OK
 
 B084 (sub sp, #16) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[132w; 176w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[132w; 176w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sub sp, #16";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "SP_main" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Minus
                    (BExp_Align Bit32 2
@@ -623,15 +623,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4251 (rsbs r1, r2, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[81w; 66w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[81w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rsbs r1, r2, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_BinPred BIExp_Equal
                    (BExp_Den (BVar "R2" (BType_Imm Bit32)))
@@ -659,15 +659,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4359 (muls r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[89w; 67w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[89w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "muls r1, r3";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_Mult
@@ -692,15 +692,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4299 (cmp r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[153w; 66w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[153w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, r3";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Den (BVar "R3" (BType_Imm Bit32))));
@@ -724,15 +724,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4289 (cmp r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[137w; 66w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[137w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "PSR_N" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "PSR_V" BType_Bool) bir_exp_false;
@@ -746,15 +746,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 2900 (cmp r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[0w; 41w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[0w; 41w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
@@ -772,15 +772,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 290C (cmp r1, #12) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[12w; 41w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[12w; 41w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, #12";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 12w)));
@@ -804,15 +804,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 42D9 (cmn r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[217w; 66w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[217w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmn r1, r3";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Den (BVar "R3" (BType_Imm Bit32))));
@@ -836,15 +836,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 42C9 (cmn r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[201w; 66w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[201w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmn r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Den (BVar "R1" (BType_Imm Bit32))));
@@ -868,15 +868,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4009 (ands r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[9w; 64w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[9w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ands r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_Z" BType_Bool)
@@ -892,15 +892,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4011 (ands r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[17w; 64w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[17w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ands r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_And
@@ -925,15 +925,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4051 (eors r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[81w; 64w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[81w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "eors r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_Xor
@@ -958,15 +958,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4049 (eors r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[73w; 64w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[73w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "eors r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "PSR_Z" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
@@ -980,15 +980,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4311 (orrs r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[17w; 67w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[17w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "orrs r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_Or
@@ -1013,15 +1013,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4309 (orrs r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[9w; 67w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[9w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "orrs r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_Z" BType_Bool)
@@ -1037,15 +1037,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4391 (bics r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[145w; 67w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[145w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bics r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_And
@@ -1073,15 +1073,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4389 (bics r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[137w; 67w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[137w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bics r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "PSR_Z" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
@@ -1095,15 +1095,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 43D1 (mvns r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[209w; 67w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[209w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mvns r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_UnaryExp BIExp_Not
@@ -1125,15 +1125,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 43C9 (mvns r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[201w; 67w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[201w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mvns r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_UnaryExp BIExp_Not
@@ -1155,15 +1155,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4211 (tst r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[17w; 66w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[17w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "tst r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_And
@@ -1184,15 +1184,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4209 (tst r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[9w; 66w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[9w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "tst r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_Z" BType_Bool)
@@ -1208,15 +1208,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4088 (lsls r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[136w; 64w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[136w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
@@ -1262,15 +1262,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0080 (lsls r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[128w; 0w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[128w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, #2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_word_bit Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32)))
                    30);
@@ -1295,15 +1295,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0000 (lsls r0, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[0w; 0w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[0w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_Z" BType_Bool)
@@ -1319,15 +1319,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 40C8 (lsrs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[200w; 64w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[200w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsrs r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
@@ -1378,15 +1378,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0880 (lsrs r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[128w; 8w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[128w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsrs r0, #2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_word_bit Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32)))
                    1);
@@ -1413,15 +1413,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4108 (asrs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[8w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[8w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "asrs r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
@@ -1474,15 +1474,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 1080 (asrs r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[128w; 16w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[128w; 16w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "asrs r0, #2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_word_bit Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32)))
                    1);
@@ -1509,15 +1509,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 41C8 (rors r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[200w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[200w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rors r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
@@ -1552,15 +1552,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6801 (ldr r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[1w; 104w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[1w; 104w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1577,15 +1577,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6841 (ldr r1, [r0, #4]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 104w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 104w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, #4]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1603,15 +1603,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6881 (ldr r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 104w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 104w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1629,15 +1629,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8901 (ldrh r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[1w; 137w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[1w; 137w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1657,15 +1657,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8801 (ldrh r1, [r0, #0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[1w; 136w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[1w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1683,15 +1683,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8841 (ldrh r1, [r0, #2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 136w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1711,15 +1711,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7801 (ldrb r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[1w; 120w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[1w; 120w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
@@ -1734,15 +1734,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7841 (ldrb r1, [r0, #1]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 120w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 120w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, #1]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
@@ -1759,15 +1759,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7CC1 (ldrb r1, [r0, #19]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[193w; 124w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[193w; 124w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, #19]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
@@ -1784,15 +1784,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5881 (ldr r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 88w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 88w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_BinExp BIExp_Plus
@@ -1813,15 +1813,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5A81 (ldrh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 90w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 90w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_BinExp BIExp_Plus
@@ -1843,15 +1843,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5E81 (ldrsh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 94w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 94w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrsh r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_BinExp BIExp_Plus
@@ -1873,15 +1873,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5C81 (ldrb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 92w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 92w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
@@ -1898,15 +1898,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5681 (ldrsb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 86w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 86w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrsb r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_SignedCast
                    (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
@@ -1923,15 +1923,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4902 (ldr r1, [pc, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[2w; 73w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[2w; 73w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [pc, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
                    (BExp_Const (Imm32 316w)) BEnd_LittleEndian Bit32);
@@ -1944,15 +1944,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 9902 (ldr r1, [sp, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[2w; 153w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[2w; 153w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [sp, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_main" (BType_Imm Bit32))));
@@ -1970,15 +1970,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[14w; 203w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[14w; 203w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldm r3, {r1, r2, r3}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551611w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFBw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R3" (BType_Imm Bit32))));
@@ -2005,15 +2005,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6001 (str r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[1w; 96w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[1w; 96w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2033,15 +2033,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6041 (str r1, [r0, #4]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 96w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 96w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, #4]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2065,15 +2065,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6081 (str r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 96w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 96w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2097,15 +2097,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8101 (strh r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[1w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[1w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2130,15 +2130,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8001 (strh r1, [r0, #0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[1w; 128w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[1w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2159,15 +2159,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8041 (strh r1, [r0, #2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 128w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2192,15 +2192,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 7001 (strb r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[1w; 112w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[1w; 112w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_unchanged_mem_interval_distinct Bit32 0 65536
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))) 1);
@@ -2218,15 +2218,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 7041 (strb r1, [r0, #1]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 112w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 112w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, #1]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_unchanged_mem_interval_distinct Bit32 0 65536
                    (BExp_BinExp BIExp_Plus
@@ -2248,15 +2248,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 74C1 (strb r1, [r0, #19]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[193w; 116w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[193w; 116w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, #19]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_unchanged_mem_interval_distinct Bit32 0 65536
                    (BExp_BinExp BIExp_Plus
@@ -2278,15 +2278,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5081 (str r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 80w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 80w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_BinExp BIExp_Plus
@@ -2312,15 +2312,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5281 (strh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 82w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 82w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_BinExp BIExp_Plus
@@ -2348,15 +2348,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5481 (strb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 84w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 84w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_unchanged_mem_interval_distinct Bit32 0 65536
                    (BExp_BinExp BIExp_Plus
@@ -2379,15 +2379,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 9102 (str r1, [sp, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[2w; 145w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[2w; 145w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [sp, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_main" (BType_Imm Bit32))));
@@ -2411,15 +2411,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 C10E (stm r1!, {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[14w; 193w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[14w; 193w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "stm r1!, {r1, r2, r3}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551611w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFBw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R1" (BType_Imm Bit32))));
@@ -2457,15 +2457,15 @@ C10E (stm r1!, {r1, r2, r3}) @ 0x130 - OK
 
 B40E (push {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[14w; 180w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[14w; 180w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "push {r1, r2, r3}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551611w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFBw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_main" (BType_Imm Bit32))));
@@ -2506,15 +2506,15 @@ B40E (push {r1, r2, r3}) @ 0x130 - OK
 
 BC0E (pop {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[14w; 188w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[14w; 188w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "pop {r1, r2, r3}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551611w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFBw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_main" (BType_Imm Bit32))));
@@ -2545,15 +2545,15 @@ BC0E (pop {r1, r2, r3}) @ 0x130 - OK
 
 B50E (push {r1, r2, r3, lr}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[14w; 181w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[14w; 181w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "push {r1, r2, r3, lr}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551610w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFAw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_main" (BType_Imm Bit32))));
@@ -2599,15 +2599,15 @@ B50E (push {r1, r2, r3, lr}) @ 0x130 - OK
 
 BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[14w; 189w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[14w; 189w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "pop {r1, r2, r3, pc}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551607w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFF7w)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_main" (BType_Imm Bit32))));
@@ -2655,15 +2655,15 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 4708 (bx r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[8w; 71w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[8w; 71w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bx r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551612w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFCw)));
               BStmt_Assert
                 (BExp_LSB (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assert
@@ -2681,15 +2681,15 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 4788 (blx r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[136w; 71w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[136w; 71w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "blx r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551612w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFCw)));
               BStmt_Assert
                 (BExp_LSB (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assign (BVar "LR" (BType_Imm Bit32))
@@ -2706,15 +2706,15 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 B211 (sxth r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[17w; 178w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[17w; 178w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sxth r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_SignedCast
                    (BExp_Cast BIExp_LowCast
@@ -2728,15 +2728,15 @@ B211 (sxth r1, r2) @ 0x130 - OK
 
 B251 (sxtb r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[81w; 178w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[81w; 178w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sxtb r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_SignedCast
                    (BExp_Cast BIExp_LowCast
@@ -2750,15 +2750,15 @@ B251 (sxtb r1, r2) @ 0x130 - OK
 
 B291 (uxth r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[145w; 178w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[145w; 178w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "uxth r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Cast BIExp_LowCast
@@ -2772,15 +2772,15 @@ B291 (uxth r1, r2) @ 0x130 - OK
 
 B2D1 (uxtb r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[209w; 178w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[209w; 178w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "uxtb r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Cast BIExp_LowCast
@@ -2794,15 +2794,15 @@ B2D1 (uxtb r1, r2) @ 0x130 - OK
 
 BA11 (rev r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[17w; 186w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[17w; 186w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rev r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_word_reverse_8_32
                    (BExp_Den (BVar "R2" (BType_Imm Bit32))));
@@ -2815,15 +2815,15 @@ BA11 (rev r1, r2) @ 0x130 - OK
 
 BA51 (rev16 r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[81w; 186w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[81w; 186w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rev16 r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_word_reverse_16_32
                    (BExp_word_reverse_8_32
@@ -2837,15 +2837,15 @@ BA51 (rev16 r1, r2) @ 0x130 - OK
 
 BAD1 (revsh r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[209w; 186w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[209w; 186w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "revsh r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_SignedCast
                    (BExp_word_reverse_8_16
@@ -2861,15 +2861,15 @@ BAD1 (revsh r1, r2) @ 0x130 - OK
 
 3104 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[4w; 49w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[4w; 49w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "3104";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 4w)));
@@ -2897,15 +2897,15 @@ BAD1 (revsh r1, r2) @ 0x130 - OK
 
 B007 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[7w; 176w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[7w; 176w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B007";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "SP_main" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Align Bit32 2
@@ -2920,15 +2920,15 @@ B007 @ 0x130 - OK
 
 4A15 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[21w; 74w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[21w; 74w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4A15";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R2" (BType_Imm Bit32))
                 (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
                    (BExp_Const (Imm32 392w)) BEnd_LittleEndian Bit32);
@@ -2941,15 +2941,15 @@ B007 @ 0x130 - OK
 
 4011 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[17w; 64w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[17w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4011";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_And
@@ -2974,15 +2974,15 @@ B007 @ 0x130 - OK
 
 B510 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[16w; 181w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[16w; 181w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B510";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551612w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFCw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_main" (BType_Imm Bit32))));
@@ -3017,15 +3017,15 @@ B510 @ 0x130 - OK
 
 BA18 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[24w; 186w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[24w; 186w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "BA18";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R0" (BType_Imm Bit32))
                 (BExp_word_reverse_8_32
                    (BExp_Den (BVar "R3" (BType_Imm Bit32))));
@@ -3038,15 +3038,15 @@ BA18 @ 0x130 - OK
 
 F000F858 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[0w; 240w; 88w; 248w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[0w; 240w; 88w; 248w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "F000F858";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551611w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFBw)));
               BStmt_Assign (BVar "LR" (BType_Imm Bit32))
                 (BExp_Const (Imm32 309w));
               BStmt_Assign (BVar "countw" (BType_Imm Bit64))
@@ -3061,15 +3061,15 @@ F000F858 @ 0x130 - OK
 
 BDF7 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[247w; 189w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[247w; 189w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "BDF7";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551603w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFF3w)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_main" (BType_Imm Bit32))));
@@ -3137,15 +3137,15 @@ BDF7 @ 0x130 - OK
 
 3202 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[2w; 50w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[2w; 50w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "3202";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R2" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 2w)));
@@ -3173,15 +3173,15 @@ BDF7 @ 0x130 - OK
 
 635C @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[92w; 99w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[92w; 99w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "635C";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R3" (BType_Imm Bit32))));
@@ -3205,15 +3205,15 @@ BDF7 @ 0x130 - OK
 
 70E8 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[232w; 112w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[232w; 112w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "70E8";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_unchanged_mem_interval_distinct Bit32 0 65536
                    (BExp_BinExp BIExp_Plus
@@ -3235,15 +3235,15 @@ BDF7 @ 0x130 - OK
 
 B285 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[133w; 178w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[133w; 178w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B285";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R5" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Cast BIExp_LowCast
@@ -3257,15 +3257,15 @@ B285 @ 0x130 - OK
 
 8028 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[40w; 128w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[40w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "8028";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R5" (BType_Imm Bit32))));
@@ -3292,15 +3292,15 @@ A1BC @ 0x130 - FAILED
 
 4182 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[130w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[130w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4182";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "tmp_PSR_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C
                    (BExp_Den (BVar "R2" (BType_Imm Bit32)))
@@ -3343,15 +3343,15 @@ A1BC @ 0x130 - FAILED
 
 1000 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[0w; 16w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[0w; 16w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "1000";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
@@ -3377,15 +3377,15 @@ A1BC @ 0x130 - FAILED
 
 4088 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[136w; 64w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[136w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4088";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
@@ -3431,15 +3431,15 @@ A1BC @ 0x130 - FAILED
 
 B5F7 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[247w; 181w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[247w; 181w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B5F7";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551606w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFF6w)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_main" (BType_Imm Bit32))));
@@ -3515,15 +3515,15 @@ B5F7 @ 0x130 - OK
 
 C29C @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[156w; 194w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,F)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[156w; 194w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "C29C";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551610w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFAw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R2" (BType_Imm Bit32))));

--- a/src/tools/lifter/selftest_m0_mod_le_proc.log
+++ b/src/tools/lifter/selftest_m0_mod_le_proc.log
@@ -1,14 +1,14 @@
 4608 (mov r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[8w; 70w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[8w; 70w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mov r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R0" (BType_Imm Bit32))
                 (BExp_Den (BVar "R1" (BType_Imm Bit32)));
               BStmt_Assign (BVar "countw" (BType_Imm Bit64))
@@ -20,15 +20,15 @@
 
 0008 (movs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[8w; 0w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[8w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "movs r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_Z" BType_Bool)
@@ -46,15 +46,15 @@
 
 468F (mov pc, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[143w; 70w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[143w; 70w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mov pc, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551612w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFCw)));
               BStmt_Assign (BVar "countw" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
@@ -67,15 +67,15 @@
 
 1C08 (adds r0, r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[8w; 28w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[8w; 28w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
@@ -95,15 +95,15 @@
 
 1C88 (adds r0, r1, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[136w; 28w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[136w; 28w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, #2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 2w)));
@@ -131,15 +131,15 @@
 
 1888 (adds r0, r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[136w; 24w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[136w; 24w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit32))));
@@ -167,15 +167,15 @@
 
 4408 (add r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[8w; 68w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[8w; 68w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R0" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "R0" (BType_Imm Bit32)))
@@ -189,15 +189,15 @@
 
 448F (add pc, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[143w; 68w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[143w; 68w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add pc, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551612w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFCw)));
               BStmt_Assign (BVar "countw" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
@@ -212,15 +212,15 @@
 
 3080 (adds r0, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[128w; 48w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[128w; 48w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adds r0, #128";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R0" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 128w)));
@@ -248,15 +248,15 @@
 
 4148 (adcs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[72w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[72w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "adcs r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "tmp_PSR_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C
                    (BExp_Den (BVar "R0" (BType_Imm Bit32)))
@@ -295,15 +295,15 @@
 
 B020 (add sp, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[32w; 176w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[32w; 176w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add sp, #128";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "SP_process" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Align Bit32 2
@@ -318,15 +318,15 @@ B020 (add sp, #128) @ 0x130 - OK
 
 A820 (add r0, sp, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[32w; 168w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[32w; 168w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "add r0, sp, #128";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R0" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "SP_process" (BType_Imm Bit32)))
@@ -340,15 +340,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1A88 (subs r0, r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[136w; 26w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[136w; 26w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Den (BVar "R2" (BType_Imm Bit32))));
@@ -376,15 +376,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1EC8 (subs r0, r1, #3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[200w; 30w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[200w; 30w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, #3";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 3w)));
@@ -412,15 +412,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1A48 (subs r0, r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[72w; 26w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[72w; 26w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "PSR_N" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "PSR_V" BType_Bool) bir_exp_false;
@@ -436,15 +436,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1E08 (subs r0, r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[8w; 30w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[8w; 30w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, r1, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
@@ -464,15 +464,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 3880 (subs r0, #128) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[128w; 56w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[128w; 56w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, #128";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R0" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 128w)));
@@ -500,15 +500,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 1E00 (subs r0, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[0w; 30w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[0w; 30w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "subs r0, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -526,15 +526,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 4198 (sbcs r0, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[152w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[152w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sbcs r0, r3";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "tmp_PSR_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C
                    (BExp_Den (BVar "R0" (BType_Imm Bit32)))
@@ -577,15 +577,15 @@ A820 (add r0, sp, #128) @ 0x130 - OK
 
 B082 (sub sp, #8) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[130w; 176w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[130w; 176w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sub sp, #8";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "SP_process" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Minus
                    (BExp_Align Bit32 2
@@ -600,15 +600,15 @@ B082 (sub sp, #8) @ 0x130 - OK
 
 B084 (sub sp, #16) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[132w; 176w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[132w; 176w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sub sp, #16";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "SP_process" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Minus
                    (BExp_Align Bit32 2
@@ -623,15 +623,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4251 (rsbs r1, r2, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[81w; 66w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[81w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rsbs r1, r2, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_BinPred BIExp_Equal
                    (BExp_Den (BVar "R2" (BType_Imm Bit32)))
@@ -659,15 +659,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4359 (muls r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[89w; 67w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[89w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "muls r1, r3";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_Mult
@@ -692,15 +692,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4299 (cmp r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[153w; 66w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[153w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, r3";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Den (BVar "R3" (BType_Imm Bit32))));
@@ -724,15 +724,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4289 (cmp r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[137w; 66w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[137w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "PSR_N" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "PSR_V" BType_Bool) bir_exp_false;
@@ -746,15 +746,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 2900 (cmp r1, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[0w; 41w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[0w; 41w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
@@ -772,15 +772,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 290C (cmp r1, #12) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[12w; 41w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[12w; 41w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmp r1, #12";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_SUB_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 12w)));
@@ -804,15 +804,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 42D9 (cmn r1, r3) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[217w; 66w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[217w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmn r1, r3";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Den (BVar "R3" (BType_Imm Bit32))));
@@ -836,15 +836,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 42C9 (cmn r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[201w; 66w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[201w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "cmn r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Den (BVar "R1" (BType_Imm Bit32))));
@@ -868,15 +868,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4009 (ands r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[9w; 64w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[9w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ands r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_Z" BType_Bool)
@@ -892,15 +892,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4011 (ands r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[17w; 64w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[17w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ands r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_And
@@ -925,15 +925,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4051 (eors r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[81w; 64w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[81w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "eors r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_Xor
@@ -958,15 +958,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4049 (eors r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[73w; 64w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[73w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "eors r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "PSR_Z" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
@@ -980,15 +980,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4311 (orrs r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[17w; 67w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[17w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "orrs r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_Or
@@ -1013,15 +1013,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4309 (orrs r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[9w; 67w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[9w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "orrs r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_Z" BType_Bool)
@@ -1037,15 +1037,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4391 (bics r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[145w; 67w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[145w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bics r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_And
@@ -1073,15 +1073,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4389 (bics r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[137w; 67w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[137w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bics r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool) bir_exp_false;
               BStmt_Assign (BVar "PSR_Z" BType_Bool) bir_exp_true;
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
@@ -1095,15 +1095,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 43D1 (mvns r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[209w; 67w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[209w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mvns r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_UnaryExp BIExp_Not
@@ -1125,15 +1125,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 43C9 (mvns r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[201w; 67w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[201w; 67w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "mvns r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_UnaryExp BIExp_Not
@@ -1155,15 +1155,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4211 (tst r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[17w; 66w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[17w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "tst r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_And
@@ -1184,15 +1184,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4209 (tst r1, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[9w; 66w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[9w; 66w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "tst r1, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_Z" BType_Bool)
@@ -1208,15 +1208,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4088 (lsls r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[136w; 64w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[136w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
@@ -1262,15 +1262,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0080 (lsls r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[128w; 0w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[128w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, #2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_word_bit Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32)))
                    30);
@@ -1295,15 +1295,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0000 (lsls r0, #0) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[0w; 0w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[0w; 0w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsls r0, #0";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_Z" BType_Bool)
@@ -1319,15 +1319,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 40C8 (lsrs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[200w; 64w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[200w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsrs r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
@@ -1378,15 +1378,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 0880 (lsrs r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[128w; 8w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[128w; 8w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "lsrs r0, #2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_word_bit Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32)))
                    1);
@@ -1413,15 +1413,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4108 (asrs r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[8w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[8w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "asrs r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
@@ -1474,15 +1474,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 1080 (asrs r0, #2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[128w; 16w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[128w; 16w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "asrs r0, #2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_word_bit Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32)))
                    1);
@@ -1509,15 +1509,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 41C8 (rors r0, r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[200w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[200w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rors r0, r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
@@ -1552,15 +1552,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6801 (ldr r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[1w; 104w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[1w; 104w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1577,15 +1577,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6841 (ldr r1, [r0, #4]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 104w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 104w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, #4]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1603,15 +1603,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 6881 (ldr r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 104w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 104w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1629,15 +1629,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8901 (ldrh r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[1w; 137w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[1w; 137w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1657,15 +1657,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8801 (ldrh r1, [r0, #0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[1w; 136w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[1w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1683,15 +1683,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 8841 (ldrh r1, [r0, #2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 136w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 136w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, #2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -1711,15 +1711,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7801 (ldrb r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[1w; 120w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[1w; 120w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
@@ -1734,15 +1734,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7841 (ldrb r1, [r0, #1]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 120w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 120w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, #1]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
@@ -1759,15 +1759,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 7CC1 (ldrb r1, [r0, #19]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[193w; 124w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[193w; 124w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, #19]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
@@ -1784,15 +1784,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5881 (ldr r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 88w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 88w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_BinExp BIExp_Plus
@@ -1813,15 +1813,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5A81 (ldrh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 90w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 90w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrh r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_BinExp BIExp_Plus
@@ -1843,15 +1843,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5E81 (ldrsh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 94w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 94w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrsh r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_BinExp BIExp_Plus
@@ -1873,15 +1873,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5C81 (ldrb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 92w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 92w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrb r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
@@ -1898,15 +1898,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 5681 (ldrsb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 86w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 86w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldrsb r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_SignedCast
                    (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
@@ -1923,15 +1923,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 4902 (ldr r1, [pc, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[2w; 73w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[2w; 73w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [pc, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
                    (BExp_Const (Imm32 316w)) BEnd_LittleEndian Bit32);
@@ -1944,15 +1944,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 9902 (ldr r1, [sp, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[2w; 153w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[2w; 153w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldr r1, [sp, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_process" (BType_Imm Bit32))));
@@ -1970,15 +1970,15 @@ B084 (sub sp, #16) @ 0x130 - OK
 
 CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[14w; 203w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[14w; 203w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "ldm r3, {r1, r2, r3}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551611w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFBw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R3" (BType_Imm Bit32))));
@@ -2005,15 +2005,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6001 (str r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[1w; 96w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[1w; 96w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2033,15 +2033,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6041 (str r1, [r0, #4]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 96w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 96w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, #4]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2065,15 +2065,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 6081 (str r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 96w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 96w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2097,15 +2097,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8101 (strh r1, [r0, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[1w; 129w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[1w; 129w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2130,15 +2130,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8001 (strh r1, [r0, #0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[1w; 128w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[1w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2159,15 +2159,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 8041 (strh r1, [r0, #2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 128w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, #2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))));
@@ -2192,15 +2192,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 7001 (strb r1, [r0]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[1w; 112w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[1w; 112w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_unchanged_mem_interval_distinct Bit32 0 65536
                    (BExp_Den (BVar "R0" (BType_Imm Bit32))) 1);
@@ -2218,15 +2218,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 7041 (strb r1, [r0, #1]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[65w; 112w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[65w; 112w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, #1]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_unchanged_mem_interval_distinct Bit32 0 65536
                    (BExp_BinExp BIExp_Plus
@@ -2248,15 +2248,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 74C1 (strb r1, [r0, #19]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[193w; 116w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[193w; 116w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, #19]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_unchanged_mem_interval_distinct Bit32 0 65536
                    (BExp_BinExp BIExp_Plus
@@ -2278,15 +2278,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5081 (str r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 80w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 80w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_BinExp BIExp_Plus
@@ -2312,15 +2312,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5281 (strh r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 82w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 82w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strh r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_BinExp BIExp_Plus
@@ -2348,15 +2348,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 5481 (strb r1, [r0, r2]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[129w; 84w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[129w; 84w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "strb r1, [r0, r2]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_unchanged_mem_interval_distinct Bit32 0 65536
                    (BExp_BinExp BIExp_Plus
@@ -2379,15 +2379,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 9102 (str r1, [sp, #8]) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[2w; 145w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[2w; 145w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "str r1, [sp, #8]";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_process" (BType_Imm Bit32))));
@@ -2411,15 +2411,15 @@ CB0E (ldm r3, {r1, r2, r3}) @ 0x130 - OK
 
 C10E (stm r1!, {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[14w; 193w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[14w; 193w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "stm r1!, {r1, r2, r3}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551611w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFBw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R1" (BType_Imm Bit32))));
@@ -2457,15 +2457,15 @@ C10E (stm r1!, {r1, r2, r3}) @ 0x130 - OK
 
 B40E (push {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[14w; 180w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[14w; 180w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "push {r1, r2, r3}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551611w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFBw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_process" (BType_Imm Bit32))));
@@ -2506,15 +2506,15 @@ B40E (push {r1, r2, r3}) @ 0x130 - OK
 
 BC0E (pop {r1, r2, r3}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[14w; 188w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[14w; 188w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "pop {r1, r2, r3}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551611w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFBw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_process" (BType_Imm Bit32))));
@@ -2545,15 +2545,15 @@ BC0E (pop {r1, r2, r3}) @ 0x130 - OK
 
 B50E (push {r1, r2, r3, lr}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[14w; 181w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[14w; 181w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "push {r1, r2, r3, lr}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551610w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFAw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_process" (BType_Imm Bit32))));
@@ -2600,15 +2600,15 @@ B50E (push {r1, r2, r3, lr}) @ 0x130 - OK
 
 BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[14w; 189w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[14w; 189w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "pop {r1, r2, r3, pc}";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551607w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFF7w)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_process" (BType_Imm Bit32))));
@@ -2656,15 +2656,15 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 4708 (bx r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[8w; 71w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[8w; 71w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "bx r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551612w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFCw)));
               BStmt_Assert
                 (BExp_LSB (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assert
@@ -2682,15 +2682,15 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 4788 (blx r1) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[136w; 71w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[136w; 71w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "blx r1";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551612w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFCw)));
               BStmt_Assert
                 (BExp_LSB (BExp_Den (BVar "R1" (BType_Imm Bit32))));
               BStmt_Assign (BVar "LR" (BType_Imm Bit32))
@@ -2707,15 +2707,15 @@ BD0E (pop {r1, r2, r3, pc}) @ 0x130 - OK
 
 B211 (sxth r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[17w; 178w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[17w; 178w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sxth r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_SignedCast
                    (BExp_Cast BIExp_LowCast
@@ -2729,15 +2729,15 @@ B211 (sxth r1, r2) @ 0x130 - OK
 
 B251 (sxtb r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[81w; 178w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[81w; 178w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "sxtb r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_SignedCast
                    (BExp_Cast BIExp_LowCast
@@ -2751,15 +2751,15 @@ B251 (sxtb r1, r2) @ 0x130 - OK
 
 B291 (uxth r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[145w; 178w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[145w; 178w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "uxth r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Cast BIExp_LowCast
@@ -2773,15 +2773,15 @@ B291 (uxth r1, r2) @ 0x130 - OK
 
 B2D1 (uxtb r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[209w; 178w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[209w; 178w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "uxtb r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Cast BIExp_LowCast
@@ -2795,15 +2795,15 @@ B2D1 (uxtb r1, r2) @ 0x130 - OK
 
 BA11 (rev r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[17w; 186w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[17w; 186w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rev r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_word_reverse_8_32
                    (BExp_Den (BVar "R2" (BType_Imm Bit32))));
@@ -2816,15 +2816,15 @@ BA11 (rev r1, r2) @ 0x130 - OK
 
 BA51 (rev16 r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[81w; 186w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[81w; 186w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "rev16 r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_word_reverse_16_32
                    (BExp_word_reverse_8_32
@@ -2838,15 +2838,15 @@ BA51 (rev16 r1, r2) @ 0x130 - OK
 
 BAD1 (revsh r1, r2) @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[209w; 186w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[209w; 186w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "revsh r1, r2";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R1" (BType_Imm Bit32))
                 (BExp_Cast BIExp_SignedCast
                    (BExp_word_reverse_8_16
@@ -2862,15 +2862,15 @@ BAD1 (revsh r1, r2) @ 0x130 - OK
 
 3104 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[4w; 49w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[4w; 49w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "3104";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R1" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 4w)));
@@ -2898,15 +2898,15 @@ BAD1 (revsh r1, r2) @ 0x130 - OK
 
 B007 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[7w; 176w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[7w; 176w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B007";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "SP_process" (BType_Imm Bit32))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Align Bit32 2
@@ -2921,15 +2921,15 @@ B007 @ 0x130 - OK
 
 4A15 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[21w; 74w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[21w; 74w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4A15";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assign (BVar "R2" (BType_Imm Bit32))
                 (BExp_Load (BExp_Den (BVar "MEM" (BType_Mem Bit32 Bit8)))
                    (BExp_Const (Imm32 392w)) BEnd_LittleEndian Bit32);
@@ -2942,15 +2942,15 @@ B007 @ 0x130 - OK
 
 4011 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[17w; 64w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[17w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4011";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
                 (BExp_MSB Bit32
                    (BExp_BinExp BIExp_And
@@ -2975,15 +2975,15 @@ B007 @ 0x130 - OK
 
 B510 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[16w; 181w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[16w; 181w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B510";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551612w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFCw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_process" (BType_Imm Bit32))));
@@ -3018,15 +3018,15 @@ B510 @ 0x130 - OK
 
 BA18 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[24w; 186w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[24w; 186w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "BA18";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R0" (BType_Imm Bit32))
                 (BExp_word_reverse_8_32
                    (BExp_Den (BVar "R3" (BType_Imm Bit32))));
@@ -3039,15 +3039,15 @@ BA18 @ 0x130 - OK
 
 F000F858 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[0w; 240w; 88w; 248w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[0w; 240w; 88w; 248w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "F000F858";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551611w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFBw)));
               BStmt_Assign (BVar "LR" (BType_Imm Bit32))
                 (BExp_Const (Imm32 309w));
               BStmt_Assign (BVar "countw" (BType_Imm Bit64))
@@ -3062,15 +3062,15 @@ F000F858 @ 0x130 - OK
 
 BDF7 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[247w; 189w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[247w; 189w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "BDF7";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551603w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFF3w)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_process" (BType_Imm Bit32))));
@@ -3138,15 +3138,15 @@ BDF7 @ 0x130 - OK
 
 3202 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[2w; 50w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[2w; 50w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "3202";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_nzcv_ADD_C (BExp_Den (BVar "R2" (BType_Imm Bit32)))
                    (BExp_Const (Imm32 2w)));
@@ -3174,15 +3174,15 @@ BDF7 @ 0x130 - OK
 
 635C @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[92w; 99w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[92w; 99w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "635C";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R3" (BType_Imm Bit32))));
@@ -3206,15 +3206,15 @@ BDF7 @ 0x130 - OK
 
 70E8 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[232w; 112w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[232w; 112w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "70E8";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_unchanged_mem_interval_distinct Bit32 0 65536
                    (BExp_BinExp BIExp_Plus
@@ -3236,15 +3236,15 @@ BDF7 @ 0x130 - OK
 
 B285 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[133w; 178w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[133w; 178w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B285";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "R5" (BType_Imm Bit32))
                 (BExp_Cast BIExp_UnsignedCast
                    (BExp_Cast BIExp_LowCast
@@ -3258,15 +3258,15 @@ B285 @ 0x130 - OK
 
 8028 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[40w; 128w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[40w; 128w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "8028";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551613w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFDw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 1
                    (BExp_Den (BVar "R5" (BType_Imm Bit32))));
@@ -3293,15 +3293,15 @@ A1BC @ 0x130 - FAILED
 
 4182 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[130w; 65w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[130w; 65w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4182";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "tmp_PSR_C" BType_Bool)
                 (BExp_ADD_WITH_CARRY_C
                    (BExp_Den (BVar "R2" (BType_Imm Bit32)))
@@ -3344,15 +3344,15 @@ A1BC @ 0x130 - FAILED
 
 1000 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[0w; 16w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[0w; 16w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "1000";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_MSB Bit32 (BExp_Den (BVar "R0" (BType_Imm Bit32))));
               BStmt_Assign (BVar "PSR_N" BType_Bool)
@@ -3378,15 +3378,15 @@ A1BC @ 0x130 - FAILED
 
 4088 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[136w; 64w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[136w; 64w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "4088";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551614w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFEw)));
               BStmt_Assign (BVar "PSR_C" BType_Bool)
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
@@ -3432,15 +3432,15 @@ A1BC @ 0x130 - FAILED
 
 B5F7 @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[247w; 181w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[247w; 181w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "B5F7";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551606w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFF6w)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "SP_process" (BType_Imm Bit32))));
@@ -3518,15 +3518,15 @@ B5F7 @ 0x130 - OK
 
 C29C @ 0x130 - OK
  []
-|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w) (WI_end 0w 65536w)
-     (304w,[156w; 194w])
+|- bir_is_lifted_inst_prog (m0_mod_bmr (F,T)) (Imm32 304w)
+     (WI_end 0w 0x10000w) (304w,[156w; 194w])
      (BirProgram
         [<|bb_label := BL_Address_HC (Imm32 304w) "C29C";
            bb_statements :=
              [BStmt_Assert
                 (BExp_BinPred BIExp_LessOrEqual
                    (BExp_Den (BVar "countw" (BType_Imm Bit64)))
-                   (BExp_Const (Imm64 18446744073709551610w)));
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFAw)));
               BStmt_Assert
                 (BExp_Aligned Bit32 2
                    (BExp_Den (BVar "R2" (BType_Imm Bit32))));

--- a/src/tools/lifter/selftest_riscv.log
+++ b/src/tools/lifter/selftest_riscv.log
@@ -4,72 +4,72 @@ RV64I Base Instruction Set (instructions inherited from RV32I)
 
 LUI x10, 0xDEAD: 0DEAD537 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[55w; 213w; 234w; 13w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[55w; 213w; 234w; 13w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "0DEAD537";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "0DEAD537";
            bb_statements :=
              [BStmt_Assign (BVar "x10" (BType_Imm Bit64))
-                (BExp_Const (Imm64 233492480w))];
+                (BExp_Const (Imm64 0xDEAD000w))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 AUIPC x10, 0xDEAD: 0DEAD517 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[23w; 213w; 234w; 13w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[23w; 213w; 234w; 13w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "0DEAD517";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "0DEAD517";
            bb_statements :=
              [BStmt_Assign (BVar "x10" (BType_Imm Bit64))
-                (BExp_Const (Imm64 233558064w))];
+                (BExp_Const (Imm64 0xDEBD030w))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 JAL x1, 0x0: 000000EF @ 0x10030 - OK
- [~word_bit 0 65584w]
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[239w; 0w; 0w; 0w])
+ [~word_bit 0 0x10030w]
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[239w; 0w; 0w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "000000EF";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "000000EF";
            bb_statements :=
              [BStmt_Assign (BVar "x1" (BType_Imm Bit64))
-                (BExp_Const (Imm64 65588w))];
+                (BExp_Const (Imm64 0x10034w))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65584w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10030w)))|>])
 
 JALR x1, 0x0: 000000E7 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[231w; 0w; 0w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[231w; 0w; 0w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "000000E7";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "000000E7";
            bb_statements :=
              [BStmt_Assign (BVar "x1" (BType_Imm Bit64))
-                (BExp_Const (Imm64 65588w))];
+                (BExp_Const (Imm64 0x10034w))];
            bb_last_statement := BStmt_Jmp (BLE_Label (BL_Address (Imm64 0w)))|>])
 
 BEQ x19, x10, 8: 00A98863 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[99w; 136w; 169w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[99w; 136w; 169w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "00A98863";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "00A98863";
            bb_statements := [];
            bb_last_statement :=
              BStmt_CJmp
                (BExp_BinPred BIExp_Equal
                   (BExp_Den (BVar "x19" (BType_Imm Bit64)))
                   (BExp_Den (BVar "x10" (BType_Imm Bit64))))
-               (BLE_Label (BL_Address (Imm64 65600w)))
-               (BLE_Label (BL_Address (Imm64 65588w)))|>])
+               (BLE_Label (BL_Address (Imm64 0x10040w)))
+               (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 BNE x19, x10, 8: 00A99863 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[99w; 152w; 169w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[99w; 152w; 169w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "00A99863";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "00A99863";
            bb_statements := [];
            bb_last_statement :=
              BStmt_CJmp
@@ -77,30 +77,30 @@ BNE x19, x10, 8: 00A99863 @ 0x10030 - OK
                   (BExp_BinPred BIExp_Equal
                      (BExp_Den (BVar "x19" (BType_Imm Bit64)))
                      (BExp_Den (BVar "x10" (BType_Imm Bit64)))))
-               (BLE_Label (BL_Address (Imm64 65600w)))
-               (BLE_Label (BL_Address (Imm64 65588w)))|>])
+               (BLE_Label (BL_Address (Imm64 0x10040w)))
+               (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 BLT x19, x10, 8: 00A9C863 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[99w; 200w; 169w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[99w; 200w; 169w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "00A9C863";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "00A9C863";
            bb_statements := [];
            bb_last_statement :=
              BStmt_CJmp
                (BExp_BinPred BIExp_SignedLessThan
                   (BExp_Den (BVar "x19" (BType_Imm Bit64)))
                   (BExp_Den (BVar "x10" (BType_Imm Bit64))))
-               (BLE_Label (BL_Address (Imm64 65600w)))
-               (BLE_Label (BL_Address (Imm64 65588w)))|>])
+               (BLE_Label (BL_Address (Imm64 0x10040w)))
+               (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 BGE x19, x10, 8: 00A9D863 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[99w; 216w; 169w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[99w; 216w; 169w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "00A9D863";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "00A9D863";
            bb_statements := [];
            bb_last_statement :=
              BStmt_CJmp
@@ -108,30 +108,30 @@ BGE x19, x10, 8: 00A9D863 @ 0x10030 - OK
                   (BExp_BinPred BIExp_SignedLessThan
                      (BExp_Den (BVar "x19" (BType_Imm Bit64)))
                      (BExp_Den (BVar "x10" (BType_Imm Bit64)))))
-               (BLE_Label (BL_Address (Imm64 65600w)))
-               (BLE_Label (BL_Address (Imm64 65588w)))|>])
+               (BLE_Label (BL_Address (Imm64 0x10040w)))
+               (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 BLTU x19, x10, 8: 00A9E863 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[99w; 232w; 169w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[99w; 232w; 169w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "00A9E863";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "00A9E863";
            bb_statements := [];
            bb_last_statement :=
              BStmt_CJmp
                (BExp_BinPred BIExp_LessThan
                   (BExp_Den (BVar "x19" (BType_Imm Bit64)))
                   (BExp_Den (BVar "x10" (BType_Imm Bit64))))
-               (BLE_Label (BL_Address (Imm64 65600w)))
-               (BLE_Label (BL_Address (Imm64 65588w)))|>])
+               (BLE_Label (BL_Address (Imm64 0x10040w)))
+               (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 BGEU x19, x10, 8: 00A9F863 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[99w; 248w; 169w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[99w; 248w; 169w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "00A9F863";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "00A9F863";
            bb_statements := [];
            bb_last_statement :=
              BStmt_CJmp
@@ -139,15 +139,15 @@ BGEU x19, x10, 8: 00A9F863 @ 0x10030 - OK
                   (BExp_BinPred BIExp_LessThan
                      (BExp_Den (BVar "x19" (BType_Imm Bit64)))
                      (BExp_Den (BVar "x10" (BType_Imm Bit64)))))
-               (BLE_Label (BL_Address (Imm64 65600w)))
-               (BLE_Label (BL_Address (Imm64 65588w)))|>])
+               (BLE_Label (BL_Address (Imm64 0x10040w)))
+               (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 LB x1,x2,-50: FCE10083 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[131w; 0w; 225w; 252w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[131w; 0w; 225w; 252w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "FCE10083";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "FCE10083";
            bb_statements :=
              [BStmt_Assign (BVar "x1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_SignedCast
@@ -157,14 +157,14 @@ LB x1,x2,-50: FCE10083 @ 0x10030 - OK
                          (BExp_Const (Imm64 50w))) BEnd_LittleEndian Bit8)
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 LH x1,x2,-50: FCE11083 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[131w; 16w; 225w; 252w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[131w; 16w; 225w; 252w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "FCE11083";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "FCE11083";
            bb_statements :=
              [BStmt_Assert
                 (BExp_Aligned Bit64 1
@@ -177,14 +177,14 @@ LH x1,x2,-50: FCE11083 @ 0x10030 - OK
                          (BExp_Const (Imm64 50w))) BEnd_LittleEndian Bit16)
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 LW x1,x2,-50: FCE12083 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[131w; 32w; 225w; 252w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[131w; 32w; 225w; 252w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "FCE12083";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "FCE12083";
            bb_statements :=
              [BStmt_Assert
                 (BExp_Aligned Bit64 2
@@ -199,14 +199,14 @@ LW x1,x2,-50: FCE12083 @ 0x10030 - OK
                          (BExp_Const (Imm64 50w))) BEnd_LittleEndian Bit32)
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 LBU x1,x2,-50: FCE14083 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[131w; 64w; 225w; 252w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[131w; 64w; 225w; 252w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "FCE14083";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "FCE14083";
            bb_statements :=
              [BStmt_Assign (BVar "x1" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -216,14 +216,14 @@ LBU x1,x2,-50: FCE14083 @ 0x10030 - OK
                          (BExp_Const (Imm64 50w))) BEnd_LittleEndian Bit8)
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 LHU x1,x2,-50: FCE15083 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[131w; 80w; 225w; 252w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[131w; 80w; 225w; 252w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "FCE15083";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "FCE15083";
            bb_statements :=
              [BStmt_Assert
                 (BExp_Aligned Bit64 1
@@ -236,14 +236,14 @@ LHU x1,x2,-50: FCE15083 @ 0x10030 - OK
                          (BExp_Const (Imm64 50w))) BEnd_LittleEndian Bit16)
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SB x14, 8(x2): 00E10423 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[35w; 4w; 225w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[35w; 4w; 225w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "00E10423";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "00E10423";
            bb_statements :=
              [BStmt_Assert
                 (BExp_unchanged_mem_interval_distinct Bit64 0 16777216
@@ -258,14 +258,14 @@ SB x14, 8(x2): 00E10423 @ 0x10030 - OK
                    (BExp_Cast BIExp_LowCast
                       (BExp_Den (BVar "x14" (BType_Imm Bit64))) Bit8))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SH x14, 8(x2): 00E11423 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[35w; 20w; 225w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[35w; 20w; 225w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "00E11423";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "00E11423";
            bb_statements :=
              [BStmt_Assert
                 (BExp_Aligned Bit64 1
@@ -283,14 +283,14 @@ SH x14, 8(x2): 00E11423 @ 0x10030 - OK
                    (BExp_Cast BIExp_LowCast
                       (BExp_Den (BVar "x14" (BType_Imm Bit64))) Bit16))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SW x14, 8(x2): 00E12423 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[35w; 36w; 225w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[35w; 36w; 225w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "00E12423";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "00E12423";
            bb_statements :=
              [BStmt_Assert
                 (BExp_Aligned Bit64 2
@@ -308,28 +308,28 @@ SW x14, 8(x2): 00E12423 @ 0x10030 - OK
                    (BExp_Cast BIExp_LowCast
                       (BExp_Den (BVar "x14" (BType_Imm Bit64))) Bit32))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 ADDI x15,x1,-50: FCE08793 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[147w; 135w; 224w; 252w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[147w; 135w; 224w; 252w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "FCE08793";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "FCE08793";
            bb_statements :=
              [BStmt_Assign (BVar "x15" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Minus
                    (BExp_Den (BVar "x1" (BType_Imm Bit64)))
                    (BExp_Const (Imm64 50w)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SLTI x15,x1,5: 0050A793 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[147w; 167w; 80w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[147w; 167w; 80w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "0050A793";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "0050A793";
            bb_statements :=
              [BStmt_Assign (BVar "x15" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -337,14 +337,14 @@ SLTI x15,x1,5: 0050A793 @ 0x10030 - OK
                       (BExp_Den (BVar "x1" (BType_Imm Bit64)))
                       (BExp_Const (Imm64 5w))) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SLTIU x15,x1,5: 0050B793 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[147w; 183w; 80w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[147w; 183w; 80w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "0050B793";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "0050B793";
            bb_statements :=
              [BStmt_Assign (BVar "x15" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -352,127 +352,127 @@ SLTIU x15,x1,5: 0050B793 @ 0x10030 - OK
                       (BExp_Den (BVar "x1" (BType_Imm Bit64)))
                       (BExp_Const (Imm64 5w))) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 XORI x15,x1,5: 0050C793 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[147w; 199w; 80w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[147w; 199w; 80w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "0050C793";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "0050C793";
            bb_statements :=
              [BStmt_Assign (BVar "x15" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Xor
                    (BExp_Den (BVar "x1" (BType_Imm Bit64)))
                    (BExp_Const (Imm64 5w)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 ORI x15,x1,5: 0050E793 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[147w; 231w; 80w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[147w; 231w; 80w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "0050E793";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "0050E793";
            bb_statements :=
              [BStmt_Assign (BVar "x15" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Or
                    (BExp_Den (BVar "x1" (BType_Imm Bit64)))
                    (BExp_Const (Imm64 5w)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 ANDI x15,x1,5: 0050F793 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[147w; 247w; 80w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[147w; 247w; 80w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "0050F793";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "0050F793";
            bb_statements :=
              [BStmt_Assign (BVar "x15" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_And (BExp_Const (Imm64 5w))
                    (BExp_Den (BVar "x1" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SLLI x15,x1,5: 00509793 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[147w; 151w; 80w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[147w; 151w; 80w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "00509793";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "00509793";
            bb_statements :=
              [BStmt_Assign (BVar "x15" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_LeftShift
                    (BExp_Den (BVar "x1" (BType_Imm Bit64)))
                    (BExp_Const (Imm64 5w)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SRLI x15,x1,5: 0050D793 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[147w; 215w; 80w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[147w; 215w; 80w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "0050D793";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "0050D793";
            bb_statements :=
              [BStmt_Assign (BVar "x15" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_RightShift
                    (BExp_Den (BVar "x1" (BType_Imm Bit64)))
                    (BExp_Const (Imm64 5w)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SRAI x15,x1,1029: 4050D793 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[147w; 215w; 80w; 64w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[147w; 215w; 80w; 64w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "4050D793";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "4050D793";
            bb_statements :=
              [BStmt_Assign (BVar "x15" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_SignedRightShift
                    (BExp_Den (BVar "x1" (BType_Imm Bit64)))
                    (BExp_Const (Imm64 5w)))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 ADD x5, x6, x7: 007302B3 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[179w; 2w; 115w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[179w; 2w; 115w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "007302B3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "007302B3";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
                    (BExp_Den (BVar "x7" (BType_Imm Bit64)))
                    (BExp_Den (BVar "x6" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SUB x5, x6, x7: 407302B3 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[179w; 2w; 115w; 64w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[179w; 2w; 115w; 64w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "407302B3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "407302B3";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
                    (BExp_BinExp BIExp_Mult
-                      (BExp_Const (Imm64 18446744073709551615w))
+                      (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
                       (BExp_Den (BVar "x7" (BType_Imm Bit64))))
                    (BExp_Den (BVar "x6" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SLL x5, x6, x7: 007312B3 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[179w; 18w; 115w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[179w; 18w; 115w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "007312B3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "007312B3";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_LeftShift
@@ -480,14 +480,14 @@ SLL x5, x6, x7: 007312B3 @ 0x10030 - OK
                    (BExp_BinExp BIExp_And (BExp_Const (Imm64 63w))
                       (BExp_Den (BVar "x7" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SLT x5, x6, x7: 007322B3 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[179w; 34w; 115w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[179w; 34w; 115w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "007322B3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "007322B3";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -495,14 +495,14 @@ SLT x5, x6, x7: 007322B3 @ 0x10030 - OK
                       (BExp_Den (BVar "x6" (BType_Imm Bit64)))
                       (BExp_Den (BVar "x7" (BType_Imm Bit64)))) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SLTU x5, x6, x7: 007332B3 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[179w; 50w; 115w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[179w; 50w; 115w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "007332B3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "007332B3";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_Cast BIExp_UnsignedCast
@@ -510,28 +510,28 @@ SLTU x5, x6, x7: 007332B3 @ 0x10030 - OK
                       (BExp_Den (BVar "x6" (BType_Imm Bit64)))
                       (BExp_Den (BVar "x7" (BType_Imm Bit64)))) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 XOR x5, x6, x7: 007342B3 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[179w; 66w; 115w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[179w; 66w; 115w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "007342B3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "007342B3";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Xor
                    (BExp_Den (BVar "x7" (BType_Imm Bit64)))
                    (BExp_Den (BVar "x6" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SRL x5, x6, x7: 007352B3 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[179w; 82w; 115w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[179w; 82w; 115w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "007352B3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "007352B3";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_RightShift
@@ -539,14 +539,14 @@ SRL x5, x6, x7: 007352B3 @ 0x10030 - OK
                    (BExp_BinExp BIExp_And (BExp_Const (Imm64 63w))
                       (BExp_Den (BVar "x7" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SRA x5, x6, x7: 407352B3 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[179w; 82w; 115w; 64w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[179w; 82w; 115w; 64w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "407352B3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "407352B3";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_SignedRightShift
@@ -554,35 +554,35 @@ SRA x5, x6, x7: 407352B3 @ 0x10030 - OK
                    (BExp_BinExp BIExp_And (BExp_Const (Imm64 63w))
                       (BExp_Den (BVar "x7" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 OR x5, x6, x7: 007362B3 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[179w; 98w; 115w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[179w; 98w; 115w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "007362B3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "007362B3";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Or
                    (BExp_Den (BVar "x7" (BType_Imm Bit64)))
                    (BExp_Den (BVar "x6" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 AND x5, x6, x7: 007372B3 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[179w; 114w; 115w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[179w; 114w; 115w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "007372B3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "007372B3";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_And
                    (BExp_Den (BVar "x7" (BType_Imm Bit64)))
                    (BExp_Den (BVar "x6" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 FENCE x1, x2, i, i: 0881008F @ 0x10030 - FAILED
    bmr_step_hex failed
@@ -598,10 +598,10 @@ RV64I Base Instruction Set (instructions added to RV32I)
 
 LWU x1,x2,-50: FCE16083 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[131w; 96w; 225w; 252w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[131w; 96w; 225w; 252w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "FCE16083";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "FCE16083";
            bb_statements :=
              [BStmt_Assert
                 (BExp_Aligned Bit64 2
@@ -616,14 +616,14 @@ LWU x1,x2,-50: FCE16083 @ 0x10030 - OK
                          (BExp_Const (Imm64 50w))) BEnd_LittleEndian Bit32)
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 LD x1,x2,-50: FCE13083 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[131w; 48w; 225w; 252w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[131w; 48w; 225w; 252w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "FCE13083";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "FCE13083";
            bb_statements :=
              [BStmt_Assert
                 (BExp_Aligned Bit64 3
@@ -636,14 +636,14 @@ LD x1,x2,-50: FCE13083 @ 0x10030 - OK
                       (BExp_Den (BVar "x2" (BType_Imm Bit64)))
                       (BExp_Const (Imm64 50w))) BEnd_LittleEndian Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SD x14, 8(x2): 00E13423 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[35w; 52w; 225w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[35w; 52w; 225w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "00E13423";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "00E13423";
            bb_statements :=
              [BStmt_Assert
                 (BExp_Aligned Bit64 3
@@ -660,14 +660,14 @@ SD x14, 8(x2): 00E13423 @ 0x10030 - OK
                       (BExp_Const (Imm64 8w))) BEnd_LittleEndian
                    (BExp_Den (BVar "x14" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 ADDIW x15,x1,-50: FCE0879B @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[155w; 135w; 224w; 252w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[155w; 135w; 224w; 252w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "FCE0879B";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "FCE0879B";
            bb_statements :=
              [BStmt_Assign (BVar "x15" (BType_Imm Bit64))
                 (BExp_Cast BIExp_SignedCast
@@ -676,14 +676,14 @@ ADDIW x15,x1,-50: FCE0879B @ 0x10030 - OK
                          (BExp_Den (BVar "x1" (BType_Imm Bit64)))
                          (BExp_Const (Imm64 50w))) Bit32) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SLLIW x15,x1,5: 0050979B @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[155w; 151w; 80w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[155w; 151w; 80w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "0050979B";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "0050979B";
            bb_statements :=
              [BStmt_Assign (BVar "x15" (BType_Imm Bit64))
                 (BExp_Cast BIExp_SignedCast
@@ -692,14 +692,14 @@ SLLIW x15,x1,5: 0050979B @ 0x10030 - OK
                          (BExp_Den (BVar "x1" (BType_Imm Bit64))) Bit32)
                       (BExp_Const (Imm32 5w))) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SRLIW x15,x1,5: 0050D79B @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[155w; 215w; 80w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[155w; 215w; 80w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "0050D79B";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "0050D79B";
            bb_statements :=
              [BStmt_Assign (BVar "x15" (BType_Imm Bit64))
                 (BExp_Cast BIExp_SignedCast
@@ -708,14 +708,14 @@ SRLIW x15,x1,5: 0050D79B @ 0x10030 - OK
                          (BExp_Den (BVar "x1" (BType_Imm Bit64))) Bit32)
                       (BExp_Const (Imm32 5w))) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SRAIW x15,x1,1029: 4050D79B @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[155w; 215w; 80w; 64w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[155w; 215w; 80w; 64w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "4050D79B";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "4050D79B";
            bb_statements :=
              [BStmt_Assign (BVar "x15" (BType_Imm Bit64))
                 (BExp_Cast BIExp_SignedCast
@@ -724,14 +724,14 @@ SRAIW x15,x1,1029: 4050D79B @ 0x10030 - OK
                          (BExp_Den (BVar "x1" (BType_Imm Bit64))) Bit32)
                       (BExp_Const (Imm32 5w))) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 ADDW x5, x6, x7: 007302BB @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[187w; 2w; 115w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[187w; 2w; 115w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "007302BB";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "007302BB";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_Cast BIExp_SignedCast
@@ -741,34 +741,34 @@ ADDW x5, x6, x7: 007302BB @ 0x10030 - OK
                          (BExp_Den (BVar "x6" (BType_Imm Bit64)))) Bit32)
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SUBW x5, x6, x7: 407302BB @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[187w; 2w; 115w; 64w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[187w; 2w; 115w; 64w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "407302BB";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "407302BB";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_Cast BIExp_SignedCast
                    (BExp_BinExp BIExp_Plus
                       (BExp_BinExp BIExp_Mult
-                         (BExp_Const (Imm32 4294967295w))
+                         (BExp_Const (Imm32 0xFFFFFFFFw))
                          (BExp_Cast BIExp_LowCast
                             (BExp_Den (BVar "x7" (BType_Imm Bit64))) Bit32))
                       (BExp_Cast BIExp_LowCast
                          (BExp_Den (BVar "x6" (BType_Imm Bit64))) Bit32))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SLLW x5, x6, x7: 007312BB @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[187w; 18w; 115w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[187w; 18w; 115w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "007312BB";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "007312BB";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_Cast BIExp_SignedCast
@@ -780,14 +780,14 @@ SLLW x5, x6, x7: 007312BB @ 0x10030 - OK
                             (BExp_Den (BVar "x7" (BType_Imm Bit64))) Bit32)))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SRLW x5, x6, x7: 007352BB @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[187w; 82w; 115w; 0w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[187w; 82w; 115w; 0w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "007352BB";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "007352BB";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_Cast BIExp_SignedCast
@@ -799,14 +799,14 @@ SRLW x5, x6, x7: 007352BB @ 0x10030 - OK
                             (BExp_Den (BVar "x7" (BType_Imm Bit64))) Bit32)))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 SRAW x5, x6, x7: 407352BB @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[187w; 82w; 115w; 64w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[187w; 82w; 115w; 64w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "407352BB";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "407352BB";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_Cast BIExp_SignedCast
@@ -818,7 +818,7 @@ SRAW x5, x6, x7: 407352BB @ 0x10030 - OK
                             (BExp_Den (BVar "x7" (BType_Imm Bit64))) Bit32)))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 
 RV64 Zifencei Standard Extension
@@ -852,24 +852,24 @@ RV64M Standard Extension (instructions inherited from RV32M)
 
 MUL x5, x6, x7: 027302B3 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[179w; 2w; 115w; 2w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[179w; 2w; 115w; 2w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "027302B3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "027302B3";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Mult
                    (BExp_Den (BVar "x7" (BType_Imm Bit64)))
                    (BExp_Den (BVar "x6" (BType_Imm Bit64))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 MULH x5, x6, x7: 027312B3 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[179w; 18w; 115w; 2w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[179w; 18w; 115w; 2w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "027312B3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "027312B3";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_Cast BIExp_HighCast
@@ -880,14 +880,14 @@ MULH x5, x6, x7: 027312B3 @ 0x10030 - OK
                          (BExp_Den (BVar "x6" (BType_Imm Bit64))) Bit128))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 MULHSU x5, x6, x7: 027322B3 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[179w; 34w; 115w; 2w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[179w; 34w; 115w; 2w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "027322B3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "027322B3";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_Cast BIExp_HighCast
@@ -898,14 +898,14 @@ MULHSU x5, x6, x7: 027322B3 @ 0x10030 - OK
                          (BExp_Den (BVar "x7" (BType_Imm Bit64))) Bit128))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 MULHU x5, x6, x7: 027332B3 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[179w; 50w; 115w; 2w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[179w; 50w; 115w; 2w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "027332B3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "027332B3";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_Cast BIExp_HighCast
@@ -916,52 +916,52 @@ MULHU x5, x6, x7: 027332B3 @ 0x10030 - OK
                          (BExp_Den (BVar "x6" (BType_Imm Bit64))) Bit128))
                    Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 DIV x5, x6, x7: 027342B3 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[179w; 66w; 115w; 2w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[179w; 66w; 115w; 2w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "027342B3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "027342B3";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
                       (BExp_Den (BVar "x7" (BType_Imm Bit64)))
                       (BExp_Const (Imm64 0w)))
-                   (BExp_Const (Imm64 18446744073709551615w))
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
                    (BExp_BinExp BIExp_SignedDiv
                       (BExp_Den (BVar "x6" (BType_Imm Bit64)))
                       (BExp_Den (BVar "x7" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 DIVU x5, x6, x7: 027352B3 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[179w; 82w; 115w; 2w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[179w; 82w; 115w; 2w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "027352B3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "027352B3";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_IfThenElse
                    (BExp_BinPred BIExp_Equal
                       (BExp_Den (BVar "x7" (BType_Imm Bit64)))
                       (BExp_Const (Imm64 0w)))
-                   (BExp_Const (Imm64 18446744073709551615w))
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
                    (BExp_BinExp BIExp_Div
                       (BExp_Den (BVar "x6" (BType_Imm Bit64)))
                       (BExp_Den (BVar "x7" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 REM x5, x6, x7: 027362B3 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[179w; 98w; 115w; 2w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[179w; 98w; 115w; 2w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "027362B3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "027362B3";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_IfThenElse
@@ -997,14 +997,14 @@ REM x5, x6, x7: 027362B3 @ 0x10030 - OK
                             (BExp_Den (BVar "x6" (BType_Imm Bit64)))
                             (BExp_Den (BVar "x7" (BType_Imm Bit64)))))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 REMU x5, x6, x7: 027372B3 @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[179w; 114w; 115w; 2w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[179w; 114w; 115w; 2w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "027372B3";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "027372B3";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_IfThenElse
@@ -1016,17 +1016,17 @@ REMU x5, x6, x7: 027372B3 @ 0x10030 - OK
                       (BExp_Den (BVar "x6" (BType_Imm Bit64)))
                       (BExp_Den (BVar "x7" (BType_Imm Bit64)))))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 
 RV64M Standard Extension (instructions added to RV32M)
 
 MULW x5, x6, x7: 027302BB @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[187w; 2w; 115w; 2w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[187w; 2w; 115w; 2w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "027302BB";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "027302BB";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_Cast BIExp_SignedCast
@@ -1039,14 +1039,14 @@ MULW x5, x6, x7: 027302BB @ 0x10030 - OK
                                (BExp_Den (BVar "x6" (BType_Imm Bit64))) Bit32))
                          Bit64) Bit32) Bit64)];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 DIVW x5, x6, x7: 027342BB @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[187w; 66w; 115w; 2w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[187w; 66w; 115w; 2w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "027342BB";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "027342BB";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_IfThenElse
@@ -1054,7 +1054,7 @@ DIVW x5, x6, x7: 027342BB @ 0x10030 - OK
                       (BExp_Cast BIExp_LowCast
                          (BExp_Den (BVar "x7" (BType_Imm Bit64))) Bit32)
                       (BExp_Const (Imm32 0w)))
-                   (BExp_Const (Imm64 18446744073709551615w))
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
                    (BExp_Cast BIExp_SignedCast
                       (BExp_BinExp BIExp_SignedDiv
                          (BExp_Cast BIExp_LowCast
@@ -1063,14 +1063,14 @@ DIVW x5, x6, x7: 027342BB @ 0x10030 - OK
                             (BExp_Den (BVar "x7" (BType_Imm Bit64))) Bit32))
                       Bit64))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 DIVUW x5, x6, x7: 027352BB @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[187w; 82w; 115w; 2w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[187w; 82w; 115w; 2w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "027352BB";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "027352BB";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_IfThenElse
@@ -1078,7 +1078,7 @@ DIVUW x5, x6, x7: 027352BB @ 0x10030 - OK
                       (BExp_Cast BIExp_LowCast
                          (BExp_Den (BVar "x7" (BType_Imm Bit64))) Bit32)
                       (BExp_Const (Imm32 0w)))
-                   (BExp_Const (Imm64 18446744073709551615w))
+                   (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
                    (BExp_Cast BIExp_SignedCast
                       (BExp_BinExp BIExp_Div
                          (BExp_Cast BIExp_LowCast
@@ -1087,14 +1087,14 @@ DIVUW x5, x6, x7: 027352BB @ 0x10030 - OK
                             (BExp_Den (BVar "x7" (BType_Imm Bit64))) Bit32))
                       Bit64))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 REMW x5, x6, x7: 027362BB @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[187w; 98w; 115w; 2w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[187w; 98w; 115w; 2w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "027362BB";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "027362BB";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_IfThenElse
@@ -1159,14 +1159,14 @@ REMW x5, x6, x7: 027362BB @ 0x10030 - OK
                                   (BExp_Den (BVar "x7" (BType_Imm Bit64)))
                                   Bit32)))) Bit64))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 REMUW x5, x6, x7: 027372BB @ 0x10030 - OK
  []
-|- bir_is_lifted_inst_prog riscv_bmr (Imm64 65584w) (WI_end 0w 16777216w)
-     (65584w,[187w; 114w; 115w; 2w])
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[187w; 114w; 115w; 2w])
      (BirProgram
-        [<|bb_label := BL_Address_HC (Imm64 65584w) "027372BB";
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "027372BB";
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_IfThenElse
@@ -1186,7 +1186,7 @@ REMUW x5, x6, x7: 027372BB @ 0x10030 - OK
                             (BExp_Den (BVar "x7" (BType_Imm Bit64))) Bit32))
                       Bit64))];
            bb_last_statement :=
-             BStmt_Jmp (BLE_Label (BL_Address (Imm64 65588w)))|>])
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
 
 

--- a/src/tools/lifter/selftest_riscv.sml
+++ b/src/tools/lifter/selftest_riscv.sml
@@ -4,6 +4,7 @@ open bir_inst_liftingLib;
 open PPBackEnd
 open riscv_assemblerLib;
 open selftestLib;
+open selftest_styleLib;
 
 (* Flags for determining type of output *)
 val unicode = false;

--- a/src/tools/lifter/selftest_styleLib.sig
+++ b/src/tools/lifter/selftest_styleLib.sig
@@ -1,0 +1,11 @@
+signature selftest_styleLib = sig
+
+  include PPBackEnd;
+
+  (* TODO: Put test instances here? *)
+  val sty_OK     : pp_style list
+  val sty_CACHE  : pp_style list
+  val sty_FAIL   : pp_style list
+  val sty_HEADER : pp_style list
+
+end;

--- a/src/tools/lifter/selftest_styleLib.sml
+++ b/src/tools/lifter/selftest_styleLib.sml
@@ -1,0 +1,13 @@
+structure selftest_styleLib :> selftest_styleLib = struct
+
+  open PPBackEnd;
+
+  (* TODO: Put test instances here? *)
+
+  (* Styles for success, fail and header *)
+  val sty_OK     = [FG Green];
+  val sty_CACHE  = [FG Yellow];
+  val sty_FAIL   = [FG OrangeRed];
+  val sty_HEADER = [Bold, Underline];
+
+end;

--- a/src/tools/scamv/proggen/bir_prog_gen_randLib.sml
+++ b/src/tools/scamv/proggen/bir_prog_gen_randLib.sml
@@ -149,7 +149,7 @@ struct
      alphaList @ numList @ (regExLib.literalList "'_") @ specialChar @ [LITERAL #" ", LITERAL #"\t", LITERAL #"\n"]
  val alphabet_r = ALTERNATION (identifierList);
 
- val Any = STAR alphabet_r;
+ val Any_ = STAR alphabet_r;
  (* val PatConcat = stringLiteral "@@"; *)
  val Star = STAR;
  val OrRegx = ALTERNATION;
@@ -163,15 +163,15 @@ struct
 
 
  val pattern_xzrwzr1  =  ThenRegx([stringLiteral "ld",  Star(OrRegx(alphaList)), whitespace_r]
- 				 @[OrRegx[stringLiteral "xzr", stringLiteral "wzr"], Any, END]);
+ 				 @[OrRegx[stringLiteral "xzr", stringLiteral "wzr"], Any_, END]);
 
  val pattern_xzrwzr2  =  ThenRegx([stringLiteral "ld",  Star(OrRegx(alphaList)), whitespace_r]
  				 @[Star (OrRegx(alphaList@numList@specialChar)), whitespace_r]
- 				 @[OrRegx[stringLiteral "xzr", stringLiteral "wzr"], Any, END]);
+ 				 @[OrRegx[stringLiteral "xzr", stringLiteral "wzr"], Any_, END]);
 
  val pattern_xzrwzr = OrRegx[pattern_xzrwzr1, pattern_xzrwzr2];
 
- val pattern_cbnz  = ThenRegx[stringLiteral "cbnz", whitespace_r, Any, END];
+ val pattern_cbnz  = ThenRegx[stringLiteral "cbnz", whitespace_r, Any_, END];
 
  (*  val p = pattern_xzrwzr *)
  (*  val p = pattern_cbnz *)


### PR DESCRIPTION
The changes contained required to keep HolBA up-to-date with Kananaskis-14 are very small.

`make main` and `make tests` currently compile without errors, we will have to discuss if other things should be ticked off.