### PR TITLE
Fixed bug in procedure bir_populate_blacklist'

### DIFF
--- a/src/tools/comp/bir_compositionLib.sml
+++ b/src/tools/comp/bir_compositionLib.sml
@@ -292,7 +292,7 @@ open bir_inst_liftingHelpersLib;
 		     HO_MATCH_MP new_map_triple3 (SIMP_RULE std_ss [] elabel_post_is_false_thm)
                    (* Finalize with assumption and INSERT and DELETE simplification *)
 		   val new_map_triple5 =
-                     SIMP_RULE std_ss [ASSUME assmpt]
+                     SIMP_RULE (std_ss++stringSimps.STRING_ss++string_ss) [ASSUME assmpt]
 		     (simp_delete_set_repr_rule new_map_triple4)
 		   val new_map_triple6 =
 		     simp_insert_set_repr_rule new_map_triple5

--- a/src/tools/comp/examples/Holmakefile.gen
+++ b/src/tools/comp/examples/Holmakefile.gen
@@ -1,0 +1,16 @@
+# includes
+# ----------------------------------
+DEPENDENCIES   =
+
+
+# configuration
+# ----------------------------------
+HOLHEAP        = ../HolBATools_Comp-heap
+NEWHOLHEAP     = 
+
+HEAPINC_EXTRA  = 
+
+
+# included lines follow
+# ----------------------------------
+include ../../../Holmakefile.inc

--- a/src/tools/comp/examples/test-bir_populate_blacklist_predset.sml
+++ b/src/tools/comp/examples/test-bir_populate_blacklist_predset.sml
@@ -1,0 +1,20 @@
+open HolKernel Parse boolLib bossLib;
+open bslSyntax;
+open bir_compositionLib;
+open bir_bool_expTheory;
+
+val observe_type = Type `: 'a`
+val bdefprog_list = bdefprog_list observe_type
+
+val p_def = bdefprog_list "p" [(blabel_str "entry", [], (bjmp o belabel_str) "0w"),
+                               (blabel_str "0w", [], (bjmp o belabel_str) "1w"),
+                               (blabel_str "1w", [], (bjmp o belabel_addr64) 2),
+                               (blabel_addr64 2, [], (bhalt o bconst64) 0)]
+
+val post = ``(\l. if (l = BL_Address (Imm64 2w)) then bir_exp_true else bir_exp_false)``
+val c = prove(
+  ``bir_simp_jgmt p bir_exp_true (BL_Label "entry") {BL_Address (Imm64 2w) ; BL_Label "0w" ; BL_Label "1w"} {} bir_exp_true ^post``,
+    cheat)
+
+(*Check that string labels are handled correctly*)
+val c' = bir_populate_blacklist_predset c


### PR DESCRIPTION
Fixes bug in procedure `bir_populate_blacklist'` causing it to throw an exception because equalities between strings and characters are not properly reduced. For example it throws the exception ` HOL_ERR {message = "", origin_function = "EQT_ELIM", origin_structure = "Drule"}` in the following code snippet
```
open HolKernel Parse boolLib bossLib;
open bslSyntax;
open bir_compositionLib;
open bir_bool_expTheory;

val observe_type = Type `: 'a`
val bdefprog_list = bdefprog_list observe_type

val p_def = bdefprog_list "p" [(blabel_str "entry", [], (bjmp o belabel_str) "0w"),
                               (blabel_str "0w", [], (bjmp o belabel_str) "1w"),
                               (blabel_str "1w", [], (bjmp o belabel_addr64) 2),
                               (blabel_addr64 2, [], (bhalt o bconst64) 0)]

val c = prove(
  “bir_simp_jgmt p bir_exp_true (BL_Label "entry") {BL_Address (Imm64 2w) ; BL_Label "0w" ; BL_Label "1w"} {} bir_exp_true (λl. if (l = BL_Address (Imm64 2w)) then bir_exp_true else bir_exp_false)”,
  cheat)

val c' = bir_populate_blacklist_predset c
```