### PR TITLE
Small modifications of evalwrapLib from the P4 project

### DIFF
--- a/src/shared/eval/evalwrapLib.sig
+++ b/src/shared/eval/evalwrapLib.sig
@@ -2,7 +2,7 @@ signature evalwrapLib =
 sig
 
   include Abbrev
-  val eval_ctxt_gen : term list -> term list -> term list -> term -> thm
+  val eval_ctxt_gen : term list -> term list -> thm -> term -> thm
   val qeval_ctxt : term frag list list -> term frag list -> thm
   val eval_ctxt_unify : term list -> term list -> term -> term -> thm
 

--- a/src/shared/eval/evalwrapLib.sml
+++ b/src/shared/eval/evalwrapLib.sml
@@ -2,7 +2,7 @@ structure evalwrapLib :> evalwrapLib =
 struct
 
 open HolKernel Parse boolLib bossLib;
-open computeLib;
+open computeLib hurdUtils;
 
 (*
  * This file offers functionality to evaluate a term given preconditions.
@@ -28,32 +28,18 @@ fun unify_same_free_vars ctxt tm =
   end;
 
 (*
- * evaluate a term  tm  in a non-empty context  ctxt : term list
+ * evaluate a term  tm  in a non-empty context  ctxt : thm
  * given list of constants   stop_consts1  and  stop_consts2
  * whose definition should not be unfolded in the first and second evaluation
  * step, respectively.
  *)
 fun eval_ctxt_gen stop_consts1 stop_consts2 ctxt tm =
-  let
-    val assl = map ASSUME ctxt;
-  in
-    RESTR_EVAL_CONV stop_consts1 tm
-    |> PROVE_HYP (LIST_CONJ assl)
-    |> CONV_RULE $ RAND_CONV
-      (REWRITE_CONV assl THENC RESTR_EVAL_CONV stop_consts2)
-    |> DISCH_ALL
-    |> GEN_ALL
-  end;
-
-(* dest_conj_list : term -> term list *)
-(* like CONJUNCTS but for a term *)
-fun dest_conj_list tm =
-  if can dest_conj tm
-  then
-    let val (x,y) = dest_conj tm
-    in dest_conj_list x @ dest_conj_list y
-    end
-  else [tm]
+  RESTR_EVAL_CONV stop_consts1 tm
+  |> PROVE_HYP ctxt
+  |> CONV_RULE $ RAND_CONV
+    (REWRITE_CONV [ctxt] THENC RESTR_EVAL_CONV stop_consts2)
+  |> DISCH_CONJUNCTS_ALL
+;
 
 (*
  * same as eval_ctxt_gen but unifies free variables in  ctxt_tm  and  tm ,
@@ -71,7 +57,7 @@ fun eval_ctxt_unify stop_consts1 stop_consts2 ctxt_tm tm =
   let
     val (ctxt_tm,tm) = unify_same_free_vars ctxt_tm tm
   in
-    eval_ctxt_gen stop_consts1 stop_consts2 (dest_conj_list ctxt_tm) tm
+    eval_ctxt_gen stop_consts1 stop_consts2 (ASSUME ctxt_tm) tm
   end
 
 (*
@@ -82,6 +68,6 @@ fun eval_ctxt_unify stop_consts1 stop_consts2 ctxt_tm tm =
  *   ⊢ ∀g f. f 3 = 24 ⇒ (g ∘ f) (1 + 2) = g 24: thm
  *)
 fun qeval_ctxt ctxt tm =
-  eval_ctxt_gen [] [] (map Term ctxt) $ Term tm
+  eval_ctxt_gen [] [] (ASSUME $ list_mk_conj $ map Term ctxt) (Term tm)
 
 end


### PR DESCRIPTION
The suggested changes are as follows:

* No `GEN_ALL` done at the end of `eval_ctxt_gen`. Rationale: for the step-wise evaluation-under-assumptions, I take the result of `eval_ctxt_gen` and use it with `MATCH_MP`, for which I don't want any enclosing universal quantifier, but free variables. If you want `GEN_ALL` of the result it's trivial to add it anyhow, but it just adds inefficiency if it's the default if you always need to reverse it. Maybe another wrapper can be added that also does `GEN_ALL` if this is the preferred format for another project?
* `ctxt` parameter of `eval_ctxt_gen` changed to type `thm` from type `term list`. Rationale: Similarly to the previous point, if `eval_ctxt_gen` is used inside a loop with the same `ctxt` every time, it's inefficient to do `map ASSUME` and `LIST_CONJ` every time.
  * The interface of `qeval_ctxt` is unchanged by making compensations to the call of `eval_ctxt_gen` - other new wrappers like this can be created if needed.
  * `dest_conj_list` is no longer needed due to this change
  * Swapped the `DISCH_ALL` at the end for a `DISCH_CONJUNCTS_ALL` to match the new format

IMO in general when you program some core functionality that's called by means of different wrappers, it's a good idea to build in the least amount of format conversions into it. Then you can split the ways of calling the mechanism into those most suitable for computation and convenience and add in the extra stuff in the latter.