### PR TITLE
add some selftests to Holmakefile with test action

### DIFF
--- a/src/theory/bir-support/Holmakefile
+++ b/src/theory/bir-support/Holmakefile
@@ -1,4 +1,11 @@
 INCLUDES = $(HOLBADIR)/src/theory/bir
 
-all: $(DEFAULT_TARGETS)
+all: $(DEFAULT_TARGETS) selftest.exe
 .PHONY: all
+
+selftest.exe: selftest.uo
+	$(HOLMOSMLC) -o $@ $<
+
+test: selftest.exe
+	./selftest.exe
+.PHONY: test

--- a/src/theory/bir/Holmakefile
+++ b/src/theory/bir/Holmakefile
@@ -1,4 +1,11 @@
 INCLUDES = $(HOLBADIR)/src/aux
 
-all: $(DEFAULT_TARGETS)
+all: $(DEFAULT_TARGETS) selftest.exe
 .PHONY: all
+
+selftest.exe: selftest.uo
+	$(HOLMOSMLC) -o $@ $<
+
+test: selftest.exe
+	./selftest.exe
+.PHONY: test

--- a/src/tools/lifter/Holmakefile
+++ b/src/tools/lifter/Holmakefile
@@ -12,5 +12,16 @@ INCLUDES = $(HOLDIR)/examples/l3-machine-code/common \
            $(HOLBADIR)/src/shared \
            $(HOLBADIR)/src/theory/tools/lifter
 
-all: $(DEFAULT_TARGETS)
+all: $(DEFAULT_TARGETS) selftest_arm.exe selftest_riscv.exe
 .PHONY: all
+
+selftest_arm.exe: selftest_arm.uo
+	$(HOLMOSMLC) -o $@ $<
+
+selftest_riscv.exe: selftest_riscv.uo
+	$(HOLMOSMLC) -o $@ $<
+
+test: selftest_arm.exe selftest_riscv.exe
+	./selftest_arm.exe
+	./selftest_riscv.exe
+.PHONY: test

--- a/src/tools/lifter/selftest_arm.sml
+++ b/src/tools/lifter/selftest_arm.sml
@@ -1,5 +1,12 @@
 open HolKernel Parse;
 open testutils;
+
+(* FIXME: needed to avoid quse errors *)
+open m0_stepLib;
+
+open bir_update_blockTheory;
+open bir_inst_liftingTheory;
+
 open bir_inst_liftingLib;
 open bir_inst_liftingLibTypes;
 open bir_inst_liftingHelpersLib;

--- a/src/tools/lifter/selftest_riscv.sml
+++ b/src/tools/lifter/selftest_riscv.sml
@@ -1,5 +1,9 @@
 open HolKernel Parse
 open testutils
+
+(* FIXME: needed to avoid quse errors *)
+open m0_stepLib;
+
 open bir_inst_liftingLib;
 open PPBackEnd
 open riscv_assemblerLib;


### PR DESCRIPTION
This is in preparation of a larger overhaul of the tests, but maybe it's OK to merge even now as it doesn't affect the regular build @didriklundberg?

In particular, we agreed all test `.sml` files should follow the convention: `test-*.sml` instead of `selftest*.sml` or something without the word `test`. I didn't do this change here, since it's probably best to do in one go.