### PR TITLE
Additional opens in bir_m0_extrasScript

### DIFF
--- a/src/theory/tools/lifter/bir_m0_extrasScript.sml
+++ b/src/theory/tools/lifter/bir_m0_extrasScript.sml
@@ -1,7 +1,7 @@
 open HolKernel Parse boolLib bossLib;
 open wordsTheory
 open bir_exp_liftingTheory
-open m0Theory
+open m0Theory m0_stepTheory;
 open bir_lifter_general_auxTheory;
 open bir_interval_expTheory
 open bir_extra_expsTheory;


### PR DESCRIPTION
Fixes the issues with Cortex-M0-lifting. The problem was that `R_name` from `m0_stepTheory` was treated as a free variable when the theory in question wasn't opened. Since this happened in a forward proof, it wasn't discovered during regular compilation.