### PR TITLE
RISC-V backlifting and examples

### DIFF
--- a/examples/riscv/Holmakefile
+++ b/examples/riscv/Holmakefile
@@ -1,0 +1,14 @@
+INCLUDES = $(HOLBADIR)/examples/riscv/swap \
+           $(HOLBADIR)/examples/riscv/isqrt \
+           $(HOLBADIR)/examples/riscv/mod2
+
+all: $(DEFAULT_TARGETS) test-riscv.exe
+.PHONY: all
+
+test-riscv.exe: test-riscv.uo
+	$(HOLMOSMLC) -o $@ $<
+
+test: test-riscv.exe
+	./test-riscv.exe
+
+EXTRA_CLEANS = test-riscv.exe

--- a/examples/riscv/mod2/Holmakefile
+++ b/examples/riscv/mod2/Holmakefile
@@ -1,0 +1,14 @@
+INCLUDES = $(HOLDIR)/examples/l3-machine-code/common \
+           $(HOLDIR)/examples/l3-machine-code/arm8/model \
+           $(HOLDIR)/examples/l3-machine-code/arm8/step \
+           $(HOLDIR)/examples/l3-machine-code/m0/model \
+           $(HOLDIR)/examples/l3-machine-code/m0/step \
+           $(HOLDIR)/examples/l3-machine-code/riscv/model \
+           $(HOLDIR)/examples/l3-machine-code/riscv/step \
+           $(HOLBADIR)/src/theory/bir \
+           $(HOLBADIR)/src/theory/bir-support \
+           $(HOLBADIR)/src/tools/lifter \
+           $(HOLBADIR)/src/tools/backlifter
+
+all: $(DEFAULT_TARGETS)
+.PHONY: all

--- a/examples/riscv/mod2/mod2.c
+++ b/examples/riscv/mod2/mod2.c
@@ -1,0 +1,7 @@
+#include <stdint.h>
+
+uint64_t mod2(uint64_t * i) {
+  uint64_t j;
+  j =  * i % 2;
+  return j;
+}

--- a/examples/riscv/mod2/mod2.da
+++ b/examples/riscv/mod2/mod2.da
@@ -1,0 +1,10 @@
+
+mod2.o:     file format elf64-littleriscv
+
+
+Disassembly of section .text:
+
+0000000000000000 <mod2>:
+   0:	00053503          	ld	a0,0(a0)
+   4:	00157513          	andi	a0,a0,1
+   8:	00008067          	ret

--- a/examples/riscv/mod2/mod2Script.sml
+++ b/examples/riscv/mod2/mod2Script.sml
@@ -1,0 +1,15 @@
+open HolKernel Parse;
+
+(* FIXME: needed to avoid quse errors *)
+open m0_stepLib;
+
+open bir_lifter_interfaceLib;
+
+val _ = Parse.current_backend := PPBackEnd.vt100_terminal;
+val _ = set_trace "bir_inst_lifting.DEBUG_LEVEL" 2;
+
+val _ = new_theory "mod2";
+
+val _ = lift_da_and_store "mod2" "mod2.da" da_riscv ((Arbnum.fromInt 0), (Arbnum.fromInt 0x1000000));
+
+val _ = export_theory ();

--- a/examples/riscv/mod2/mod2_backliftingScript.sml
+++ b/examples/riscv/mod2/mod2_backliftingScript.sml
@@ -1,0 +1,23 @@
+open HolKernel Parse boolLib bossLib;
+
+(* FIXME: needed to avoid quse errors *)
+open m0_stepLib;
+
+open bir_backlifterLib;
+
+val _ = new_theory "mod2_backlifting";
+
+(*
+val arm_add_reg_contract_thm =
+  save_thm("arm_add_reg_contract_thm",
+  get_arm8_contract_sing bir_add_reg_ct ``bir_add_reg_progbin`` ``arm8_add_reg_pre``
+                       ``arm8_add_reg_post`` bir_add_reg_prog_def
+                       [bir_add_reg_contract_1_pre_def, bir_add_reg_pre_def]
+                       bir_add_reg_contract_1_pre_def arm8_pre_imp_bir_pre_thm
+                       [bir_add_reg_contract_4_post_def] arm8_post_imp_bir_post_thm
+                       bir_prog_add_regTheory.bir_add_reg_arm8_lift_THM);
+
+|- arm8_cont bir_add_reg_progbin 28w {72w} arm8_add_reg_pre arm8_add_reg_post
+*)
+
+val _ = export_theory ();

--- a/examples/riscv/mod2/mod2_propScript.sml
+++ b/examples/riscv/mod2/mod2_propScript.sml
@@ -1,0 +1,28 @@
+open HolKernel boolLib Parse bossLib;
+
+open BasicProvers simpLib metisLib;
+
+open numTheory arithmeticTheory int_bitwiseTheory pairTheory combinTheory wordsTheory;
+
+(* FIXME: needed to avoid quse errors *)
+open m0_stepLib;
+
+open bir_inst_liftingTheory;
+open bir_lifting_machinesTheory;
+open bir_lifting_machinesLib bir_lifting_machinesLib_instances;
+
+open bir_programSyntax bir_program_labelsTheory bir_immTheory;
+
+open mod2Theory;
+
+val _ = new_theory "mod2_prop";
+
+(* top-level relation between pre and post RISC-V states *)
+Definition mod2_spec_def:
+ mod2_spec_def ms ms' : bool =
+  let input = ms.c_gpr ms.procID 0w in
+  let output = ms'.c_gpr ms'.procID 0w in
+  (w2n output) = (w2n input) MOD 2
+End
+
+val _ = export_theory ();

--- a/examples/riscv/swap/Holmakefile
+++ b/examples/riscv/swap/Holmakefile
@@ -8,7 +8,9 @@ INCLUDES = $(HOLDIR)/examples/l3-machine-code/common \
            $(HOLBADIR)/src/theory/bir \
            $(HOLBADIR)/src/theory/bir-support \
            $(HOLBADIR)/src/tools/lifter \
-           $(HOLBADIR)/src/tools/exec
+           $(HOLBADIR)/src/tools/exec \
+           $(HOLBADIR)/src/theory/tools/backlifter \
+           $(HOLBADIR)/src/tools/backlifter
 
 all: $(DEFAULT_TARGETS)
 .PHONY: all

--- a/examples/riscv/swap/Holmakefile
+++ b/examples/riscv/swap/Holmakefile
@@ -10,6 +10,7 @@ INCLUDES = $(HOLDIR)/examples/l3-machine-code/common \
            $(HOLBADIR)/src/tools/lifter \
            $(HOLBADIR)/src/tools/exec \
            $(HOLBADIR)/src/theory/tools/backlifter \
+           $(HOLBADIR)/src/tools/comp \
            $(HOLBADIR)/src/tools/backlifter
 
 all: $(DEFAULT_TARGETS)

--- a/examples/riscv/swap/Holmakefile
+++ b/examples/riscv/swap/Holmakefile
@@ -11,7 +11,9 @@ INCLUDES = $(HOLDIR)/examples/l3-machine-code/common \
            $(HOLBADIR)/src/tools/exec \
            $(HOLBADIR)/src/theory/tools/backlifter \
            $(HOLBADIR)/src/tools/comp \
-           $(HOLBADIR)/src/tools/backlifter
+           $(HOLBADIR)/src/tools/wp \
+           $(HOLBADIR)/src/tools/backlifter \
+           $(HOLBADIR)/examples/tutorial/support
 
 all: $(DEFAULT_TARGETS)
 .PHONY: all

--- a/examples/riscv/swap/swap_propScript.sml
+++ b/examples/riscv/swap/swap_propScript.sml
@@ -3,7 +3,8 @@ open HolKernel boolLib Parse bossLib;
 (* FIXME: needed to avoid quse errors *)
 open m0_stepLib;
 
-open bir_programSyntax bir_program_labelsTheory bir_immTheory bir_tsTheory;
+open bir_programSyntax bir_program_labelsTheory bir_immTheory;
+open bir_tsTheory bir_bool_expTheory;
 
 open bir_riscv_backlifterTheory;
 open bir_backlifterLib;
@@ -49,13 +50,13 @@ End
 Theorem swap_riscv_pre_imp_bir_pre_thm:
  bir_pre_riscv_to_bir riscv_swap_pre bir_swap_pre
 Proof
- cheat
+ EVAL_TAC >> rw []
 QED
 
 Theorem swap_riscv_post_imp_bir_post_thm:
  !ls. bir_post_bir_to_riscv riscv_swap_post (\l. bir_swap_post) ls
 Proof
- cheat
+ EVAL_TAC >> rw []
 QED
 
 Theorem bir_cont_swap:
@@ -64,11 +65,10 @@ Theorem bir_cont_swap:
   bir_swap_pre
   (\l. if l = BL_Address (Imm64 20w) then bir_swap_post else bir_exp_false)
 Proof
- (* this is supposed to be proved by symbolic exec + SMT *)
  cheat
 QED
 
-(* for debugging:
+(* For debugging:
 
 val bir_ct = bir_cont_swap;
 val prog_bin = ``bir_swap_progbin``;

--- a/examples/riscv/swap/swap_propScript.sml
+++ b/examples/riscv/swap/swap_propScript.sml
@@ -15,11 +15,11 @@ bir_swap_riscv_lift_THM;
 
 Definition swap_mem_spec_def:
  swap_mem_spec ms =
- let ms'_mem8 = (riscv_mem_store_word (ms.c_gpr ms.procID 0w)
-   (riscv_mem_load_word ms.MEM8 (ms.c_gpr ms.procID 1w)) ms.MEM8)
+ let ms'_mem8 = (riscv_mem_store_dword (ms.c_gpr ms.procID 0w)
+   (riscv_mem_load_dword ms.MEM8 (ms.c_gpr ms.procID 1w)) ms.MEM8)
  in
-   (riscv_mem_store_word (ms.c_gpr ms.procID 1w)
-    (riscv_mem_load_word ms.MEM8 (ms.c_gpr ms.procID 0w)) ms'_mem8)
+   (riscv_mem_store_dword (ms.c_gpr ms.procID 1w)
+    (riscv_mem_load_dword ms.MEM8 (ms.c_gpr ms.procID 0w)) ms'_mem8)
 End
 
 Definition swap_spec_output_def:

--- a/examples/riscv/swap/swap_propScript.sml
+++ b/examples/riscv/swap/swap_propScript.sml
@@ -1,6 +1,13 @@
 open HolKernel boolLib Parse bossLib;
 
+(* FIXME: needed to avoid quse errors *)
+open m0_stepLib;
+
 open bir_programSyntax bir_program_labelsTheory bir_immTheory;
+
+open bir_riscv_backlifterTheory;
+
+open bir_backlifterLib;
 
 open swapTheory;
 
@@ -30,7 +37,86 @@ Definition swap_spec_def:
  swap_spec ms ms' : bool = (ms'.MEM8 = swap_mem_spec ms)
 End
 
-(* run symbolic execution of BIR to get two symbolic states  *)
-(* connect this back to the riscv state via the lifting theorem *)
+(*
+  val bir_ct = bir_swap_ct;
+  val prog_bin = ``bir_swap_progbin``;
+  val bir_prog_def = bir_swap_prog_def;
+
+  val riscv_pre = ``riscv_swap_pre``;
+  val riscv_post = ``riscv_swap_post``;
+
+  val bir_pre_defs = [bir_add_reg_contract_1_pre_def, bir_add_reg_pre_def];
+  val bir_pre1_def = bir_add_reg_contract_1_pre_def;
+
+  val riscv_pre_imp_bir_pre_thm = riscv_pre_imp_bir_pre_thm;
+
+  val bir_post_defs = [bir_add_reg_contract_4_post_def];
+
+  val arm8_post_imp_bir_post_thm = arm8_post_imp_bir_post_thm;
+
+  val bir_is_lifted_prog_thm = bir_swap_riscv_lift_THM;
+
+  val riscv_swap_contract_thm =
+   save_thm("riscv_swap_contract_thm",
+    get_riscv_contract_sing
+     bir_swap_ct ``bir_swap_progbin``
+     ``riscv_swap_pre`` ``riscv_swap_post`` bir_swap_prog_def
+     [bir_swap_contract_pre_def, bir_swap_pre_def]
+     bir_swap_contract_pre_def riscv_pre_imp_bir_pre_thm
+     [bir_swap_contract_post_def] riscv_post_imp_bir_post_thm
+     bir_swap_riscv_lift_THM
+*)
+
+Definition riscv_swap_pre_def:
+ riscv_swap_pre (m : riscv_state) = T
+End
+
+Definition riscv_swap_post_def:
+ riscv_swap_post (m : riscv_state) = T
+End
+
+(*
+bir_add_reg_ct;
+val it =
+    []
+   ⊢ bir_cont bir_add_reg_prog bir_exp_true (BL_Address (Imm64 28w))
+       {BL_Address (Imm64 72w)} ∅ bir_add_reg_contract_1_pre
+       (λl.
+            if l = BL_Address (Imm64 72w) then bir_add_reg_contract_4_post
+            else bir_exp_false): thm
+
+bir_cont prog invariant l ls ls' pre post
+*)
+
+Definition bir_swap_pre_def:
+  bir_swap_pre : bir_exp_t = bir_exp_true
+End
+
+Definition bir_swap_post_def:
+ bir_swap_post : bir_exp_t = bir_exp_true
+End
+
+Theorem swap_riscv_pre_imp_bir_pre_thm:
+ bir_pre_riscv_to_bir riscv_swap_pre bir_swap_pre
+Proof
+ cheat
+QED
+
+Theorem riscv_post_imp_bir_post_thm:
+ !ls. bir_post_bir_to_riscv riscv_swap_post (\l. bir_swap_post) ls
+Proof
+ cheat
+QED
+
+(*
+Theorem bir_cont_swap:
+ bir_cont bir_swap_prog bir_exp_true (BL_Address (Imm64 28w))
+  {BL_Address (Imm64 72w)} bir_swap_pre
+  (\l. if l = BL_Address (Imm64 72w) then bir_swap_post
+   else bir_exp-false)
+Proof
+ cheat
+QED
+*)
 
 val _ = export_theory ();

--- a/examples/riscv/swap/swap_propScript.sml
+++ b/examples/riscv/swap/swap_propScript.sml
@@ -116,7 +116,7 @@ QED
 
 Theorem bir_cont_swap:
   bir_cont bir_swap_prog bir_exp_true
-   (BL_Address (Imm64 28w)) {BL_Address (Imm64 0w)} {}
+   (BL_Address (Imm64 0w)) {BL_Address (Imm64 20w)} {}
   bir_swap_pre
   (\l. if l = BL_Address (Imm64 20w) then bir_swap_post else bir_exp_false)
 Proof
@@ -125,10 +125,6 @@ Proof
 QED
 
 (*
-HOL_ERR
-     {message = "can't type-instantiate input theorem", origin_function =
-      "ISPECL", origin_structure = "Drule"} raised
-
 val riscv_swap_contract_thm =
    save_thm("riscv_swap_contract_thm",
     get_riscv_contract_sing

--- a/examples/riscv/swap/swap_propScript.sml
+++ b/examples/riscv/swap/swap_propScript.sml
@@ -3,24 +3,15 @@ open HolKernel boolLib Parse bossLib;
 (* FIXME: needed to avoid quse errors *)
 open m0_stepLib;
 
-open bir_programSyntax bir_program_labelsTheory bir_immTheory;
+open bir_programSyntax bir_program_labelsTheory bir_immTheory bir_tsTheory;
 
 open bir_riscv_backlifterTheory;
-
 open bir_backlifterLib;
-
-open bir_tsTheory;
+open bir_compositionLib;
 
 open swapTheory;
 
 val _ = new_theory "swap_prop";
-
-val blocks = (fst o listSyntax.dest_list o dest_BirProgram o snd o dest_eq o concl o EVAL) ``bir_swap_prog``;
-
-(el 1)blocks;
-(el 2)blocks;
-
-bir_swap_riscv_lift_THM;
 
 Definition swap_mem_spec_def:
  swap_mem_spec ms =
@@ -38,53 +29,6 @@ End
 Definition swap_spec_def:
  swap_spec ms ms' : bool = (ms'.MEM8 = swap_mem_spec ms)
 End
-
-(*
-  BINARY RISC-V PROGRAM (via DISSASSEMBLY):
-  val prog_bin = ``bir_swap_progbin``;
-  
-  LIFTED BIR PROGRAM (via LIFTER):
-  val bir_prog_def = bir_swap_prog_def;
-
-  BIR-LEVEL CONTRACT FOR LIFTED BIR PROGRAM (via SYMBOLIC EXEC + SMT):
-  val bir_ct = bir_swap_ct;
-
-  PRECONDITION PREDICATE FOR RISC-V PROGRAM (via RISC-V SPEC):
-  val riscv_pre = ``riscv_swap_pre``;
-
-  POSTCONDITION PREDICATE FOR RISC-V PROGRAM (via RISC-V SPEC):
-  val riscv_post = ``riscv_swap_post``;
-
-  LIFTED BIR PROGRAM PRECONDITIONS (via RISC-V SPEC): 
-  val bir_pre_defs = [bir_add_reg_contract_1_pre_def, bir_add_reg_pre_def];
-  val bir_pre1_def = bir_add_reg_contract_1_pre_def;
-
-  RISC-V PRECONDITION IMPLIES BIR PRECONDITION:
-  val riscv_pre_imp_bir_pre_thm = swap_riscv_pre_imp_bir_pre_thm;
-
-  LIFTER BIR PROGRAM POSTCONDITIONS (via RISC-V SPEC):
-  val bir_post_defs = [bir_add_reg_contract_4_post_def];
-
-  BIR POSTCONDITION IMPLIES RISC-V POSTCONDITION:
-  val riscv_post_imp_bir_post_thm = swap_riscv_post_imp_bir_post_thm;
-
-  RISC-V PROGRAM THEOREM:
-  val bir_is_lifted_prog_thm = bir_swap_riscv_lift_THM;
-
-  val riscv_swap_contract_thm =
-
-   save_thm("riscv_swap_contract_thm",
-
-    get_riscv_contract_sing
-     bir_swap_ct ``bir_swap_progbin``
-     ``riscv_swap_pre`` ``riscv_swap_post`` bir_swap_prog_def
-     [bir_swap_contract_pre_def, bir_swap_pre_def]
-     bir_swap_contract_pre_def riscv_pre_imp_bir_pre_thm
-     [bir_swap_contract_post_def] riscv_post_imp_bir_post_thm
-     bir_swap_riscv_lift_THM
-
-  get_riscv_contract_sing USES: GENERAL riscv_lift_contract_thm
-*)
 
 Definition riscv_swap_pre_def:
  riscv_swap_pre (m : riscv_state) = T
@@ -124,16 +68,29 @@ Proof
  cheat
 QED
 
-(*
-val riscv_swap_contract_thm =
-   save_thm("riscv_swap_contract_thm",
-    get_riscv_contract_sing
-     bir_cont_swap ``bir_swap_progbin``
-     ``riscv_swap_pre`` ``riscv_swap_post`` bir_swap_prog_def
-     [bir_swap_pre_def]
-     bir_swap_pre_def swap_riscv_pre_imp_bir_pre_thm
-     [bir_swap_post_def] swap_riscv_post_imp_bir_post_thm
-     bir_swap_riscv_lift_THM);
+(* for debugging:
+
+val bir_ct = bir_cont_swap;
+val prog_bin = ``bir_swap_progbin``;
+val riscv_pre = ``riscv_swap_pre``;
+val riscv_post = ``riscv_swap_post``;
+val bir_prog_def = bir_swap_prog_def;
+val bir_pre_defs = [bir_swap_pre_def]
+val bir_pre1_def = bir_swap_pre_def;
+val riscv_pre_imp_bir_pre_thm = swap_riscv_pre_imp_bir_pre_thm;
+val bir_post_defs = [bir_swap_post_def];
+val riscv_post_imp_bir_post_thm = swap_riscv_post_imp_bir_post_thm;
+val bir_is_lifted_prog_thm = bir_swap_riscv_lift_THM;
 *)
+
+val riscv_swap_contract_thm = save_thm("riscv_swap_contract_thm",
+ get_riscv_contract_sing
+  bir_cont_swap
+  ``bir_swap_progbin``
+  ``riscv_swap_pre`` ``riscv_swap_post`` bir_swap_prog_def
+  [bir_swap_pre_def]
+  bir_swap_pre_def swap_riscv_pre_imp_bir_pre_thm
+  [bir_swap_post_def] swap_riscv_post_imp_bir_post_thm
+  bir_swap_riscv_lift_THM);
 
 val _ = export_theory ();

--- a/examples/riscv/swap/swap_propScript.sml
+++ b/examples/riscv/swap/swap_propScript.sml
@@ -9,6 +9,8 @@ open bir_riscv_backlifterTheory;
 
 open bir_backlifterLib;
 
+open bir_tsTheory;
+
 open swapTheory;
 
 val _ = new_theory "swap_prop";
@@ -38,26 +40,41 @@ Definition swap_spec_def:
 End
 
 (*
-  val bir_ct = bir_swap_ct;
+  BINARY RISC-V PROGRAM (via DISSASSEMBLY):
   val prog_bin = ``bir_swap_progbin``;
+  
+  LIFTED BIR PROGRAM (via LIFTER):
   val bir_prog_def = bir_swap_prog_def;
 
+  BIR-LEVEL CONTRACT FOR LIFTED BIR PROGRAM (via SYMBOLIC EXEC + SMT):
+  val bir_ct = bir_swap_ct;
+
+  PRECONDITION PREDICATE FOR RISC-V PROGRAM (via RISC-V SPEC):
   val riscv_pre = ``riscv_swap_pre``;
+
+  POSTCONDITION PREDICATE FOR RISC-V PROGRAM (via RISC-V SPEC):
   val riscv_post = ``riscv_swap_post``;
 
+  LIFTED BIR PROGRAM PRECONDITIONS (via RISC-V SPEC): 
   val bir_pre_defs = [bir_add_reg_contract_1_pre_def, bir_add_reg_pre_def];
   val bir_pre1_def = bir_add_reg_contract_1_pre_def;
 
-  val riscv_pre_imp_bir_pre_thm = riscv_pre_imp_bir_pre_thm;
+  RISC-V PRECONDITION IMPLIES BIR PRECONDITION:
+  val riscv_pre_imp_bir_pre_thm = swap_riscv_pre_imp_bir_pre_thm;
 
+  LIFTER BIR PROGRAM POSTCONDITIONS (via RISC-V SPEC):
   val bir_post_defs = [bir_add_reg_contract_4_post_def];
 
-  val arm8_post_imp_bir_post_thm = arm8_post_imp_bir_post_thm;
+  BIR POSTCONDITION IMPLIES RISC-V POSTCONDITION:
+  val riscv_post_imp_bir_post_thm = swap_riscv_post_imp_bir_post_thm;
 
+  RISC-V PROGRAM THEOREM:
   val bir_is_lifted_prog_thm = bir_swap_riscv_lift_THM;
 
   val riscv_swap_contract_thm =
+
    save_thm("riscv_swap_contract_thm",
+
     get_riscv_contract_sing
      bir_swap_ct ``bir_swap_progbin``
      ``riscv_swap_pre`` ``riscv_swap_post`` bir_swap_prog_def
@@ -65,6 +82,8 @@ End
      bir_swap_contract_pre_def riscv_pre_imp_bir_pre_thm
      [bir_swap_contract_post_def] riscv_post_imp_bir_post_thm
      bir_swap_riscv_lift_THM
+
+  get_riscv_contract_sing USES: GENERAL riscv_lift_contract_thm
 *)
 
 Definition riscv_swap_pre_def:
@@ -74,19 +93,6 @@ End
 Definition riscv_swap_post_def:
  riscv_swap_post (m : riscv_state) = T
 End
-
-(*
-bir_add_reg_ct;
-val it =
-    []
-   ⊢ bir_cont bir_add_reg_prog bir_exp_true (BL_Address (Imm64 28w))
-       {BL_Address (Imm64 72w)} ∅ bir_add_reg_contract_1_pre
-       (λl.
-            if l = BL_Address (Imm64 72w) then bir_add_reg_contract_4_post
-            else bir_exp_false): thm
-
-bir_cont prog invariant l ls ls' pre post
-*)
 
 Definition bir_swap_pre_def:
   bir_swap_pre : bir_exp_t = bir_exp_true
@@ -102,21 +108,36 @@ Proof
  cheat
 QED
 
-Theorem riscv_post_imp_bir_post_thm:
+Theorem swap_riscv_post_imp_bir_post_thm:
  !ls. bir_post_bir_to_riscv riscv_swap_post (\l. bir_swap_post) ls
 Proof
  cheat
 QED
 
-(*
 Theorem bir_cont_swap:
- bir_cont bir_swap_prog bir_exp_true (BL_Address (Imm64 28w))
-  {BL_Address (Imm64 72w)} bir_swap_pre
-  (\l. if l = BL_Address (Imm64 72w) then bir_swap_post
-   else bir_exp-false)
+  bir_cont bir_swap_prog bir_exp_true
+   (BL_Address (Imm64 28w)) {BL_Address (Imm64 0w)} {}
+  bir_swap_pre
+  (\l. if l = BL_Address (Imm64 20w) then bir_swap_post else bir_exp_false)
 Proof
+ (* this is supposed to be proved by symbolic exec + SMT *)
  cheat
 QED
+
+(*
+HOL_ERR
+     {message = "can't type-instantiate input theorem", origin_function =
+      "ISPECL", origin_structure = "Drule"} raised
+
+val riscv_swap_contract_thm =
+   save_thm("riscv_swap_contract_thm",
+    get_riscv_contract_sing
+     bir_cont_swap ``bir_swap_progbin``
+     ``riscv_swap_pre`` ``riscv_swap_post`` bir_swap_prog_def
+     [bir_swap_pre_def]
+     bir_swap_pre_def swap_riscv_pre_imp_bir_pre_thm
+     [bir_swap_post_def] swap_riscv_post_imp_bir_post_thm
+     bir_swap_riscv_lift_THM);
 *)
 
 val _ = export_theory ();

--- a/examples/riscv/test-riscv.sml
+++ b/examples/riscv/test-riscv.sml
@@ -1,0 +1,33 @@
+open HolKernel Parse boolLib bossLib;
+
+val _ = Parse.current_backend := PPBackEnd.vt100_terminal;
+val _ = Globals.show_tags := true;
+
+open wordsTheory;
+
+open bir_programSyntax bir_program_labelsTheory bir_immTheory;
+
+open swapTheory swap_propTheory;
+open isqrtTheory isqrt_propTheory;
+open mod2Theory mod2_propTheory;
+
+fun print_and_check_thm name thm t_concl =
+  let
+    val _ = print (name ^ ":\n");
+    val _ = print "===============================\n";
+    val _ = (Hol_pp.print_thm thm; print "\n");
+    val _ = if identical (concl thm) t_concl then () else
+            raise Fail "print_and_check_thm::conclusion is not as expected"
+    val _ = print "\n\n";
+  in
+    ()
+  end;
+
+val _ = print_and_check_thm
+  "swap RISC-V lift theorem"
+  bir_swap_riscv_lift_THM
+  ``
+  bir_is_lifted_prog riscv_bmr (WI_end (0w : word64) (0x1000000w : word64))
+   bir_swap_progbin
+   (bir_swap_prog : 'observation_type bir_program_t)
+  ``;

--- a/examples/riscv/test-riscv.sml
+++ b/examples/riscv/test-riscv.sml
@@ -31,3 +31,11 @@ val _ = print_and_check_thm
    bir_swap_progbin
    (bir_swap_prog : 'observation_type bir_program_t)
   ``;
+
+val _ = print_and_check_thm
+  "swap RISC-V backlifted theorem"
+  riscv_swap_contract_thm
+  ``riscv_cont
+     bir_swap_progbin
+     0w {20w}
+     riscv_swap_pre riscv_swap_post``;

--- a/examples/tutorial/4-bir-to-arm/tutorial_bir_to_armScript.sml
+++ b/examples/tutorial/4-bir-to-arm/tutorial_bir_to_armScript.sml
@@ -25,7 +25,7 @@ open bir_inst_liftingHelpersLib;
 
 (* Code specific for the example *)
 open HolBASimps;
-open bir_backlifterTheory;
+open bir_arm8_backlifterTheory;
 open bslSyntax;
 
 val _ = new_theory "tutorial_bir_to_arm";

--- a/src/theory/tools/backlifter/bir_arm8_backlifterScript.sml
+++ b/src/theory/tools/backlifter/bir_arm8_backlifterScript.sml
@@ -25,7 +25,7 @@ open bir_auxiliaryLib;
 
 open m0_mod_stepLib;
 
-val _ = new_theory "bir_backlifter";
+val _ = new_theory "bir_arm8_backlifter";
 
 (* This part should be generalized *)
 (*
@@ -694,7 +694,7 @@ FULL_SIMP_TAC (std_ss++holBACore_ss++bir_wm_SS++pred_setLib.PRED_SET_ss)
 );
 
 
-val lift_contract_thm = store_thm("lift_contract_thm",
+val arm8_lift_contract_thm = store_thm("arm8_lift_contract_thm",
   ``!p mms ml mls mu mpre mpost bpre bpost.
       MEM (BL_Address (Imm64 ml)) (bir_labels_of_program p) ==>
       bir_cont p bir_exp_true (BL_Address (Imm64 ml))

--- a/src/theory/tools/backlifter/bir_common_backlifterScript.sml
+++ b/src/theory/tools/backlifter/bir_common_backlifterScript.sml
@@ -1,0 +1,150 @@
+open HolKernel Parse boolLib bossLib;
+
+(* FIXME: avoid quse errors *)
+open m0_stepLib;
+
+open bir_immTheory;
+open bir_programTheory;
+open bir_tsTheory;
+open bir_program_multistep_propsTheory;
+open bir_auxiliaryTheory;
+
+(* From lifter: *)
+open bir_inst_liftingTheory;
+open bir_lifting_machinesTheory;
+
+(* From comp: *)
+open total_program_logicTheory;
+open total_ext_program_logicTheory;
+
+open HolBASimps;
+open HolBACoreSimps;
+open program_logicSimps;
+
+open bir_auxiliaryLib;
+
+open m0_mod_stepLib;
+
+val _ = new_theory "bir_common_backlifter";
+
+Theorem set_of_address_in_all_address_labels_thm:
+ !l adds.
+    l IN {BL_Address (Imm64 ml') | ml' IN adds} ==>
+    l IN {l | IS_BL_Address l}
+Proof
+REPEAT STRIP_TAC >>
+FULL_SIMP_TAC std_ss [pred_setTheory.GSPECIFICATION, bir_program_labelsTheory.IS_BL_Address_def]
+QED
+
+Theorem bir_exec_to_labels_TO_exec_to_addr_label_n:
+   !bs' ml' mls p bs l n n0.
+    (bs'.bst_pc.bpc_label IN {BL_Address (Imm64 ml') | ml' IN mls}) ==>
+    (bir_exec_to_labels {BL_Address (Imm64 ml') | ml' IN mls} p bs =
+         BER_Ended l n n0 bs') ==>
+    ?n' lo c_st c_addr_labels.
+         (n' > 0) /\
+         (c_st = n) /\
+         (bir_exec_to_addr_label_n p bs n' =
+           BER_Ended lo c_st c_addr_labels bs')
+Proof
+REPEAT STRIP_TAC >>
+subgoal `bs'.bst_pc.bpc_label IN {l | IS_BL_Address l}` >- (
+  METIS_TAC [set_of_address_in_all_address_labels_thm]
+) >>
+FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_exec_to_labels_def, bir_exec_to_addr_label_n_def,
+				      bir_exec_to_labels_n_def] >>
+subgoal `bir_pc_cond_impl (F,
+	   (\pc.
+	     (pc.bpc_index = 0) /\
+	     pc.bpc_label IN {BL_Address (Imm64 ml') | ml' IN mls})) (F, (\pc. (pc.bpc_index = 0) /\ pc.bpc_label IN {l | IS_BL_Address l}))` >- (
+  FULL_SIMP_TAC std_ss [bir_pc_cond_impl_def] >>
+  REPEAT STRIP_TAC >>
+  METIS_TAC [set_of_address_in_all_address_labels_thm]
+) >>
+IMP_RES_TAC bir_exec_steps_GEN_change_cond_Ended_SOME >>
+Q.EXISTS_TAC `n2` >>
+FULL_SIMP_TAC arith_ss [] >>
+METIS_TAC []
+QED
+
+(* Just a version of bir_is_lifted_prog_MULTI_STEP_EXEC phrased in a more handy way *)
+Theorem bir_is_lifted_prog_MULTI_STEP_EXEC_compute:
+  !mu bs bs' ms ml (p:'a bir_program_t) (r:(64, 8, 'b) bir_lifting_machine_rec_t)
+      mms n' lo c_st c_addr_labels.
+    bir_is_lifted_prog r mu mms p ==>
+    bmr_rel r bs ms ==>
+    MEM (BL_Address (Imm64 ml)) (bir_labels_of_program p) ==>
+    (bs.bst_pc = bir_block_pc (BL_Address (Imm64 ml))) ==>
+    EVERY (bmr_ms_mem_contains r ms) mms ==>
+    (bir_exec_to_addr_label_n p bs n' =
+         BER_Ended lo c_st c_addr_labels bs') ==>
+    ~bir_state_is_terminated bs ==>
+    ~bir_state_is_terminated bs' ==>
+    ?ms' li.
+    (FUNPOW_OPT r.bmr_step_fun c_addr_labels ms = SOME ms') /\
+    bmr_ms_mem_unchanged r ms ms' mu /\
+    EVERY (bmr_ms_mem_contains r ms') mms /\
+    (bs'.bst_pc = bir_block_pc (BL_Address li)) /\
+    MEM (BL_Address li) (bir_labels_of_program p) /\
+    bmr_rel r bs' ms'
+Proof
+REPEAT STRIP_TAC >>
+ASSUME_TAC (ISPECL [``r:(64, 8, 'b) bir_lifting_machine_rec_t``, ``mu:64 word_interval_t``,
+                    ``mms:(word64# word8 list) list``,
+                    ``p:'a bir_program_t``] bir_is_lifted_prog_MULTI_STEP_EXEC) >>
+REV_FULL_SIMP_TAC std_ss [] >>
+QSPECL_X_ASSUM ``!n ms bs. _`` [`n'`, `ms`, `bs`] >>
+REV_FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_state_is_terminated_def]
+QED
+
+Theorem bir_inter_exec_notin_end_label_set:
+   !mls p bs l n0 n' n'' lo lo' c_st c_st' bs' bs''.
+    (bir_exec_to_labels {BL_Address (Imm64 ml') | ml' IN mls} p bs =
+       BER_Ended l c_st n0 bs') ==>
+    (bir_exec_to_addr_label_n p bs n'' = BER_Ended lo' c_st' n'' bs'') ==>
+    c_st' < c_st ==>
+    n'' > 0 ==>
+    ~bir_state_is_terminated bs'' ==>
+    bs''.bst_pc.bpc_label NOTIN
+      {BL_Address (Imm64 ml') | ml' IN mls}
+Proof
+REPEAT STRIP_TAC >>
+(* NOTE: The number of taken statement steps is c_st for both the to-label execution
+ * and the to-addr-label-execution. *)
+(* The number of PCs counted (= in mls) at c_st' statement steps must be 0. *)
+subgoal `~bir_state_COUNT_PC (F,
+	  (\pc.
+	       (pc.bpc_index = 0) /\
+	       pc.bpc_label IN {BL_Address (Imm64 ml') | ml' IN mls}))
+	      (bir_exec_infinite_steps_fun p bs c_st')` >- (
+  FULL_SIMP_TAC std_ss [bir_exec_to_labels_def, bir_exec_to_labels_n_def,
+			bir_exec_steps_GEN_SOME_EQ_Ended] >>
+  (* Ergo, at c_st' statement steps, the PC label is not in mls, which follows after
+   * some arithmetic. *)
+  QSPECL_X_ASSUM ``!(n:num). (n < c_st) ==> _`` [`c_st'`] >>
+  REV_FULL_SIMP_TAC std_ss [] >>
+  subgoal `c_st' > 0` >- (
+    METIS_TAC [bir_exec_to_addr_label_n_def, bir_exec_to_labels_n_def,
+	       bir_exec_steps_GEN_SOME_EQ_Ended_Running_steps,
+	       bir_state_is_terminated_def]
+  ) >>
+  FULL_SIMP_TAC std_ss [NUM_LSONE_EQZ, bir_exec_infinite_steps_fun_COUNT_PCs_EQ_0] >>
+  QSPECL_X_ASSUM ``!j. _`` [`PRE c_st'`] >>
+  SUBGOAL_THEN ``SUC (PRE (c_st':num)) = c_st'`` (fn thm => FULL_SIMP_TAC std_ss [thm]) >- (
+    FULL_SIMP_TAC arith_ss []
+  ) >>
+  METIS_TAC [NUM_PRE_LT]
+) >>
+(* So either PC at c_st' statement steps has index 0, or it is not in mls.
+ * But PC has index 0... *)
+subgoal `bs''.bst_pc.bpc_index = 0` >- (
+  METIS_TAC [bir_exec_to_addr_label_n_ended_running, bir_state_is_terminated_def]
+) >>
+(* ... which proves the goal, after some identification of states. *)
+FULL_SIMP_TAC std_ss [bir_state_COUNT_PC_def, bir_exec_to_addr_label_n_def,
+		      bir_exec_to_labels_n_def,
+		      bir_exec_steps_GEN_SOME_EQ_Ended] >>
+REV_FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_state_is_terminated_def]
+QED
+
+val _ = export_theory ();

--- a/src/theory/tools/backlifter/bir_riscv_backlifterScript.sml
+++ b/src/theory/tools/backlifter/bir_riscv_backlifterScript.sml
@@ -29,6 +29,7 @@ open bir_riscv_extrasTheory;
 
 val _ = new_theory "bir_riscv_backlifter";
 
+(* FIXME: procID must never change *)
 Definition riscv_weak_trs_def:
  riscv_weak_trs ls ms ms' = 
   ?n.
@@ -108,207 +109,343 @@ FULL_SIMP_TAC std_ss [bir_expTheory.bir_eval_load_FULL_REWRS, riscv_mem_load_dwo
 FULL_SIMP_TAC (srw_ss()) []
 QED
 
-(*
-val bool2w_and =
-  prove(``!a b. ((bool2w a) && (bool2w b)) = (bool2w (a /\ b))``,
-
+Theorem bool2w_and[local]:
+ !a b. ((bool2w a) && (bool2w b)) = (bool2w (a /\ b))
+Proof
 REPEAT STRIP_TAC >>
 FULL_SIMP_TAC std_ss [bool2w_def] >>
 Cases_on `a` >>
 Cases_on `b` >>
 EVAL_TAC
-);
+QED
 
+Theorem imm_eq_to_val_eq[local]:
+ !a b . ((BVal_Imm(Imm1 a)) = (BVal_Imm(Imm1 b))) = (a = b)
+Proof
+REPEAT STRIP_TAC >> EVAL_TAC
+QED
 
-val imm_eq_to_val_eq =
-  prove(``!a b . ((BVal_Imm(Imm1 a)) = (BVal_Imm(Imm1 b))) = (a = b)``,
+(* TODO: handle floating-point registers *)
+Definition riscv_vars_def:
+ riscv_vars = {
+  (BVar "x0" (BType_Imm Bit64));
+  (BVar "tmp_x0" (BType_Imm Bit64));
+  (BVar "x1" (BType_Imm Bit64));
+  (BVar "tmp_x1" (BType_Imm Bit64));
+  (BVar "x2" (BType_Imm Bit64));
+  (BVar "tmp_x2" (BType_Imm Bit64));
+  (BVar "x3" (BType_Imm Bit64));
+  (BVar "tmp_x3" (BType_Imm Bit64));
+  (BVar "x4" (BType_Imm Bit64));
+  (BVar "tmp_x4" (BType_Imm Bit64));
+  (BVar "x5" (BType_Imm Bit64));
+  (BVar "tmp_x5" (BType_Imm Bit64));
+  (BVar "x6" (BType_Imm Bit64));
+  (BVar "tmp_x6" (BType_Imm Bit64));
+  (BVar "x7" (BType_Imm Bit64));
+  (BVar "tmp_x7" (BType_Imm Bit64));
+  (BVar "x8" (BType_Imm Bit64));
+  (BVar "tmp_x8" (BType_Imm Bit64));
+  (BVar "x9" (BType_Imm Bit64));
+  (BVar "tmp_x9" (BType_Imm Bit64));
+  (BVar "x10" (BType_Imm Bit64));
+  (BVar "tmp_x10" (BType_Imm Bit64));
+  (BVar "x11" (BType_Imm Bit64));
+  (BVar "tmp_x11" (BType_Imm Bit64));
+  (BVar "x12" (BType_Imm Bit64));
+  (BVar "tmp_x12" (BType_Imm Bit64));
+  (BVar "x13" (BType_Imm Bit64));
+  (BVar "tmp_x13" (BType_Imm Bit64));
+  (BVar "x14" (BType_Imm Bit64));
+  (BVar "tmp_x14" (BType_Imm Bit64));
+  (BVar "x15" (BType_Imm Bit64));
+  (BVar "tmp_x15" (BType_Imm Bit64));
+  (BVar "x16" (BType_Imm Bit64));
+  (BVar "tmp_x16" (BType_Imm Bit64));
+  (BVar "x17" (BType_Imm Bit64));
+  (BVar "tmp_x17" (BType_Imm Bit64));
+  (BVar "x18" (BType_Imm Bit64));
+  (BVar "tmp_x18" (BType_Imm Bit64));
+  (BVar "x19" (BType_Imm Bit64));
+  (BVar "tmp_x19" (BType_Imm Bit64));
+  (BVar "x20" (BType_Imm Bit64));
+  (BVar "tmp_x20" (BType_Imm Bit64));
+  (BVar "x21" (BType_Imm Bit64));
+  (BVar "tmp_x21" (BType_Imm Bit64));
+  (BVar "x22" (BType_Imm Bit64));
+  (BVar "tmp_x22" (BType_Imm Bit64));
+  (BVar "x23" (BType_Imm Bit64));
+  (BVar "tmp_x23" (BType_Imm Bit64));
+  (BVar "x24" (BType_Imm Bit64));
+  (BVar "tmp_x24" (BType_Imm Bit64));
+  (BVar "x25" (BType_Imm Bit64));
+  (BVar "tmp_x25" (BType_Imm Bit64));
+  (BVar "x26" (BType_Imm Bit64));
+  (BVar "tmp_x26" (BType_Imm Bit64));
+  (BVar "x27" (BType_Imm Bit64));
+  (BVar "tmp_x27" (BType_Imm Bit64));
+  (BVar "x28" (BType_Imm Bit64));
+  (BVar "tmp_x28" (BType_Imm Bit64));
+  (BVar "x29" (BType_Imm Bit64));
+  (BVar "tmp_x29" (BType_Imm Bit64));
+  (BVar "x30" (BType_Imm Bit64));
+  (BVar "tmp_x30" (BType_Imm Bit64));
+  (BVar "x31" (BType_Imm Bit64));
+  (BVar "tmp_x31" (BType_Imm Bit64));
 
-REPEAT STRIP_TAC >> EVAL_TAC);
+  (BVar "f0" (BType_Imm Bit64));
+  (BVar "tmp_f0" (BType_Imm Bit64));
+  (BVar "f1" (BType_Imm Bit64));
+  (BVar "tmp_f1" (BType_Imm Bit64));
+  (BVar "f2" (BType_Imm Bit64));
+  (BVar "tmp_f2" (BType_Imm Bit64));
+  (BVar "f3" (BType_Imm Bit64));
+  (BVar "tmp_f3" (BType_Imm Bit64));
+  (BVar "f4" (BType_Imm Bit64));
+  (BVar "tmp_f4" (BType_Imm Bit64));
+  (BVar "f5" (BType_Imm Bit64));
+  (BVar "tmp_f5" (BType_Imm Bit64));
+  (BVar "f6" (BType_Imm Bit64));
+  (BVar "tmp_f6" (BType_Imm Bit64));
+  (BVar "f7" (BType_Imm Bit64));
+  (BVar "tmp_f7" (BType_Imm Bit64));
+  (BVar "f8" (BType_Imm Bit64));
+  (BVar "tmp_f8" (BType_Imm Bit64));
+  (BVar "f9" (BType_Imm Bit64));
+  (BVar "tmp_f9" (BType_Imm Bit64));
+  (BVar "f10" (BType_Imm Bit64));
+  (BVar "tmp_f10" (BType_Imm Bit64));
+  (BVar "f11" (BType_Imm Bit64));
+  (BVar "tmp_f11" (BType_Imm Bit64));
+  (BVar "f12" (BType_Imm Bit64));
+  (BVar "tmp_f12" (BType_Imm Bit64));
+  (BVar "f13" (BType_Imm Bit64));
+  (BVar "tmp_f13" (BType_Imm Bit64));
+  (BVar "f14" (BType_Imm Bit64));
+  (BVar "tmp_f14" (BType_Imm Bit64));
+  (BVar "f15" (BType_Imm Bit64));
+  (BVar "tmp_f15" (BType_Imm Bit64));
+  (BVar "f16" (BType_Imm Bit64));
+  (BVar "tmp_f16" (BType_Imm Bit64));
+  (BVar "f17" (BType_Imm Bit64));
+  (BVar "tmp_f17" (BType_Imm Bit64));
+  (BVar "f18" (BType_Imm Bit64));
+  (BVar "tmp_f18" (BType_Imm Bit64));
+  (BVar "f19" (BType_Imm Bit64));
+  (BVar "tmp_f19" (BType_Imm Bit64));
+  (BVar "f20" (BType_Imm Bit64));
+  (BVar "tmp_f20" (BType_Imm Bit64));
+  (BVar "f21" (BType_Imm Bit64));
+  (BVar "tmp_f21" (BType_Imm Bit64));
+  (BVar "f22" (BType_Imm Bit64));
+  (BVar "tmp_f22" (BType_Imm Bit64));
+  (BVar "f23" (BType_Imm Bit64));
+  (BVar "tmp_f23" (BType_Imm Bit64));
+  (BVar "f24" (BType_Imm Bit64));
+  (BVar "tmp_f24" (BType_Imm Bit64));
+  (BVar "f25" (BType_Imm Bit64));
+  (BVar "tmp_f25" (BType_Imm Bit64));
+  (BVar "f26" (BType_Imm Bit64));
+  (BVar "tmp_f26" (BType_Imm Bit64));
+  (BVar "f27" (BType_Imm Bit64));
+  (BVar "tmp_f27" (BType_Imm Bit64));
+  (BVar "f28" (BType_Imm Bit64));
+  (BVar "tmp_f28" (BType_Imm Bit64));
+  (BVar "f29" (BType_Imm Bit64));
+  (BVar "tmp_f29" (BType_Imm Bit64));
+  (BVar "f30" (BType_Imm Bit64));
+  (BVar "tmp_f30" (BType_Imm Bit64));
+  (BVar "f31" (BType_Imm Bit64));
+  (BVar "tmp_f31" (BType_Imm Bit64));
 
-val arm8_vars_def = Define `
-  arm8_vars= {
-    (BVar "ProcState_C" (BType_Imm Bit1));
-    (BVar "tmp_ProcState_C" (BType_Imm Bit1));
-    (BVar "ProcState_N" (BType_Imm Bit1));
-    (BVar "tmp_ProcState_N" (BType_Imm Bit1));
-    (BVar "ProcState_V" (BType_Imm Bit1));
-    (BVar "tmp_ProcState_V" (BType_Imm Bit1));
-    (BVar "ProcState_Z" (BType_Imm Bit1));
-    (BVar "tmp_ProcState_Z" (BType_Imm Bit1));
-    (BVar "R0" (BType_Imm Bit64));
-    (BVar "tmp_R0" (BType_Imm Bit64));
-    (BVar "R1" (BType_Imm Bit64));
-    (BVar "tmp_R1" (BType_Imm Bit64));
-    (BVar "R2" (BType_Imm Bit64));
-    (BVar "tmp_R2" (BType_Imm Bit64));
-    (BVar "R3" (BType_Imm Bit64));
-    (BVar "tmp_R3" (BType_Imm Bit64));
-    (BVar "R4" (BType_Imm Bit64));
-    (BVar "tmp_R4" (BType_Imm Bit64));
-    (BVar "R5" (BType_Imm Bit64));
-    (BVar "tmp_R5" (BType_Imm Bit64));
-    (BVar "R6" (BType_Imm Bit64));
-    (BVar "tmp_R6" (BType_Imm Bit64));
-    (BVar "R7" (BType_Imm Bit64));
-    (BVar "tmp_R7" (BType_Imm Bit64));
-    (BVar "R8" (BType_Imm Bit64));
-    (BVar "tmp_R8" (BType_Imm Bit64));
-    (BVar "R9" (BType_Imm Bit64));
-    (BVar "tmp_R9" (BType_Imm Bit64));
-    (BVar "R10" (BType_Imm Bit64));
-    (BVar "tmp_R10" (BType_Imm Bit64));
-    (BVar "R11" (BType_Imm Bit64));
-    (BVar "tmp_R11" (BType_Imm Bit64));
-    (BVar "R12" (BType_Imm Bit64));
-    (BVar "tmp_R12" (BType_Imm Bit64));
-    (BVar "R13" (BType_Imm Bit64));
-    (BVar "tmp_R13" (BType_Imm Bit64));
-    (BVar "R14" (BType_Imm Bit64));
-    (BVar "tmp_R14" (BType_Imm Bit64));
-    (BVar "R15" (BType_Imm Bit64));
-    (BVar "tmp_R15" (BType_Imm Bit64));
-    (BVar "R16" (BType_Imm Bit64));
-    (BVar "tmp_R16" (BType_Imm Bit64));
-    (BVar "R17" (BType_Imm Bit64));
-    (BVar "tmp_R17" (BType_Imm Bit64));
-    (BVar "R18" (BType_Imm Bit64));
-    (BVar "tmp_R18" (BType_Imm Bit64));
-    (BVar "R19" (BType_Imm Bit64));
-    (BVar "tmp_R19" (BType_Imm Bit64));
-    (BVar "R20" (BType_Imm Bit64));
-    (BVar "tmp_R20" (BType_Imm Bit64));
-    (BVar "R21" (BType_Imm Bit64));
-    (BVar "tmp_R21" (BType_Imm Bit64));
-    (BVar "R22" (BType_Imm Bit64));
-    (BVar "tmp_R22" (BType_Imm Bit64));
-    (BVar "R23" (BType_Imm Bit64));
-    (BVar "tmp_R23" (BType_Imm Bit64));
-    (BVar "R24" (BType_Imm Bit64));
-    (BVar "tmp_R24" (BType_Imm Bit64));
-    (BVar "R25" (BType_Imm Bit64));
-    (BVar "tmp_R25" (BType_Imm Bit64));
-    (BVar "R26" (BType_Imm Bit64));
-    (BVar "tmp_R26" (BType_Imm Bit64));
-    (BVar "R27" (BType_Imm Bit64));
-    (BVar "tmp_R27" (BType_Imm Bit64));
-    (BVar "R28" (BType_Imm Bit64));
-    (BVar "tmp_R28" (BType_Imm Bit64));
-    (BVar "R29" (BType_Imm Bit64));
-    (BVar "tmp_R29" (BType_Imm Bit64));
-    (BVar "R30" (BType_Imm Bit64));
-    (BVar "tmp_R30" (BType_Imm Bit64));
-    (BVar "R31" (BType_Imm Bit64));
-    (BVar "tmp_R31" (BType_Imm Bit64));
-    (BVar "SP_EL0" (BType_Imm Bit64));
-    (BVar "tmp_SP_EL0" (BType_Imm Bit64));
-    (BVar "SP_EL1" (BType_Imm Bit64));
-    (BVar "tmp_SP_EL1" (BType_Imm Bit64));
-    (BVar "SP_EL2" (BType_Imm Bit64));
-    (BVar "tmp_SP_EL2" (BType_Imm Bit64));
-    (BVar "SP_EL3" (BType_Imm Bit64));
-    (BVar "tmp_SP_EL3" (BType_Imm Bit64));
-    (BVar "MEM" (BType_Mem Bit64 Bit8));
-    (BVar "tmp_MEM" (BType_Mem Bit64 Bit8));
-    (BVar "tmp_PC" (BType_Imm Bit64));
-    (BVar "tmp_COND" (BType_Imm Bit1))
-  }
-`;
+  (BVar "MEM8" (BType_Mem Bit64 Bit8));
+  (BVar "tmp_MEM8" (BType_Mem Bit64 Bit8));
 
-val arm8_wf_varset_def = Define `
-  arm8_wf_varset vset = (vset SUBSET arm8_vars)`;
+  (BVar "tmp_PC" (BType_Imm Bit64));
+  (BVar "tmp_COND" (BType_Imm Bit1))
+ }
+End
 
-val default_arm8_bir_state_def = Define `default_arm8_bir_state ms =
- <|bst_pc :=  bir_block_pc (BL_Address (Imm64 ms.PC)); 
- bst_environ := BEnv (
- ("ProcState_C" =+ SOME(BVal_Imm (bool2b ms.PSTATE.C)))
- (("tmp_ProcState_C" =+ SOME(BVal_Imm (bool2b ms.PSTATE.C)))
- (("ProcState_N" =+ SOME(BVal_Imm (bool2b ms.PSTATE.N)))
- (("tmp_ProcState_N" =+ SOME(BVal_Imm (bool2b ms.PSTATE.N)))
- (("ProcState_V" =+ SOME(BVal_Imm (bool2b ms.PSTATE.V)))
- (("tmp_ProcState_V" =+ SOME(BVal_Imm (bool2b ms.PSTATE.V)))
- (("ProcState_Z" =+ SOME(BVal_Imm (bool2b ms.PSTATE.Z)))
- (("tmp_ProcState_Z" =+ SOME(BVal_Imm (bool2b ms.PSTATE.Z)))
- (("R0" =+ SOME(BVal_Imm (Imm64 (ms.REG 0w))))
- (("tmp_R0" =+ SOME(BVal_Imm (Imm64 (ms.REG 0w))))
- (("R1" =+ SOME(BVal_Imm (Imm64 (ms.REG 1w))))
- (("tmp_R1" =+ SOME(BVal_Imm (Imm64 (ms.REG 1w))))
- (("R2" =+ SOME(BVal_Imm (Imm64 (ms.REG 2w))))
- (("tmp_R2" =+ SOME(BVal_Imm (Imm64 (ms.REG 2w))))
- (("R3" =+ SOME(BVal_Imm (Imm64 (ms.REG 3w))))
- (("tmp_R3" =+ SOME(BVal_Imm (Imm64 (ms.REG 3w))))
- (("R4" =+ SOME(BVal_Imm (Imm64 (ms.REG 4w))))
- (("tmp_R4" =+ SOME(BVal_Imm (Imm64 (ms.REG 4w))))
- (("R5" =+ SOME(BVal_Imm (Imm64 (ms.REG 5w))))
- (("tmp_R5" =+ SOME(BVal_Imm (Imm64 (ms.REG 5w))))
- (("R6" =+ SOME(BVal_Imm (Imm64 (ms.REG 6w))))
- (("tmp_R6" =+ SOME(BVal_Imm (Imm64 (ms.REG 6w))))
- (("R7" =+ SOME(BVal_Imm (Imm64 (ms.REG 7w))))
- (("tmp_R7" =+ SOME(BVal_Imm (Imm64 (ms.REG 7w))))
- (("R8" =+ SOME(BVal_Imm (Imm64 (ms.REG 8w))))
- (("tmp_R8" =+ SOME(BVal_Imm (Imm64 (ms.REG 8w))))
- (("R9" =+ SOME(BVal_Imm (Imm64 (ms.REG 9w))))
- (("tmp_R9" =+ SOME(BVal_Imm (Imm64 (ms.REG 9w))))
- (("R10" =+ SOME(BVal_Imm (Imm64 (ms.REG 10w))))
- (("tmp_R10" =+ SOME(BVal_Imm (Imm64 (ms.REG 10w))))
- (("R11" =+ SOME(BVal_Imm (Imm64 (ms.REG 11w))))
- (("tmp_R11" =+ SOME(BVal_Imm (Imm64 (ms.REG 11w))))
- (("R12" =+ SOME(BVal_Imm (Imm64 (ms.REG 12w))))
- (("tmp_R12" =+ SOME(BVal_Imm (Imm64 (ms.REG 12w))))
- (("R13" =+ SOME(BVal_Imm (Imm64 (ms.REG 13w))))
- (("tmp_R13" =+ SOME(BVal_Imm (Imm64 (ms.REG 13w))))
- (("R14" =+ SOME(BVal_Imm (Imm64 (ms.REG 14w))))
- (("tmp_R14" =+ SOME(BVal_Imm (Imm64 (ms.REG 14w))))
- (("R15" =+ SOME(BVal_Imm (Imm64 (ms.REG 15w))))
- (("tmp_R15" =+ SOME(BVal_Imm (Imm64 (ms.REG 15w))))
- (("R16" =+ SOME(BVal_Imm (Imm64 (ms.REG 16w))))
- (("tmp_R16" =+ SOME(BVal_Imm (Imm64 (ms.REG 16w))))
- (("R17" =+ SOME(BVal_Imm (Imm64 (ms.REG 17w))))
- (("tmp_R17" =+ SOME(BVal_Imm (Imm64 (ms.REG 17w))))
- (("R18" =+ SOME(BVal_Imm (Imm64 (ms.REG 18w))))
- (("tmp_R18" =+ SOME(BVal_Imm (Imm64 (ms.REG 18w))))
- (("R19" =+ SOME(BVal_Imm (Imm64 (ms.REG 19w))))
- (("tmp_R19" =+ SOME(BVal_Imm (Imm64 (ms.REG 19w))))
- (("R20" =+ SOME(BVal_Imm (Imm64 (ms.REG 20w))))
- (("tmp_R20" =+ SOME(BVal_Imm (Imm64 (ms.REG 20w))))
- (("R21" =+ SOME(BVal_Imm (Imm64 (ms.REG 21w))))
- (("tmp_R21" =+ SOME(BVal_Imm (Imm64 (ms.REG 21w))))
- (("R22" =+ SOME(BVal_Imm (Imm64 (ms.REG 22w))))
- (("tmp_R22" =+ SOME(BVal_Imm (Imm64 (ms.REG 22w))))
- (("R23" =+ SOME(BVal_Imm (Imm64 (ms.REG 23w))))
- (("tmp_R23" =+ SOME(BVal_Imm (Imm64 (ms.REG 23w))))
- (("R24" =+ SOME(BVal_Imm (Imm64 (ms.REG 24w))))
- (("tmp_R24" =+ SOME(BVal_Imm (Imm64 (ms.REG 24w))))
- (("R25" =+ SOME(BVal_Imm (Imm64 (ms.REG 25w))))
- (("tmp_R25" =+ SOME(BVal_Imm (Imm64 (ms.REG 25w))))
- (("R26" =+ SOME(BVal_Imm (Imm64 (ms.REG 26w))))
- (("tmp_R26" =+ SOME(BVal_Imm (Imm64 (ms.REG 26w))))
- (("R27" =+ SOME(BVal_Imm (Imm64 (ms.REG 27w))))
- (("tmp_R27" =+  SOME(BVal_Imm (Imm64 (ms.REG 27w))))
- (("R28" =+ SOME(BVal_Imm (Imm64 (ms.REG 28w))))
- (("tmp_R28" =+ SOME(BVal_Imm (Imm64 (ms.REG 28w))))
- (("R29" =+ SOME(BVal_Imm (Imm64 (ms.REG 29w))))
- (("tmp_R29" =+ SOME(BVal_Imm (Imm64 (ms.REG 29w))))
- (("R30" =+ SOME(BVal_Imm (Imm64 (ms.REG 30w))))
- (("tmp_R30" =+ SOME(BVal_Imm (Imm64 (ms.REG 30w))))
- (("R31" =+ SOME(BVal_Imm (Imm64 (ms.REG 31w))))
- (("tmp_R31" =+ SOME(BVal_Imm (Imm64 (ms.REG 31w))))
- (("SP_EL0" =+ SOME(BVal_Imm (Imm64 (ms.SP_EL0))))
- (("tmp_SP_EL0" =+ SOME(BVal_Imm (Imm64 (ms.SP_EL0))))
- (("SP_EL1" =+ SOME(BVal_Imm (Imm64 (ms.SP_EL1))))
- (("tmp_SP_EL1" =+ SOME(BVal_Imm (Imm64 (ms.SP_EL1))))
- (("SP_EL2" =+ SOME(BVal_Imm (Imm64 (ms.SP_EL2))))
- (("tmp_SP_EL2" =+ SOME(BVal_Imm (Imm64 (ms.SP_EL2))))
- (("SP_EL3" =+ SOME(BVal_Imm (Imm64 (ms.SP_EL3))))
- (("tmp_SP_EL3" =+ SOME(BVal_Imm (Imm64 (ms.SP_EL3))))
- (("tmp_PC" =+ SOME(BVal_Imm (Imm64 (ms.PC))))
- (("MEM" =+ SOME(BVal_Mem Bit64 Bit8 (bir_mmap_w_w2n (bir_mf2mm ms.MEM))))
- (("tmp_MEM" =+ SOME(BVal_Mem Bit64 Bit8 (bir_mmap_w_w2n (bir_mf2mm ms.MEM))))
- (* 83 parantheses!!! *)
- (("tmp_COND" =+ SOME(BVal_Imm (Imm1 0w))) bir_env_map_empty)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
- );
-  bst_status := BST_Running|>
-`;
+Definition riscv_wf_varset_def:
+ riscv_wf_varset vset = (vset SUBSET riscv_vars)
+End
 
+Definition default_riscv_bir_state_def:
+ default_riscv_bir_state ms =
+  <| bst_pc := bir_block_pc (BL_Address (Imm64 (ms.c_PC ms.procID))) ;
+     bst_environ := BEnv (
+       ("x0"        =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 0w))))
+       (("tmp_x0"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 0w))))
+       (("x1"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 1w))))
+       (("tmp_x1"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 1w))))
+       (("x2"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 2w))))
+       (("tmp_x2"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 2w))))
+       (("x3"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 3w))))
+       (("tmp_x3"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 3w))))
+       (("x4"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 4w))))
+       (("tmp_x4"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 4w))))
+       (("x5"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 5w))))
+       (("tmp_x5"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 5w))))
+       (("x6"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 6w))))
+       (("tmp_x6"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 6w))))
+       (("x7"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 7w))))
+       (("tmp_x7"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 7w))))
+       (("x8"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 8w))))
+       (("tmp_x8"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 8w))))
+       (("x9"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 9w))))
+       (("tmp_x9"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 9w))))
+       (("x10"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 10w))))
+       (("tmp_x10"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 10w))))
+       (("x11"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 11w))))
+       (("tmp_x11"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 11w))))
+       (("x12"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 12w))))
+       (("tmp_x12"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 12w))))
+       (("x13"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 13w))))
+       (("tmp_x13"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 13w))))
+       (("x14"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 14w))))
+       (("tmp_x14"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 14w))))
+       (("x15"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 15w))))
+       (("tmp_x15"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 15w))))
+       (("x16"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 16w))))
+       (("tmp_x16"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 16w))))
+       (("x17"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 17w))))
+       (("tmp_x17"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 17w))))
+       (("x18"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 18w))))
+       (("tmp_x18"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 18w))))
+       (("x19"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 19w))))
+       (("tmp_x19"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 19w))))
+       (("x20"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 20w))))
+       (("tmp_x20"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 20w))))
+       (("x21"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 21w))))
+       (("tmp_x21"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 21w))))
+       (("x22"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 22w))))
+       (("tmp_x22"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 22w))))
+       (("x23"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 23w))))
+       (("tmp_x23"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 23w))))
+       (("x24"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 24w))))
+       (("tmp_x24"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 24w))))
+       (("x25"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 25w))))
+       (("tmp_x25"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 25w))))
+       (("x26"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 26w))))
+       (("tmp_x26"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 26w))))
+       (("x27"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 27w))))
+       (("tmp_x27"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 27w))))
+       (("x28"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 28w))))
+       (("tmp_x28"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 28w))))
+       (("x29"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 29w))))
+       (("tmp_x29"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 29w))))
+       (("x30"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 30w))))
+       (("tmp_x30"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 30w))))
+       (("x31"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 31w))))
+       (("tmp_x31"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 31w))))
+
+       (("f0"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 0w))))
+       (("tmp_f0"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 0w))))
+       (("f1"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 1w))))
+       (("tmp_f1"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 1w))))
+       (("f2"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 2w))))
+       (("tmp_f2"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 2w))))
+       (("f3"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 3w))))
+       (("tmp_f3"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 3w))))
+       (("f4"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 4w))))
+       (("tmp_f4"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 4w))))
+       (("f5"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 5w))))
+       (("tmp_f5"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 5w))))
+       (("f6"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 6w))))
+       (("tmp_f6"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 6w))))
+       (("f7"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 7w))))
+       (("tmp_f7"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 7w))))
+       (("f8"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 8w))))
+       (("tmp_f8"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 8w))))
+       (("f9"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 9w))))
+       (("tmp_f9"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 9w))))
+       (("f10"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 10w))))
+       (("tmp_f10"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 10w))))
+       (("f11"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 11w))))
+       (("tmp_f11"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 11w))))
+       (("f12"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 12w))))
+       (("tmp_f12"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 12w))))
+       (("f13"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 13w))))
+       (("tmp_f13"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 13w))))
+       (("f14"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 14w))))
+       (("tmp_x14"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 14w))))
+       (("f15"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 15w))))
+       (("tmp_f15"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 15w))))
+       (("f16"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 16w))))
+       (("tmp_f16"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 16w))))
+       (("f17"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 17w))))
+       (("tmp_f17"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 17w))))
+       (("f18"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 18w))))
+       (("tmp_f18"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 18w))))
+       (("f19"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 19w))))
+       (("tmp_f19"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 19w))))
+       (("f20"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 20w))))
+       (("tmp_f20"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 20w))))
+       (("f21"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 21w))))
+       (("tmp_f21"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 21w))))
+       (("f22"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 22w))))
+       (("tmp_f22"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 22w))))
+       (("f23"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 23w))))
+       (("tmp_f23"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 23w))))
+       (("f24"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 24w))))
+       (("tmp_f24"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 24w))))
+       (("f25"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 25w))))
+       (("tmp_f25"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 25w))))
+       (("f26"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 26w))))
+       (("tmp_f26"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 26w))))
+       (("f27"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 27w))))
+       (("tmp_f27"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 27w))))
+       (("f28"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 28w))))
+       (("tmp_f28"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 28w))))
+       (("f29"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 29w))))
+       (("tmp_f29"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 29w))))
+       (("f30"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 30w))))
+       (("tmp_f30"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 30w))))
+       (("f31"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 31w))))
+       (("tmp_f31"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 31w))))
+
+       (("MEM8"     =+ SOME (BVal_Mem Bit64 Bit8 (bir_mmap_w_w2n (bir_mf2mm ms.MEM8))))
+       (("tmp_MEM8" =+ SOME (BVal_Mem Bit64 Bit8 (bir_mmap_w_w2n (bir_mf2mm ms.MEM8))))
+
+       (("tmp_PC"   =+ SOME (BVal_Imm (Imm64 (ms.c_PC ms.procID))))
+       (("tmp_COND" =+ SOME(BVal_Imm (Imm1 0w))) bir_env_map_empty))))
+        ))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+        )))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+     );
+     bst_status := BST_Running
+   |>
+End
+
+(*
+
+Theorem default_riscv_bir_state_satisfies_rel_thm[local]:
+ !ms. riscv_bmr.bmr_extra ms ==>
+   bmr_rel riscv_bmr (default_riscv_bir_state ms) ms
+Proof
+FULL_SIMP_TAC std_ss [default_riscv_bir_state_def,
+  bir_lifting_machinesTheory.riscv_bmr_rel_EVAL,
+  bir_env_oldTheory.bir_env_var_is_declared_def,
+  bir_envTheory.bir_var_name_def] >>
+FULL_SIMP_TAC (srw_ss()) [
+              bir_envTheory.bir_env_read_UPDATE,
+              bir_envTheory.bir_var_name_def,
+              bir_envTheory.bir_env_lookup_UPDATE,
+              bir_envTheory.bir_var_type_def,
+              bir_envTheory.bir_env_lookup_type_def] >>
+FULL_SIMP_TAC std_ss [bir_valuesTheory.type_of_bir_val_def,
+                      type_of_bir_imm_def,
+                      bir_immTheory.type_of_bool2b] >>
+FULL_SIMP_TAC std_ss [bir_lifting_machinesTheory.bmr_extra_RISCV] >>
+FULL_SIMP_TAC (srw_ss()) [bir_exp_liftingTheory.bir_load_w2n_mf_simp_thm] >>
+METIS_TAC []
+QED
+
+bir_env_read (BVar "f28" (BType_Imm Bit64)) (default_riscv_bir_state ms) =
+SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 28w)))
+
+*)
+
+(*
 
 val default_arm8_bir_state_satisfies_rel_thm = prove(
   ``!ms.

--- a/src/theory/tools/backlifter/bir_riscv_backlifterScript.sml
+++ b/src/theory/tools/backlifter/bir_riscv_backlifterScript.sml
@@ -1,0 +1,743 @@
+open HolKernel Parse boolLib bossLib;
+
+(* FIXME: avoid quse errors *)
+open m0_stepLib;
+
+open bir_immTheory;
+open bir_programTheory;
+open bir_tsTheory;
+open bir_program_multistep_propsTheory;
+open bir_auxiliaryTheory;
+
+(* From lifter: *)
+open bir_inst_liftingTheory;
+open bir_lifting_machinesTheory;
+
+(* From comp: *)
+open total_program_logicTheory;
+open total_ext_program_logicTheory;
+
+open HolBASimps;
+open HolBACoreSimps;
+open program_logicSimps;
+
+open bir_auxiliaryLib;
+
+open m0_mod_stepLib;
+
+open bir_riscv_extrasTheory;
+
+val _ = new_theory "bir_riscv_backlifter";
+
+Definition riscv_weak_trs_def:
+ riscv_weak_trs ls ms ms' = 
+  ?n.
+    ((n > 0) /\
+     (FUNPOW_OPT riscv_bmr.bmr_step_fun n ms = SOME ms') /\
+     ((ms'.c_PC ms'.procID) IN ls))
+    /\
+    !n'. (((n' < n) /\ (n' > 0)) ==>
+          ?ms''.
+            (FUNPOW_OPT riscv_bmr.bmr_step_fun n' ms = SOME ms'') /\
+            (~((ms''.c_PC ms''.procID) IN ls)))
+End
+
+Definition riscv_ts_def:
+ riscv_ts  = <|
+    trs  := riscv_bmr.bmr_step_fun;
+    weak := riscv_weak_trs;
+    ctrl := (\st. (st.c_PC st.procID))
+  |>
+End
+
+(* The main contract to be used for RISC-V composition *)
+(* FIXME: generalize for both arm8 and riscv *)
+Definition riscv_cont_def:
+ riscv_cont mms l ls pre post =
+    t_jgmt riscv_ts l ls
+      (\ms. (riscv_bmr.bmr_extra ms)  /\
+            (EVERY (bmr_ms_mem_contains riscv_bmr ms) mms) /\
+            (pre ms))
+      (\ms. (riscv_bmr.bmr_extra ms)  /\
+            (EVERY (bmr_ms_mem_contains riscv_bmr ms) mms) /\
+            (post ms))
+End
+
+(* FIXME: generalize for both arm8 and riscv *)
+Definition bir_pre_riscv_to_bir_def:
+  bir_pre_riscv_to_bir pre pre_bir = (
+    bir_is_bool_exp pre_bir /\
+    !ms bs.
+    bmr_rel riscv_bmr bs ms ==>
+    bir_env_vars_are_initialised bs.bst_environ (bir_vars_of_exp pre_bir) ==>
+    pre ms ==>
+    (bir_eval_exp pre_bir bs.bst_environ = SOME bir_val_true))
+End
+
+(* FIXME: generalize for both arm8 and riscv *)
+Definition bir_post_bir_to_riscv_def:
+  bir_post_bir_to_riscv post post_bir ls =
+    !ms bs l.
+    l IN ls ==>
+    bmr_rel riscv_bmr bs ms ==>
+    (bir_eval_exp (post_bir l) bs.bst_environ = SOME bir_val_true) ==>
+    post ms
+End
+
+Theorem bload_64_to_riscv_load_64_thm:
+ !bs ms. (bmr_rel riscv_bmr bs ms) ==>
+    (!a.
+       ((bir_eval_load
+         (bir_env_read (BVar "MEM8" (BType_Mem Bit64 Bit8)) bs.bst_environ)
+         (SOME (BVal_Imm (Imm64 a))) BEnd_LittleEndian Bit64) =
+        SOME (BVal_Imm (Imm64 (riscv_mem_load_dword ms.MEM8 a)))))
+Proof
+REPEAT STRIP_TAC >>
+Q.SUBGOAL_THEN
+  `?mem_n.
+   (bir_env_read (BVar "MEM8" (BType_Mem Bit64 Bit8)) bs.bst_environ =
+     (SOME (BVal_Mem Bit64 Bit8 mem_n))) /\
+   (ms.MEM8 = (\a. n2w (bir_load_mmap mem_n (w2n a)))) /\
+   bir_env_var_is_declared bs.bst_environ
+     (BVar "tmp_MEM8" (BType_Mem Bit64 Bit8))` ASSUME_TAC >-(
+  FULL_SIMP_TAC std_ss [bir_lifting_machinesTheory.riscv_bmr_rel_EVAL] >>
+  EXISTS_TAC ``mem_n:num|->num`` >>
+  FULL_SIMP_TAC std_ss []
+) >>
+FULL_SIMP_TAC std_ss [bir_expTheory.bir_eval_load_FULL_REWRS, riscv_mem_load_dword_def] >>
+FULL_SIMP_TAC (srw_ss()) []
+QED
+
+(*
+val bool2w_and =
+  prove(``!a b. ((bool2w a) && (bool2w b)) = (bool2w (a /\ b))``,
+
+REPEAT STRIP_TAC >>
+FULL_SIMP_TAC std_ss [bool2w_def] >>
+Cases_on `a` >>
+Cases_on `b` >>
+EVAL_TAC
+);
+
+
+val imm_eq_to_val_eq =
+  prove(``!a b . ((BVal_Imm(Imm1 a)) = (BVal_Imm(Imm1 b))) = (a = b)``,
+
+REPEAT STRIP_TAC >> EVAL_TAC);
+
+val arm8_vars_def = Define `
+  arm8_vars= {
+    (BVar "ProcState_C" (BType_Imm Bit1));
+    (BVar "tmp_ProcState_C" (BType_Imm Bit1));
+    (BVar "ProcState_N" (BType_Imm Bit1));
+    (BVar "tmp_ProcState_N" (BType_Imm Bit1));
+    (BVar "ProcState_V" (BType_Imm Bit1));
+    (BVar "tmp_ProcState_V" (BType_Imm Bit1));
+    (BVar "ProcState_Z" (BType_Imm Bit1));
+    (BVar "tmp_ProcState_Z" (BType_Imm Bit1));
+    (BVar "R0" (BType_Imm Bit64));
+    (BVar "tmp_R0" (BType_Imm Bit64));
+    (BVar "R1" (BType_Imm Bit64));
+    (BVar "tmp_R1" (BType_Imm Bit64));
+    (BVar "R2" (BType_Imm Bit64));
+    (BVar "tmp_R2" (BType_Imm Bit64));
+    (BVar "R3" (BType_Imm Bit64));
+    (BVar "tmp_R3" (BType_Imm Bit64));
+    (BVar "R4" (BType_Imm Bit64));
+    (BVar "tmp_R4" (BType_Imm Bit64));
+    (BVar "R5" (BType_Imm Bit64));
+    (BVar "tmp_R5" (BType_Imm Bit64));
+    (BVar "R6" (BType_Imm Bit64));
+    (BVar "tmp_R6" (BType_Imm Bit64));
+    (BVar "R7" (BType_Imm Bit64));
+    (BVar "tmp_R7" (BType_Imm Bit64));
+    (BVar "R8" (BType_Imm Bit64));
+    (BVar "tmp_R8" (BType_Imm Bit64));
+    (BVar "R9" (BType_Imm Bit64));
+    (BVar "tmp_R9" (BType_Imm Bit64));
+    (BVar "R10" (BType_Imm Bit64));
+    (BVar "tmp_R10" (BType_Imm Bit64));
+    (BVar "R11" (BType_Imm Bit64));
+    (BVar "tmp_R11" (BType_Imm Bit64));
+    (BVar "R12" (BType_Imm Bit64));
+    (BVar "tmp_R12" (BType_Imm Bit64));
+    (BVar "R13" (BType_Imm Bit64));
+    (BVar "tmp_R13" (BType_Imm Bit64));
+    (BVar "R14" (BType_Imm Bit64));
+    (BVar "tmp_R14" (BType_Imm Bit64));
+    (BVar "R15" (BType_Imm Bit64));
+    (BVar "tmp_R15" (BType_Imm Bit64));
+    (BVar "R16" (BType_Imm Bit64));
+    (BVar "tmp_R16" (BType_Imm Bit64));
+    (BVar "R17" (BType_Imm Bit64));
+    (BVar "tmp_R17" (BType_Imm Bit64));
+    (BVar "R18" (BType_Imm Bit64));
+    (BVar "tmp_R18" (BType_Imm Bit64));
+    (BVar "R19" (BType_Imm Bit64));
+    (BVar "tmp_R19" (BType_Imm Bit64));
+    (BVar "R20" (BType_Imm Bit64));
+    (BVar "tmp_R20" (BType_Imm Bit64));
+    (BVar "R21" (BType_Imm Bit64));
+    (BVar "tmp_R21" (BType_Imm Bit64));
+    (BVar "R22" (BType_Imm Bit64));
+    (BVar "tmp_R22" (BType_Imm Bit64));
+    (BVar "R23" (BType_Imm Bit64));
+    (BVar "tmp_R23" (BType_Imm Bit64));
+    (BVar "R24" (BType_Imm Bit64));
+    (BVar "tmp_R24" (BType_Imm Bit64));
+    (BVar "R25" (BType_Imm Bit64));
+    (BVar "tmp_R25" (BType_Imm Bit64));
+    (BVar "R26" (BType_Imm Bit64));
+    (BVar "tmp_R26" (BType_Imm Bit64));
+    (BVar "R27" (BType_Imm Bit64));
+    (BVar "tmp_R27" (BType_Imm Bit64));
+    (BVar "R28" (BType_Imm Bit64));
+    (BVar "tmp_R28" (BType_Imm Bit64));
+    (BVar "R29" (BType_Imm Bit64));
+    (BVar "tmp_R29" (BType_Imm Bit64));
+    (BVar "R30" (BType_Imm Bit64));
+    (BVar "tmp_R30" (BType_Imm Bit64));
+    (BVar "R31" (BType_Imm Bit64));
+    (BVar "tmp_R31" (BType_Imm Bit64));
+    (BVar "SP_EL0" (BType_Imm Bit64));
+    (BVar "tmp_SP_EL0" (BType_Imm Bit64));
+    (BVar "SP_EL1" (BType_Imm Bit64));
+    (BVar "tmp_SP_EL1" (BType_Imm Bit64));
+    (BVar "SP_EL2" (BType_Imm Bit64));
+    (BVar "tmp_SP_EL2" (BType_Imm Bit64));
+    (BVar "SP_EL3" (BType_Imm Bit64));
+    (BVar "tmp_SP_EL3" (BType_Imm Bit64));
+    (BVar "MEM" (BType_Mem Bit64 Bit8));
+    (BVar "tmp_MEM" (BType_Mem Bit64 Bit8));
+    (BVar "tmp_PC" (BType_Imm Bit64));
+    (BVar "tmp_COND" (BType_Imm Bit1))
+  }
+`;
+
+val arm8_wf_varset_def = Define `
+  arm8_wf_varset vset = (vset SUBSET arm8_vars)`;
+
+val default_arm8_bir_state_def = Define `default_arm8_bir_state ms =
+ <|bst_pc :=  bir_block_pc (BL_Address (Imm64 ms.PC)); 
+ bst_environ := BEnv (
+ ("ProcState_C" =+ SOME(BVal_Imm (bool2b ms.PSTATE.C)))
+ (("tmp_ProcState_C" =+ SOME(BVal_Imm (bool2b ms.PSTATE.C)))
+ (("ProcState_N" =+ SOME(BVal_Imm (bool2b ms.PSTATE.N)))
+ (("tmp_ProcState_N" =+ SOME(BVal_Imm (bool2b ms.PSTATE.N)))
+ (("ProcState_V" =+ SOME(BVal_Imm (bool2b ms.PSTATE.V)))
+ (("tmp_ProcState_V" =+ SOME(BVal_Imm (bool2b ms.PSTATE.V)))
+ (("ProcState_Z" =+ SOME(BVal_Imm (bool2b ms.PSTATE.Z)))
+ (("tmp_ProcState_Z" =+ SOME(BVal_Imm (bool2b ms.PSTATE.Z)))
+ (("R0" =+ SOME(BVal_Imm (Imm64 (ms.REG 0w))))
+ (("tmp_R0" =+ SOME(BVal_Imm (Imm64 (ms.REG 0w))))
+ (("R1" =+ SOME(BVal_Imm (Imm64 (ms.REG 1w))))
+ (("tmp_R1" =+ SOME(BVal_Imm (Imm64 (ms.REG 1w))))
+ (("R2" =+ SOME(BVal_Imm (Imm64 (ms.REG 2w))))
+ (("tmp_R2" =+ SOME(BVal_Imm (Imm64 (ms.REG 2w))))
+ (("R3" =+ SOME(BVal_Imm (Imm64 (ms.REG 3w))))
+ (("tmp_R3" =+ SOME(BVal_Imm (Imm64 (ms.REG 3w))))
+ (("R4" =+ SOME(BVal_Imm (Imm64 (ms.REG 4w))))
+ (("tmp_R4" =+ SOME(BVal_Imm (Imm64 (ms.REG 4w))))
+ (("R5" =+ SOME(BVal_Imm (Imm64 (ms.REG 5w))))
+ (("tmp_R5" =+ SOME(BVal_Imm (Imm64 (ms.REG 5w))))
+ (("R6" =+ SOME(BVal_Imm (Imm64 (ms.REG 6w))))
+ (("tmp_R6" =+ SOME(BVal_Imm (Imm64 (ms.REG 6w))))
+ (("R7" =+ SOME(BVal_Imm (Imm64 (ms.REG 7w))))
+ (("tmp_R7" =+ SOME(BVal_Imm (Imm64 (ms.REG 7w))))
+ (("R8" =+ SOME(BVal_Imm (Imm64 (ms.REG 8w))))
+ (("tmp_R8" =+ SOME(BVal_Imm (Imm64 (ms.REG 8w))))
+ (("R9" =+ SOME(BVal_Imm (Imm64 (ms.REG 9w))))
+ (("tmp_R9" =+ SOME(BVal_Imm (Imm64 (ms.REG 9w))))
+ (("R10" =+ SOME(BVal_Imm (Imm64 (ms.REG 10w))))
+ (("tmp_R10" =+ SOME(BVal_Imm (Imm64 (ms.REG 10w))))
+ (("R11" =+ SOME(BVal_Imm (Imm64 (ms.REG 11w))))
+ (("tmp_R11" =+ SOME(BVal_Imm (Imm64 (ms.REG 11w))))
+ (("R12" =+ SOME(BVal_Imm (Imm64 (ms.REG 12w))))
+ (("tmp_R12" =+ SOME(BVal_Imm (Imm64 (ms.REG 12w))))
+ (("R13" =+ SOME(BVal_Imm (Imm64 (ms.REG 13w))))
+ (("tmp_R13" =+ SOME(BVal_Imm (Imm64 (ms.REG 13w))))
+ (("R14" =+ SOME(BVal_Imm (Imm64 (ms.REG 14w))))
+ (("tmp_R14" =+ SOME(BVal_Imm (Imm64 (ms.REG 14w))))
+ (("R15" =+ SOME(BVal_Imm (Imm64 (ms.REG 15w))))
+ (("tmp_R15" =+ SOME(BVal_Imm (Imm64 (ms.REG 15w))))
+ (("R16" =+ SOME(BVal_Imm (Imm64 (ms.REG 16w))))
+ (("tmp_R16" =+ SOME(BVal_Imm (Imm64 (ms.REG 16w))))
+ (("R17" =+ SOME(BVal_Imm (Imm64 (ms.REG 17w))))
+ (("tmp_R17" =+ SOME(BVal_Imm (Imm64 (ms.REG 17w))))
+ (("R18" =+ SOME(BVal_Imm (Imm64 (ms.REG 18w))))
+ (("tmp_R18" =+ SOME(BVal_Imm (Imm64 (ms.REG 18w))))
+ (("R19" =+ SOME(BVal_Imm (Imm64 (ms.REG 19w))))
+ (("tmp_R19" =+ SOME(BVal_Imm (Imm64 (ms.REG 19w))))
+ (("R20" =+ SOME(BVal_Imm (Imm64 (ms.REG 20w))))
+ (("tmp_R20" =+ SOME(BVal_Imm (Imm64 (ms.REG 20w))))
+ (("R21" =+ SOME(BVal_Imm (Imm64 (ms.REG 21w))))
+ (("tmp_R21" =+ SOME(BVal_Imm (Imm64 (ms.REG 21w))))
+ (("R22" =+ SOME(BVal_Imm (Imm64 (ms.REG 22w))))
+ (("tmp_R22" =+ SOME(BVal_Imm (Imm64 (ms.REG 22w))))
+ (("R23" =+ SOME(BVal_Imm (Imm64 (ms.REG 23w))))
+ (("tmp_R23" =+ SOME(BVal_Imm (Imm64 (ms.REG 23w))))
+ (("R24" =+ SOME(BVal_Imm (Imm64 (ms.REG 24w))))
+ (("tmp_R24" =+ SOME(BVal_Imm (Imm64 (ms.REG 24w))))
+ (("R25" =+ SOME(BVal_Imm (Imm64 (ms.REG 25w))))
+ (("tmp_R25" =+ SOME(BVal_Imm (Imm64 (ms.REG 25w))))
+ (("R26" =+ SOME(BVal_Imm (Imm64 (ms.REG 26w))))
+ (("tmp_R26" =+ SOME(BVal_Imm (Imm64 (ms.REG 26w))))
+ (("R27" =+ SOME(BVal_Imm (Imm64 (ms.REG 27w))))
+ (("tmp_R27" =+  SOME(BVal_Imm (Imm64 (ms.REG 27w))))
+ (("R28" =+ SOME(BVal_Imm (Imm64 (ms.REG 28w))))
+ (("tmp_R28" =+ SOME(BVal_Imm (Imm64 (ms.REG 28w))))
+ (("R29" =+ SOME(BVal_Imm (Imm64 (ms.REG 29w))))
+ (("tmp_R29" =+ SOME(BVal_Imm (Imm64 (ms.REG 29w))))
+ (("R30" =+ SOME(BVal_Imm (Imm64 (ms.REG 30w))))
+ (("tmp_R30" =+ SOME(BVal_Imm (Imm64 (ms.REG 30w))))
+ (("R31" =+ SOME(BVal_Imm (Imm64 (ms.REG 31w))))
+ (("tmp_R31" =+ SOME(BVal_Imm (Imm64 (ms.REG 31w))))
+ (("SP_EL0" =+ SOME(BVal_Imm (Imm64 (ms.SP_EL0))))
+ (("tmp_SP_EL0" =+ SOME(BVal_Imm (Imm64 (ms.SP_EL0))))
+ (("SP_EL1" =+ SOME(BVal_Imm (Imm64 (ms.SP_EL1))))
+ (("tmp_SP_EL1" =+ SOME(BVal_Imm (Imm64 (ms.SP_EL1))))
+ (("SP_EL2" =+ SOME(BVal_Imm (Imm64 (ms.SP_EL2))))
+ (("tmp_SP_EL2" =+ SOME(BVal_Imm (Imm64 (ms.SP_EL2))))
+ (("SP_EL3" =+ SOME(BVal_Imm (Imm64 (ms.SP_EL3))))
+ (("tmp_SP_EL3" =+ SOME(BVal_Imm (Imm64 (ms.SP_EL3))))
+ (("tmp_PC" =+ SOME(BVal_Imm (Imm64 (ms.PC))))
+ (("MEM" =+ SOME(BVal_Mem Bit64 Bit8 (bir_mmap_w_w2n (bir_mf2mm ms.MEM))))
+ (("tmp_MEM" =+ SOME(BVal_Mem Bit64 Bit8 (bir_mmap_w_w2n (bir_mf2mm ms.MEM))))
+ (* 83 parantheses!!! *)
+ (("tmp_COND" =+ SOME(BVal_Imm (Imm1 0w))) bir_env_map_empty)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+ );
+  bst_status := BST_Running|>
+`;
+
+
+val default_arm8_bir_state_satisfies_rel_thm = prove(
+  ``!ms.
+    arm8_bmr.bmr_extra ms ==>
+    bmr_rel arm8_bmr (default_arm8_bir_state ms) ms``,
+
+REPEAT STRIP_TAC >>
+FULL_SIMP_TAC std_ss [default_arm8_bir_state_def,
+  bir_lifting_machinesTheory.arm8_bmr_rel_EVAL,
+  bir_env_oldTheory.bir_env_var_is_declared_def,
+  bir_envTheory.bir_var_name_def] >>
+FULL_SIMP_TAC (srw_ss()) [
+              bir_envTheory.bir_env_read_UPDATE,
+              bir_envTheory.bir_var_name_def,
+              bir_envTheory.bir_env_lookup_UPDATE,
+              bir_envTheory.bir_var_type_def,
+              bir_envTheory.bir_env_lookup_type_def] >>
+FULL_SIMP_TAC std_ss [bir_valuesTheory.type_of_bir_val_def,
+                      type_of_bir_imm_def,
+                      bir_immTheory.type_of_bool2b] >>
+FULL_SIMP_TAC std_ss [bir_lifting_machinesTheory.bmr_extra_ARM8] >>
+FULL_SIMP_TAC (srw_ss()) [bir_exp_liftingTheory.bir_load_w2n_mf_simp_thm] >>
+METIS_TAC []
+);
+
+
+val exist_bir_of_arm8_thm = prove(
+  ``!ms vars.
+    arm8_wf_varset vars ==>
+    arm8_bmr.bmr_extra ms ==>
+    ?bs.
+      (bmr_rel arm8_bmr bs ms /\ (bs.bst_status = BST_Running) /\
+       bir_env_vars_are_initialised bs.bst_environ vars)``,
+
+REPEAT STRIP_TAC >> 
+EXISTS_TAC ``default_arm8_bir_state ms`` >>
+ASSUME_TAC (SPEC ``ms:arm8_state`` default_arm8_bir_state_satisfies_rel_thm) >>
+REV_FULL_SIMP_TAC std_ss [] >>
+STRIP_TAC >- (
+  EVAL_TAC
+) >>
+irule bir_env_oldTheory.bir_env_vars_are_initialised_SUBSET >>
+Q.EXISTS_TAC `arm8_vars` >>
+FULL_SIMP_TAC std_ss [arm8_wf_varset_def] >>
+SIMP_TAC std_ss [arm8_vars_def] >>
+(* TODO: This proof is sloooow... *)
+FULL_SIMP_TAC std_ss [bir_env_oldTheory.bir_env_vars_are_initialised_INSERT] >>
+REPEAT STRIP_TAC >>
+FULL_SIMP_TAC std_ss [bir_env_oldTheory.bir_env_var_is_initialised_def] >>
+FULL_SIMP_TAC std_ss [bir_envTheory.bir_var_name_def, default_arm8_bir_state_def,
+                        bir_envTheory.bir_env_lookup_UPDATE] >>
+EVAL_TAC  >>
+FULL_SIMP_TAC std_ss [bir_valuesTheory.bir_val_t_11,
+                      bir_immTheory.type_of_bir_imm_def,
+                      bir_valuesTheory.type_of_bir_val_EQ_ELIMS]
+);
+
+
+val set_of_address_in_all_address_labels_thm = prove (
+  ``!l adds.
+    l IN {BL_Address (Imm64 ml') | ml' IN adds} ==>
+    l IN {l | IS_BL_Address l}``,
+
+REPEAT STRIP_TAC >>
+FULL_SIMP_TAC std_ss [pred_setTheory.GSPECIFICATION, bir_program_labelsTheory.IS_BL_Address_def]
+);
+
+
+val bir_exec_to_labels_TO_exec_to_addr_label_n =
+  store_thm("bir_exec_to_labels_TO_exec_to_addr_label_n",
+  ``!bs' ml' mls p bs l n n0.
+    (bs'.bst_pc.bpc_label IN {BL_Address (Imm64 ml') | ml' IN mls}) ==>
+    (bir_exec_to_labels {BL_Address (Imm64 ml') | ml' IN mls} p bs =
+         BER_Ended l n n0 bs') ==>
+    ?n' lo c_st c_addr_labels.
+         (n' > 0) /\
+         (c_st = n) /\
+         (bir_exec_to_addr_label_n p bs n' =
+           BER_Ended lo c_st c_addr_labels bs')``,
+
+REPEAT STRIP_TAC >>
+subgoal `bs'.bst_pc.bpc_label IN {l | IS_BL_Address l}` >- (
+  METIS_TAC [set_of_address_in_all_address_labels_thm]
+) >>
+FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_exec_to_labels_def, bir_exec_to_addr_label_n_def,
+				      bir_exec_to_labels_n_def] >>
+subgoal `bir_pc_cond_impl (F,
+	   (\pc.
+	     (pc.bpc_index = 0) /\
+	     pc.bpc_label IN {BL_Address (Imm64 ml') | ml' IN mls})) (F, (\pc. (pc.bpc_index = 0) /\ pc.bpc_label IN {l | IS_BL_Address l}))` >- (
+  FULL_SIMP_TAC std_ss [bir_pc_cond_impl_def] >>
+  REPEAT STRIP_TAC >>
+  METIS_TAC [set_of_address_in_all_address_labels_thm]
+) >>
+IMP_RES_TAC bir_exec_steps_GEN_change_cond_Ended_SOME >>
+Q.EXISTS_TAC `n2` >>
+FULL_SIMP_TAC arith_ss [] >>
+METIS_TAC []
+);
+
+
+(* Just a version of bir_is_lifted_prog_MULTI_STEP_EXEC phrased in a more handy way *)
+val bir_is_lifted_prog_MULTI_STEP_EXEC_compute =
+  prove(
+  ``!mu bs bs' ms ml (p:'a bir_program_t) (r:(64, 8, 'b) bir_lifting_machine_rec_t)
+      mms n' lo c_st c_addr_labels.
+    bir_is_lifted_prog r mu mms p ==>
+    bmr_rel r bs ms ==>
+    MEM (BL_Address (Imm64 ml)) (bir_labels_of_program p) ==>
+    (bs.bst_pc = bir_block_pc (BL_Address (Imm64 ml))) ==>
+    EVERY (bmr_ms_mem_contains r ms) mms ==>
+    (bir_exec_to_addr_label_n p bs n' =
+         BER_Ended lo c_st c_addr_labels bs') ==>
+    ~bir_state_is_terminated bs ==>
+    ~bir_state_is_terminated bs' ==>
+    ?ms' li.
+    (FUNPOW_OPT r.bmr_step_fun c_addr_labels ms = SOME ms') /\
+    bmr_ms_mem_unchanged r ms ms' mu /\
+    EVERY (bmr_ms_mem_contains r ms') mms /\
+    (bs'.bst_pc = bir_block_pc (BL_Address li)) /\
+    MEM (BL_Address li) (bir_labels_of_program p) /\
+    bmr_rel r bs' ms'
+``,
+
+REPEAT STRIP_TAC >>
+ASSUME_TAC (ISPECL [``r:(64, 8, 'b) bir_lifting_machine_rec_t``, ``mu:64 word_interval_t``,
+                    ``mms:(word64# word8 list) list``,
+                    ``p:'a bir_program_t``] bir_is_lifted_prog_MULTI_STEP_EXEC) >>
+REV_FULL_SIMP_TAC std_ss [] >>
+QSPECL_X_ASSUM ``!n ms bs. _`` [`n'`, `ms`, `bs`] >>
+REV_FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_state_is_terminated_def]
+);
+
+
+val bir_arm8_block_pc = prove(
+  ``!bs ms ml.
+    bmr_rel arm8_bmr bs ms ==>
+    (arm_ts.ctrl ms = ml) ==>
+    (bs.bst_status = BST_Running) ==>
+    (bs.bst_pc = bir_block_pc (BL_Address (Imm64 ml)))``,
+
+REPEAT GEN_TAC >>
+REPEAT DISCH_TAC >>
+FULL_SIMP_TAC (std_ss++holBACore_ss++bir_wm_SS)
+  [arm8_bmr_rel_EVAL, bir_block_pc_def, arm_ts_def]
+);
+
+
+val bir_get_ht_conseq_from_m_ante = prove(
+  ``!bs p bpre bpost mpre ms ml mls.
+    bir_cont p bir_exp_true (BL_Address (Imm64 ml))
+      {BL_Address (Imm64 ml') | ml' IN mls} {} bpre bpost ==>
+    bir_pre_arm8_to_bir mpre bpre ==>
+    mpre ms ==>
+    bmr_rel arm8_bmr bs ms ==>
+    (bs.bst_status = BST_Running) ==>
+    bir_env_vars_are_initialised bs.bst_environ
+      (bir_vars_of_program p UNION bir_vars_of_exp bpre) ==>
+    (bs.bst_pc = bir_block_pc (BL_Address (Imm64 ml))) ==>
+    (?bs'.
+     (bir_weak_trs {BL_Address (Imm64 ml') | ml' IN mls} p bs =
+       SOME bs') /\
+     (bir_eval_exp (bpost bs'.bst_pc.bpc_label) bs'.bst_environ =
+       SOME bir_val_true)
+    )``,
+
+REPEAT GEN_TAC >>
+REPEAT DISCH_TAC >>
+FULL_SIMP_TAC (std_ss++bir_wm_SS)
+  [bir_cont_def, t_ext_jgmt_def, t_jgmt_def,
+   bir_exec_to_labels_triple_precond_def,
+   bir_exec_to_labels_triple_postcond_def, bir_ts_def] >>
+PAT_X_ASSUM ``!s. _``
+            (fn thm => ASSUME_TAC (SPEC ``bs:bir_state_t`` thm)) >>
+FULL_SIMP_TAC std_ss [bir_env_oldTheory.bir_env_vars_are_initialised_UNION] >>
+subgoal `bir_is_bool_exp_env bs.bst_environ bpre /\
+         (bir_eval_exp bpre bs.bst_environ = SOME bir_val_true)` >- (
+  METIS_TAC [bir_pre_arm8_to_bir_def, bir_bool_expTheory.bir_is_bool_exp_env_def]
+) >>
+FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss)
+  [bir_bool_expTheory.bir_eval_exp_TF,
+   bir_bool_expTheory.bir_is_bool_exp_env_REWRS,
+   bir_block_pc_def] >>
+REV_FULL_SIMP_TAC (std_ss++holBACore_ss) []
+);
+
+
+val bir_arm8_exec_in_end_label_set = prove(
+  ``!c_addr_labels ms' bs bs' mls p n n' lo li.
+    (* Execution from BIR HT *)
+    (bir_exec_to_addr_label_n p bs n' = BER_Ended lo n c_addr_labels bs') ==>
+    (n' > 0) ==>
+    ~bir_state_is_terminated bs' ==>
+    (bs'.bst_pc = bir_block_pc (BL_Address li)) ==>
+    ((bir_block_pc (BL_Address li)).bpc_label IN
+         {BL_Address (Imm64 ml') | ml' IN mls}) ==>
+    (* BMR relation between the final states *)
+    bmr_rel arm8_bmr bs' ms' ==>
+    c_addr_labels > 0 /\
+    ms'.PC IN mls``,
+
+REPEAT GEN_TAC >>
+REPEAT DISCH_TAC >>
+subgoal `c_addr_labels > 0` >- (
+  Cases_on `c_addr_labels = 0` >- (
+    FULL_SIMP_TAC std_ss [bir_exec_to_addr_label_n_def, bir_exec_to_labels_n_def,
+                          bir_exec_steps_GEN_SOME_EQ_Ended] >>
+    FULL_SIMP_TAC arith_ss []
+  ) >>
+  FULL_SIMP_TAC arith_ss []
+) >>
+subgoal `ms'.PC IN mls` >- (
+  subgoal `bs'.bst_pc = bir_block_pc (BL_Address (Imm64 ms'.PC))` >- (
+    REV_FULL_SIMP_TAC (std_ss++holBACore_ss)
+      [bir_state_is_terminated_def,
+       GEN_ALL bir_lifting_machinesTheory.arm8_bmr_rel_EVAL]
+  ) >>
+  REV_FULL_SIMP_TAC (std_ss++holBACore_ss++pred_setLib.PRED_SET_ss)
+    [bir_programTheory.bir_block_pc_def] >>
+  FULL_SIMP_TAC (std_ss++holBACore_ss) []
+) >>
+FULL_SIMP_TAC std_ss []
+);
+
+
+val bir_arm8_inter_exec_notin_end_label_set = prove(
+  ``!mls p bs l n0 n' n'' lo lo' c_st c_st' bs' bs''.
+    (bir_exec_to_labels {BL_Address (Imm64 ml') | ml' IN mls} p bs =
+       BER_Ended l c_st n0 bs') ==>
+    (bir_exec_to_addr_label_n p bs n'' = BER_Ended lo' c_st' n'' bs'') ==>
+    c_st' < c_st ==>
+    n'' > 0 ==>
+    ~bir_state_is_terminated bs'' ==>
+    bs''.bst_pc.bpc_label NOTIN
+      {BL_Address (Imm64 ml') | ml' IN mls}``,
+
+REPEAT STRIP_TAC >>
+(* NOTE: The number of taken statement steps is c_st for both the to-label execution
+ * and the to-addr-label-execution. *)
+(* The number of PCs counted (= in mls) at c_st' statement steps must be 0. *)
+subgoal `~bir_state_COUNT_PC (F,
+	  (\pc.
+	       (pc.bpc_index = 0) /\
+	       pc.bpc_label IN {BL_Address (Imm64 ml') | ml' IN mls}))
+	      (bir_exec_infinite_steps_fun p bs c_st')` >- (
+  FULL_SIMP_TAC std_ss [bir_exec_to_labels_def, bir_exec_to_labels_n_def,
+			bir_exec_steps_GEN_SOME_EQ_Ended] >>
+  (* Ergo, at c_st' statement steps, the PC label is not in mls, which follows after
+   * some arithmetic. *)
+  QSPECL_X_ASSUM ``!(n:num). (n < c_st) ==> _`` [`c_st'`] >>
+  REV_FULL_SIMP_TAC std_ss [] >>
+  subgoal `c_st' > 0` >- (
+    METIS_TAC [bir_exec_to_addr_label_n_def, bir_exec_to_labels_n_def,
+	       bir_exec_steps_GEN_SOME_EQ_Ended_Running_steps,
+	       bir_state_is_terminated_def]
+  ) >>
+  FULL_SIMP_TAC std_ss [NUM_LSONE_EQZ, bir_exec_infinite_steps_fun_COUNT_PCs_EQ_0] >>
+  QSPECL_X_ASSUM ``!j. _`` [`PRE c_st'`] >>
+  SUBGOAL_THEN ``SUC (PRE (c_st':num)) = c_st'`` (fn thm => FULL_SIMP_TAC std_ss [thm]) >- (
+    FULL_SIMP_TAC arith_ss []
+  ) >>
+  METIS_TAC [NUM_PRE_LT]
+) >>
+(* So either PC at c_st' statement steps has index 0, or it is not in mls.
+ * But PC has index 0... *)
+subgoal `bs''.bst_pc.bpc_index = 0` >- (
+  METIS_TAC [bir_exec_to_addr_label_n_ended_running, bir_state_is_terminated_def]
+) >>
+(* ... which proves the goal, after some identification of states. *)
+FULL_SIMP_TAC std_ss [bir_state_COUNT_PC_def, bir_exec_to_addr_label_n_def,
+		      bir_exec_to_labels_n_def,
+		      bir_exec_steps_GEN_SOME_EQ_Ended] >>
+REV_FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_state_is_terminated_def]
+);
+
+
+val bir_arm8_inter_exec = prove(
+  ``!n' c_addr_labels n0 ms ml mls bs bs' p lo l c_st n mu mms.
+    bir_is_lifted_prog arm8_bmr mu mms p ==>
+    EVERY (bmr_ms_mem_contains arm8_bmr ms) mms ==>
+    (arm_ts.ctrl ms = ml) ==>
+    (MEM (BL_Address (Imm64 ml)) (bir_labels_of_program p)) ==>
+    bmr_rel arm8_bmr bs ms ==>
+    ~bir_state_is_terminated bs ==>
+    (bs.bst_pc = bir_block_pc (BL_Address (Imm64 ml))) ==>
+    (bir_exec_to_labels {BL_Address (Imm64 ml') | ml' IN mls} p bs = BER_Ended l c_st n0 bs') ==>
+    ~bir_state_is_terminated bs' ==>
+    (bir_exec_to_addr_label_n p bs n' = BER_Ended lo c_st c_addr_labels bs') ==>
+    (!n''.
+       n'' < c_addr_labels /\ n'' > 0 ==>
+       ?ms''.
+	 (FUNPOW_OPT arm8_bmr.bmr_step_fun n'' ms = SOME ms'') /\
+	 ms''.PC NOTIN mls
+    )``,
+
+REPEAT STRIP_TAC >>
+(* The given number of address labels has been reached by bir_exec_to_addr_label_n when
+ * resulting Ended state bs' is not terminated *)
+Q.SUBGOAL_THEN `c_addr_labels = n'` (fn thm => FULL_SIMP_TAC std_ss [thm]) >- (
+  FULL_SIMP_TAC std_ss [bir_exec_to_addr_label_n_def, bir_exec_to_labels_n_def] >>
+  METIS_TAC [bir_exec_steps_GEN_SOME_EQ_Ended_pc_counts]
+) >>
+(* For some smaller number of address labels n'', bir_exec_to_addr_label_n also Ends
+ * (in bs'') *)
+subgoal `?lo' c_st' c_addr_labels' bs''.
+         bir_exec_to_addr_label_n p bs n'' =
+           BER_Ended lo' c_st' c_addr_labels' bs''` >- (
+  FULL_SIMP_TAC std_ss [bir_exec_to_addr_label_n_def, bir_exec_to_labels_n_def] >>
+  METIS_TAC [bir_exec_steps_GEN_decrease_max_steps_Ended_SOME]
+) >>
+(* Since the later state bs' is Running, bs'' must be Running as well... *)
+subgoal `~bir_state_is_terminated bs''` >- (
+  FULL_SIMP_TAC std_ss [bir_exec_to_addr_label_n_def, bir_exec_to_labels_n_def] >>
+  METIS_TAC [bir_exec_steps_GEN_decrease_max_steps_Ended_terminated]
+) >>
+(* ... with the given number of address labels reached. *)
+Q.SUBGOAL_THEN `c_addr_labels' = n''` (fn thm => FULL_SIMP_TAC std_ss [thm]) >- (
+  FULL_SIMP_TAC std_ss [bir_exec_to_addr_label_n_def, bir_exec_to_labels_n_def] >>
+  METIS_TAC [bir_exec_steps_GEN_SOME_EQ_Ended_pc_counts]
+) >>
+(* Now, prove that there is some state ms'' such that ms'' and bs'' are related in the
+ * sense of bmr_rel, with some additional sanity statements on PC and memory.
+ * Furthermore, ms'' is reached from ms by n'' applications of the machine step. *)
+subgoal `?ms'' li.
+         bmr_rel arm8_bmr bs'' ms'' /\
+         EVERY (bmr_ms_mem_contains arm8_bmr ms'') mms /\
+         bmr_ms_mem_unchanged arm8_bmr ms ms'' mu /\
+         MEM (BL_Address li) (bir_labels_of_program p) /\
+         (bs''.bst_pc = bir_block_pc (BL_Address li)) /\
+         (FUNPOW_OPT arm8_bmr.bmr_step_fun n'' ms = SOME ms'')` >- (
+  IMP_RES_TAC bir_is_lifted_prog_MULTI_STEP_EXEC_compute >>
+  METIS_TAC []
+) >>
+(* We have proven how some ms'' (in fact, the free variable ms'') can be reached
+ * from ms by n'' applications of the machine step. It remains to prove that ms'' cannot
+ * be a member of the Ending label set mls.
+ * First, we prove a similar property for the label of bs'', then we translate this to
+ * ms''. This can be easily done since both are word64 terms in different wrapping. *)
+subgoal `bs''.bst_pc.bpc_label NOTIN
+           {BL_Address (Imm64 ml') | ml' IN mls}` >- (
+  subgoal `c_st' < c_st` >- (
+    METIS_TAC [bir_exec_to_labels_def, bir_exec_to_addr_label_n_def,
+	       bir_exec_to_labels_n_def,
+	       bir_exec_steps_GEN_decrease_max_steps_Ended_steps_taken]
+  ) >>
+  METIS_TAC [bir_arm8_inter_exec_notin_end_label_set]
+) >>
+Q.EXISTS_TAC `ms''` >>
+(* Prove correspondence between the labels of the machine state PC and the BIR PC. *)
+subgoal `bs''.bst_pc = bir_block_pc (BL_Address (Imm64 ms''.PC))` >- (
+  REV_FULL_SIMP_TAC (std_ss++holBACore_ss)
+    [GEN_ALL arm8_bmr_rel_EVAL, bir_state_is_terminated_def]
+) >>
+FULL_SIMP_TAC (std_ss++holBACore_ss++bir_wm_SS++pred_setLib.PRED_SET_ss)
+  [bir_block_pc_def]
+);
+
+
+val lift_contract_thm = store_thm("lift_contract_thm",
+  ``!p mms ml mls mu mpre mpost bpre bpost.
+      MEM (BL_Address (Imm64 ml)) (bir_labels_of_program p) ==>
+      bir_cont p bir_exp_true (BL_Address (Imm64 ml))
+	{BL_Address (Imm64 ml') | ml' IN mls} {} bpre bpost ==>
+      bir_is_lifted_prog arm8_bmr mu mms p ==>
+      arm8_wf_varset (bir_vars_of_program p UNION bir_vars_of_exp bpre) ==>
+      bir_pre_arm8_to_bir mpre bpre ==>
+      bir_post_bir_to_arm8 mpost bpost {BL_Address (Imm64 ml') | ml' IN mls} ==>
+      arm8_cont mms ml mls mpre mpost``,
+
+REPEAT STRIP_TAC >>
+FULL_SIMP_TAC std_ss [arm8_cont_def, t_jgmt_def] >>
+REPEAT STRIP_TAC >>
+(* 1. Among the assumptions we now also have the antecedents of the arm8
+ *    HT. Combining these, exist_bir_of_arm8_thm gives that there is a
+ *    Running BIR state bs where the variables of arm8_wf_varset are
+ *    initialised which is related to (in the sense of bmr_rel) the the
+ *    arm8 machine state ms. *)
+IMP_RES_TAC (SPECL [``ms:arm8_state``,
+                    ``(bir_vars_of_program p) UNION (bir_vars_of_exp bpre)``]
+                  exist_bir_of_arm8_thm) >>
+
+(* 2. The assumptions now allow us to prove the antecedents of the BIR HT
+ *    and obtain the consequent. This states that the BIR weak transition
+ *    from bs to some state in the Ending label set mls results in some
+ *    state bs', in which the BIR postcondition bpost holds.
+ *    Furthermore, the PC of bs points to the first statement in the block
+ *    with label ml. *)
+IMP_RES_TAC bir_arm8_block_pc >>
+IMP_RES_TAC bir_get_ht_conseq_from_m_ante >>
+FULL_SIMP_TAC std_ss [bir_weak_trs_EQ] >>
+
+(* 3. Then, bir_is_lifted_prog_MULTI_STEP_EXEC is used to obtain the
+ *    existence of some arm8 machine state ms' related to bs'
+ *    (in the sense of bmr_rel) and some properties related to it. *)
+IMP_RES_TAC bir_exec_to_labels_TO_exec_to_addr_label_n >>
+IMP_RES_TAC bir_is_lifted_prog_MULTI_STEP_EXEC_compute >>
+REV_FULL_SIMP_TAC (std_ss++holBACore_ss) [] >>
+
+(* 4. Give ms' as witness to goal and prove the easy goal conjuncts -
+ *    all but arm_ts.weak ms mls ms', which is a statement on how ms
+ *    and ms' are related through a weak transition *)
+Q.EXISTS_TAC `ms'` >>
+subgoal `arm8_bmr.bmr_extra ms'` >- (
+  FULL_SIMP_TAC std_ss [bmr_rel_def]
+) >>
+subgoal `mpost ms'` >- (
+  FULL_SIMP_TAC std_ss [bir_post_bir_to_arm8_def] >>
+  QSPECL_X_ASSUM ``!ms. _``
+    [`ms'`, `bs'`, `(bir_block_pc (BL_Address li)).bpc_label`] >>
+  REV_FULL_SIMP_TAC std_ss []
+) >>
+FULL_SIMP_TAC std_ss [] >>
+
+(* 5. Show that the weak transition in the goal exists *)
+SIMP_TAC (std_ss++bir_wm_SS) [arm_ts_def,
+                              arm_weak_trs_def] >>
+Q.EXISTS_TAC `c_addr_labels` >>
+(* 5a. Weak transition from initial state ms ends in final state ms':
+ *     Machine-stepping from ms to ms' already exists among assumptions,
+ *     PC of final state ms' must be in Ending label set mls due to BIR HT
+ *     execution, plus the fact that bs' and ms' are related *)
+IMP_RES_TAC bir_arm8_exec_in_end_label_set >>
+FULL_SIMP_TAC std_ss [] >>
+
+(* 5b. Machine steps from ms up until ms' is reached:
+ *     This part of the proof is complex, see proof of lemma used *)
+METIS_TAC [bir_state_is_terminated_def, bir_arm8_inter_exec]
+);
+*)
+
+
+val _ = export_theory();

--- a/src/theory/tools/backlifter/bir_riscv_backlifterScript.sml
+++ b/src/theory/tools/backlifter/bir_riscv_backlifterScript.sml
@@ -270,208 +270,866 @@ Definition riscv_wf_varset_def:
  riscv_wf_varset vset = (vset SUBSET riscv_vars)
 End
 
+Definition default_riscv_bir_env_basic_def:
+ default_riscv_bir_env_basic ms env_map =
+ (("MEM8"     =+ SOME (BVal_Mem Bit64 Bit8 (bir_mmap_w_w2n (bir_mf2mm ms.MEM8))))
+ (("tmp_MEM8" =+ SOME (BVal_Mem Bit64 Bit8 (bir_mmap_w_w2n (bir_mf2mm ms.MEM8))))
+ (("tmp_PC"   =+ SOME (BVal_Imm (Imm64 (ms.c_PC ms.procID))))
+ (("tmp_COND" =+ SOME (BVal_Imm (Imm1 0w))) env_map))))
+End
+
+Definition default_riscv_bir_env_FPRS_def:
+ default_riscv_bir_env_FPRS ms env_map =
+   ("f0"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 0w))))
+   (("tmp_f0"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 0w))))
+   (("f1"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 1w))))
+   (("tmp_f1"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 1w))))
+   (("f2"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 2w))))
+   (("tmp_f2"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 2w))))
+   (("f3"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 3w))))
+   (("tmp_f3"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 3w))))
+   (("f4"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 4w))))
+   (("tmp_f4"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 4w))))
+   (("f5"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 5w))))
+   (("tmp_f5"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 5w))))
+   (("f6"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 6w))))
+   (("tmp_f6"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 6w))))
+   (("f7"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 7w))))
+   (("tmp_f7"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 7w))))
+   (("f8"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 8w))))
+   (("tmp_f8"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 8w))))
+   (("f9"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 9w))))
+   (("tmp_f9"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 9w))))
+   (("f10"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 10w))))
+   (("tmp_f10"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 10w))))
+   (("f11"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 11w))))
+   (("tmp_f11"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 11w))))
+   (("f12"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 12w))))
+   (("tmp_f12"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 12w))))
+   (("f13"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 13w))))
+   (("tmp_f13"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 13w))))
+   (("f14"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 14w))))
+   (("tmp_f14"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 14w))))
+   (("f15"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 15w))))
+   (("tmp_f15"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 15w))))
+   (("f16"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 16w))))
+   (("tmp_f16"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 16w))))
+   (("f17"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 17w))))
+   (("tmp_f17"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 17w))))
+   (("f18"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 18w))))
+   (("tmp_f18"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 18w))))
+   (("f19"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 19w))))
+   (("tmp_f19"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 19w))))
+   (("f20"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 20w))))
+   (("tmp_f20"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 20w))))
+   (("f21"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 21w))))
+   (("tmp_f21"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 21w))))
+   (("f22"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 22w))))
+   (("tmp_f22"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 22w))))
+   (("f23"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 23w))))
+   (("tmp_f23"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 23w))))
+   (("f24"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 24w))))
+   (("tmp_f24"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 24w))))
+   (("f25"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 25w))))
+   (("tmp_f25"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 25w))))
+   (("f26"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 26w))))
+   (("tmp_f26"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 26w))))
+   (("f27"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 27w))))
+   (("tmp_f27"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 27w))))
+   (("f28"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 28w))))
+   (("tmp_f28"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 28w))))
+   (("f29"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 29w))))
+   (("tmp_f29"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 29w))))
+   (("f30"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 30w))))
+   (("tmp_f30"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 30w))))
+   (("f31"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 31w))))
+   (("tmp_f31"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 31w))))
+   env_map)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+End
+
+Definition default_riscv_bir_env_GPRS_def:
+ default_riscv_bir_env_GPRS ms env_map =
+  ("x0"        =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 0w))))
+  (("tmp_x0"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 0w))))
+  (("x1"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 1w))))
+  (("tmp_x1"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 1w))))
+  (("x2"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 2w))))
+  (("tmp_x2"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 2w))))
+  (("x3"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 3w))))
+  (("tmp_x3"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 3w))))
+  (("x4"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 4w))))
+  (("tmp_x4"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 4w))))
+  (("x5"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 5w))))
+  (("tmp_x5"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 5w))))
+  (("x6"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 6w))))
+  (("tmp_x6"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 6w))))
+  (("x7"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 7w))))
+  (("tmp_x7"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 7w))))
+  (("x8"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 8w))))
+  (("tmp_x8"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 8w))))
+  (("x9"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 9w))))
+  (("tmp_x9"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 9w))))
+  (("x10"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 10w))))
+  (("tmp_x10"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 10w))))
+  (("x11"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 11w))))
+  (("tmp_x11"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 11w))))
+  (("x12"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 12w))))
+  (("tmp_x12"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 12w))))
+  (("x13"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 13w))))
+  (("tmp_x13"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 13w))))
+  (("x14"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 14w))))
+  (("tmp_x14"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 14w))))
+  (("x15"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 15w))))
+  (("tmp_x15"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 15w))))
+  (("x16"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 16w))))
+  (("tmp_x16"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 16w))))
+  (("x17"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 17w))))
+  (("tmp_x17"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 17w))))
+  (("x18"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 18w))))
+  (("tmp_x18"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 18w))))
+  (("x19"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 19w))))
+  (("tmp_x19"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 19w))))
+  (("x20"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 20w))))
+  (("tmp_x20"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 20w))))
+  (("x21"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 21w))))
+  (("tmp_x21"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 21w))))
+  (("x22"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 22w))))
+  (("tmp_x22"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 22w))))
+  (("x23"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 23w))))
+  (("tmp_x23"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 23w))))
+  (("x24"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 24w))))
+  (("tmp_x24"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 24w))))
+  (("x25"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 25w))))
+  (("tmp_x25"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 25w))))
+  (("x26"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 26w))))
+  (("tmp_x26"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 26w))))
+  (("x27"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 27w))))
+  (("tmp_x27"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 27w))))
+  (("x28"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 28w))))
+  (("tmp_x28"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 28w))))
+  (("x29"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 29w))))
+  (("tmp_x29"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 29w))))
+  (("x30"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 30w))))
+  (("tmp_x30"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 30w))))
+  (("x31"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 31w))))
+  (("tmp_x31"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 31w))))
+  env_map)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+End
+
 Definition default_riscv_bir_state_def:
  default_riscv_bir_state ms =
   <| bst_pc := bir_block_pc (BL_Address (Imm64 (ms.c_PC ms.procID))) ;
-     bst_environ := BEnv (
-       ("x0"        =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 0w))))
-       (("tmp_x0"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 0w))))
-       (("x1"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 1w))))
-       (("tmp_x1"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 1w))))
-       (("x2"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 2w))))
-       (("tmp_x2"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 2w))))
-       (("x3"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 3w))))
-       (("tmp_x3"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 3w))))
-       (("x4"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 4w))))
-       (("tmp_x4"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 4w))))
-       (("x5"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 5w))))
-       (("tmp_x5"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 5w))))
-       (("x6"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 6w))))
-       (("tmp_x6"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 6w))))
-       (("x7"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 7w))))
-       (("tmp_x7"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 7w))))
-       (("x8"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 8w))))
-       (("tmp_x8"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 8w))))
-       (("x9"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 9w))))
-       (("tmp_x9"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 9w))))
-       (("x10"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 10w))))
-       (("tmp_x10"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 10w))))
-       (("x11"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 11w))))
-       (("tmp_x11"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 11w))))
-       (("x12"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 12w))))
-       (("tmp_x12"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 12w))))
-       (("x13"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 13w))))
-       (("tmp_x13"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 13w))))
-       (("x14"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 14w))))
-       (("tmp_x14"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 14w))))
-       (("x15"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 15w))))
-       (("tmp_x15"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 15w))))
-       (("x16"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 16w))))
-       (("tmp_x16"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 16w))))
-       (("x17"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 17w))))
-       (("tmp_x17"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 17w))))
-       (("x18"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 18w))))
-       (("tmp_x18"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 18w))))
-       (("x19"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 19w))))
-       (("tmp_x19"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 19w))))
-       (("x20"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 20w))))
-       (("tmp_x20"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 20w))))
-       (("x21"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 21w))))
-       (("tmp_x21"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 21w))))
-       (("x22"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 22w))))
-       (("tmp_x22"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 22w))))
-       (("x23"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 23w))))
-       (("tmp_x23"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 23w))))
-       (("x24"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 24w))))
-       (("tmp_x24"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 24w))))
-       (("x25"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 25w))))
-       (("tmp_x25"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 25w))))
-       (("x26"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 26w))))
-       (("tmp_x26"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 26w))))
-       (("x27"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 27w))))
-       (("tmp_x27"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 27w))))
-       (("x28"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 28w))))
-       (("tmp_x28"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 28w))))
-       (("x29"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 29w))))
-       (("tmp_x29"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 29w))))
-       (("x30"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 30w))))
-       (("tmp_x30"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 30w))))
-       (("x31"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 31w))))
-       (("tmp_x31"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 31w))))
-
-       (("f0"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 0w))))
-       (("tmp_f0"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 0w))))
-       (("f1"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 1w))))
-       (("tmp_f1"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 1w))))
-       (("f2"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 2w))))
-       (("tmp_f2"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 2w))))
-       (("f3"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 3w))))
-       (("tmp_f3"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 3w))))
-       (("f4"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 4w))))
-       (("tmp_f4"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 4w))))
-       (("f5"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 5w))))
-       (("tmp_f5"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 5w))))
-       (("f6"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 6w))))
-       (("tmp_f6"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 6w))))
-       (("f7"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 7w))))
-       (("tmp_f7"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 7w))))
-       (("f8"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 8w))))
-       (("tmp_f8"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 8w))))
-       (("f9"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 9w))))
-       (("tmp_f9"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 9w))))
-       (("f10"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 10w))))
-       (("tmp_f10"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 10w))))
-       (("f11"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 11w))))
-       (("tmp_f11"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 11w))))
-       (("f12"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 12w))))
-       (("tmp_f12"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 12w))))
-       (("f13"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 13w))))
-       (("tmp_f13"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 13w))))
-       (("f14"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 14w))))
-       (("tmp_x14"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 14w))))
-       (("f15"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 15w))))
-       (("tmp_f15"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 15w))))
-       (("f16"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 16w))))
-       (("tmp_f16"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 16w))))
-       (("f17"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 17w))))
-       (("tmp_f17"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 17w))))
-       (("f18"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 18w))))
-       (("tmp_f18"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 18w))))
-       (("f19"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 19w))))
-       (("tmp_f19"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 19w))))
-       (("f20"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 20w))))
-       (("tmp_f20"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 20w))))
-       (("f21"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 21w))))
-       (("tmp_f21"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 21w))))
-       (("f22"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 22w))))
-       (("tmp_f22"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 22w))))
-       (("f23"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 23w))))
-       (("tmp_f23"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 23w))))
-       (("f24"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 24w))))
-       (("tmp_f24"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 24w))))
-       (("f25"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 25w))))
-       (("tmp_f25"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 25w))))
-       (("f26"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 26w))))
-       (("tmp_f26"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 26w))))
-       (("f27"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 27w))))
-       (("tmp_f27"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 27w))))
-       (("f28"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 28w))))
-       (("tmp_f28"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 28w))))
-       (("f29"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 29w))))
-       (("tmp_f29"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 29w))))
-       (("f30"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 30w))))
-       (("tmp_f30"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 30w))))
-       (("f31"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 31w))))
-       (("tmp_f31"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 31w))))
-
-       (("MEM8"     =+ SOME (BVal_Mem Bit64 Bit8 (bir_mmap_w_w2n (bir_mf2mm ms.MEM8))))
-       (("tmp_MEM8" =+ SOME (BVal_Mem Bit64 Bit8 (bir_mmap_w_w2n (bir_mf2mm ms.MEM8))))
-
-       (("tmp_PC"   =+ SOME (BVal_Imm (Imm64 (ms.c_PC ms.procID))))
-       (("tmp_COND" =+ SOME(BVal_Imm (Imm1 0w))) bir_env_map_empty))))
-        ))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
-        )))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
-     );
+     bst_environ := BEnv
+       (default_riscv_bir_env_GPRS ms
+        (default_riscv_bir_env_FPRS ms
+         (default_riscv_bir_env_basic ms bir_env_map_empty)));
      bst_status := BST_Running
    |>
 End
 
-(*
+Theorem default_riscv_bir_state_GPRS_read[local]:
+ !ms.
+  bir_env_read (BVar "x0" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 0w))) /\
+  bir_env_read (BVar "x1" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 1w))) /\
+  bir_env_read (BVar "x2" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 2w))) /\
+  bir_env_read (BVar "x3" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 3w))) /\
+  bir_env_read (BVar "x4" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 4w))) /\
+  bir_env_read (BVar "x5" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 5w))) /\
+  bir_env_read (BVar "x6" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 6w))) /\
+  bir_env_read (BVar "x7" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 7w))) /\
+  bir_env_read (BVar "x8" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 8w))) /\
+  bir_env_read (BVar "x9" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 9w))) /\
+  bir_env_read (BVar "x10" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 10w))) /\
+  bir_env_read (BVar "x11" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 11w))) /\
+  bir_env_read (BVar "x12" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 12w))) /\
+  bir_env_read (BVar "x13" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 13w))) /\
+  bir_env_read (BVar "x14" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 14w))) /\
+  bir_env_read (BVar "x15" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 15w))) /\
+  bir_env_read (BVar "x16" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 16w))) /\
+  bir_env_read (BVar "x17" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 17w))) /\
+  bir_env_read (BVar "x18" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 18w))) /\
+  bir_env_read (BVar "x19" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 19w))) /\
+  bir_env_read (BVar "x20" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 20w))) /\
+  bir_env_read (BVar "x21" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 21w))) /\
+  bir_env_read (BVar "x22" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 22w))) /\
+  bir_env_read (BVar "x23" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 23w))) /\
+  bir_env_read (BVar "x24" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 24w))) /\
+  bir_env_read (BVar "x25" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 25w))) /\
+  bir_env_read (BVar "x26" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 26w))) /\
+  bir_env_read (BVar "x27" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 27w))) /\
+  bir_env_read (BVar "x28" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 28w))) /\
+  bir_env_read (BVar "x29" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 29w))) /\
+  bir_env_read (BVar "x30" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 30w))) /\
+  bir_env_read (BVar "x31" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 31w)))
+Proof
+  rw [default_riscv_bir_state_def,
+      default_riscv_bir_env_GPRS_def,
+      bir_envTheory.bir_env_read_UPDATE,
+      bir_envTheory.bir_var_name_def,
+      bir_envTheory.bir_env_lookup_UPDATE,
+      bir_envTheory.bir_var_type_def,
+      bir_valuesTheory.type_of_bir_val_def,
+      type_of_bir_imm_def,
+      bir_immTheory.type_of_bool2b]
+QED
+
+Theorem default_riscv_bir_state_GPRS_read_tmp[local]:
+ !ms.
+  bir_env_read (BVar "tmp_x0" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 0w))) /\
+  bir_env_read (BVar "tmp_x1" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 1w))) /\
+  bir_env_read (BVar "tmp_x2" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 2w))) /\
+  bir_env_read (BVar "tmp_x3" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 3w))) /\
+  bir_env_read (BVar "tmp_x4" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 4w))) /\
+  bir_env_read (BVar "tmp_x5" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 5w))) /\
+  bir_env_read (BVar "tmp_x6" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 6w))) /\
+  bir_env_read (BVar "tmp_x7" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 7w))) /\
+  bir_env_read (BVar "tmp_x8" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 8w))) /\
+  bir_env_read (BVar "tmp_x9" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 9w))) /\
+  bir_env_read (BVar "tmp_x10" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 10w))) /\
+  bir_env_read (BVar "tmp_x11" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 11w))) /\
+  bir_env_read (BVar "tmp_x12" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 12w))) /\
+  bir_env_read (BVar "tmp_x13" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 13w))) /\
+  bir_env_read (BVar "tmp_x14" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 14w))) /\
+  bir_env_read (BVar "tmp_x15" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 15w))) /\
+  bir_env_read (BVar "tmp_x16" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 16w))) /\
+  bir_env_read (BVar "tmp_x17" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 17w))) /\
+  bir_env_read (BVar "tmp_x18" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 18w))) /\
+  bir_env_read (BVar "tmp_x19" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 19w))) /\
+  bir_env_read (BVar "tmp_x20" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 20w))) /\
+  bir_env_read (BVar "tmp_x21" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 21w))) /\
+  bir_env_read (BVar "tmp_x22" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 22w))) /\
+  bir_env_read (BVar "tmp_x23" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 23w))) /\
+  bir_env_read (BVar "tmp_x24" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 24w))) /\
+  bir_env_read (BVar "tmp_x25" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 25w))) /\
+  bir_env_read (BVar "tmp_x26" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 26w))) /\
+  bir_env_read (BVar "tmp_x27" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 27w))) /\
+  bir_env_read (BVar "tmp_x28" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 28w))) /\
+  bir_env_read (BVar "tmp_x29" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 29w))) /\
+  bir_env_read (BVar "tmp_x30" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 30w))) /\
+  bir_env_read (BVar "tmp_x31" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 31w)))
+Proof
+  rw [default_riscv_bir_state_def,
+      default_riscv_bir_env_GPRS_def,
+      bir_envTheory.bir_env_read_UPDATE,
+      bir_envTheory.bir_var_name_def,
+      bir_envTheory.bir_env_lookup_UPDATE,
+      bir_envTheory.bir_var_type_def,
+      bir_valuesTheory.type_of_bir_val_def,
+      type_of_bir_imm_def,
+      bir_immTheory.type_of_bool2b]
+QED
+
+Theorem default_riscv_bir_state_GPRS_lookup_type[local]:
+  !ms.
+  bir_env_lookup_type "x0" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x0" (BType_Imm Bit64)))  /\
+  bir_env_lookup_type "x1" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x1" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x2" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x2" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x3" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x3" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x4" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x4" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x5" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x5" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x6" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x6" (BType_Imm Bit64))) /\
+    bir_env_lookup_type "x7" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x7" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x8" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x8" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x9" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x9" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x10" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x10" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x11" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x11" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x12" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x12" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x13" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x13" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x14" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x14" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x15" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x15" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x16" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x16" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x17" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x17" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x18" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x18" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x19" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x19" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x20" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x20" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x21" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x21" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x22" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x22" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x23" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x23" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x24" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x24" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x25" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x25" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x26" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x26" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x27" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x27" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x28" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x28" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x29" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x29" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x30" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x30" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "x31" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "x31" (BType_Imm Bit64)))
+Proof
+  rw [default_riscv_bir_state_def,
+      default_riscv_bir_env_GPRS_def,
+      bir_env_oldTheory.bir_env_var_is_declared_def,
+      bir_envTheory.bir_var_name_def,
+      bir_envTheory.bir_env_read_UPDATE,
+      bir_envTheory.bir_var_name_def,
+      bir_envTheory.bir_env_lookup_UPDATE,
+      bir_envTheory.bir_var_type_def,
+      bir_envTheory.bir_env_lookup_type_def,
+      bir_valuesTheory.type_of_bir_val_def,
+     type_of_bir_imm_def]
+QED
+
+Theorem default_riscv_bir_state_GPRS_lookup_type_tmp[local]:
+  !ms.
+  bir_env_lookup_type "tmp_x0" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x0" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x1" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x1" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x2" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x2" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x3" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x3" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x4" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x4" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x5" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x5" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x6" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x6" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x7" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x7" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x8" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x8" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x9" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x9" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x10" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x10" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x11" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x11" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x12" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x12" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x13" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x13" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x14" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x14" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x15" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x15" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x16" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x16" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x17" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x17" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x18" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x18" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x19" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x19" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x20" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x20" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x21" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x21" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x22" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x22" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x23" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x23" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x24" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x24" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x25" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x25" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x26" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x26" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x27" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x27" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x28" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x28" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x29" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x29" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x30" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x30" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_x31" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_x31" (BType_Imm Bit64)))
+Proof
+  rw [default_riscv_bir_state_def,
+      default_riscv_bir_env_GPRS_def,
+      bir_env_oldTheory.bir_env_var_is_declared_def,
+      bir_envTheory.bir_var_name_def,
+      bir_envTheory.bir_env_read_UPDATE,
+      bir_envTheory.bir_var_name_def,
+      bir_envTheory.bir_env_lookup_UPDATE,
+      bir_envTheory.bir_var_type_def,
+      bir_envTheory.bir_env_lookup_type_def,
+      bir_valuesTheory.type_of_bir_val_def,
+     type_of_bir_imm_def]
+QED
+
+Theorem default_riscv_bir_state_FPRS_read[local]:
+ !ms.
+  bir_env_read (BVar "f0" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 0w))) /\
+  bir_env_read (BVar "f1" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 1w))) /\
+  bir_env_read (BVar "f2" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 2w))) /\
+  bir_env_read (BVar "f3" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 3w))) /\
+  bir_env_read (BVar "f4" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 4w))) /\
+  bir_env_read (BVar "f5" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 5w))) /\
+  bir_env_read (BVar "f6" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 6w))) /\
+  bir_env_read (BVar "f7" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 7w))) /\
+  bir_env_read (BVar "f8" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 8w))) /\
+  bir_env_read (BVar "f9" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 9w))) /\
+  bir_env_read (BVar "f10" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 10w))) /\
+  bir_env_read (BVar "f11" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 11w))) /\
+  bir_env_read (BVar "f12" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 12w))) /\
+  bir_env_read (BVar "f13" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 13w))) /\
+  bir_env_read (BVar "f14" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 14w))) /\
+  bir_env_read (BVar "f15" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 15w))) /\
+  bir_env_read (BVar "f16" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 16w))) /\
+  bir_env_read (BVar "f17" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 17w))) /\
+  bir_env_read (BVar "f18" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 18w))) /\
+  bir_env_read (BVar "f19" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 19w))) /\
+  bir_env_read (BVar "f20" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 20w))) /\
+  bir_env_read (BVar "f21" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 21w))) /\
+  bir_env_read (BVar "f22" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 22w))) /\
+  bir_env_read (BVar "f23" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 23w))) /\
+  bir_env_read (BVar "f24" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 24w))) /\
+  bir_env_read (BVar "f25" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 25w))) /\
+  bir_env_read (BVar "f26" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 26w))) /\
+  bir_env_read (BVar "f27" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 27w))) /\
+  bir_env_read (BVar "f28" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 28w))) /\
+  bir_env_read (BVar "f29" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 29w))) /\
+  bir_env_read (BVar "f30" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 30w))) /\
+  bir_env_read (BVar "f31" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 31w)))
+Proof
+  rw [default_riscv_bir_state_def,
+      default_riscv_bir_env_GPRS_def,
+      default_riscv_bir_env_FPRS_def,
+      bir_envTheory.bir_env_read_UPDATE,
+      bir_envTheory.bir_var_name_def,
+      bir_envTheory.bir_env_lookup_UPDATE,
+      bir_envTheory.bir_var_type_def,
+      bir_valuesTheory.type_of_bir_val_def,
+      type_of_bir_imm_def,
+      bir_immTheory.type_of_bool2b]
+QED
+
+Theorem default_riscv_bir_state_FPRS_read_tmp[local]:
+ !ms.
+  bir_env_read (BVar "tmp_f0" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 0w))) /\
+  bir_env_read (BVar "tmp_f1" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 1w))) /\
+  bir_env_read (BVar "tmp_f2" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 2w))) /\
+  bir_env_read (BVar "tmp_f3" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 3w))) /\
+  bir_env_read (BVar "tmp_f4" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 4w))) /\
+  bir_env_read (BVar "tmp_f5" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 5w))) /\
+  bir_env_read (BVar "tmp_f6" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 6w))) /\
+  bir_env_read (BVar "tmp_f7" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 7w))) /\
+  bir_env_read (BVar "tmp_f8" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 8w))) /\
+  bir_env_read (BVar "tmp_f9" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 9w))) /\
+  bir_env_read (BVar "tmp_f10" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 10w))) /\
+  bir_env_read (BVar "tmp_f11" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 11w))) /\
+  bir_env_read (BVar "tmp_f12" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 12w))) /\
+  bir_env_read (BVar "tmp_f13" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 13w))) /\
+  bir_env_read (BVar "tmp_f14" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 14w))) /\
+  bir_env_read (BVar "tmp_f15" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 15w))) /\
+  bir_env_read (BVar "tmp_f16" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 16w))) /\
+  bir_env_read (BVar "tmp_f17" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 17w))) /\
+  bir_env_read (BVar "tmp_f18" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 18w))) /\
+  bir_env_read (BVar "tmp_f19" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 19w))) /\
+  bir_env_read (BVar "tmp_f20" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 20w))) /\
+  bir_env_read (BVar "tmp_f21" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 21w))) /\
+  bir_env_read (BVar "tmp_f22" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 22w))) /\
+  bir_env_read (BVar "tmp_f23" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 23w))) /\
+  bir_env_read (BVar "tmp_f24" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 24w))) /\
+  bir_env_read (BVar "tmp_f25" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 25w))) /\
+  bir_env_read (BVar "tmp_f26" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 26w))) /\
+  bir_env_read (BVar "tmp_f27" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 27w))) /\
+  bir_env_read (BVar "tmp_f28" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 28w))) /\
+  bir_env_read (BVar "tmp_f29" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 29w))) /\
+  bir_env_read (BVar "tmp_f30" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 30w))) /\
+  bir_env_read (BVar "tmp_f31" (BType_Imm Bit64)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 31w)))
+Proof
+  rw [default_riscv_bir_state_def,
+      default_riscv_bir_env_GPRS_def,
+      default_riscv_bir_env_FPRS_def,
+      bir_envTheory.bir_env_read_UPDATE,
+      bir_envTheory.bir_var_name_def,
+      bir_envTheory.bir_env_lookup_UPDATE,
+      bir_envTheory.bir_var_type_def,
+      bir_valuesTheory.type_of_bir_val_def,
+      type_of_bir_imm_def,
+      bir_immTheory.type_of_bool2b]
+QED
+
+Theorem default_riscv_bir_state_FPRS_lookup_type[local]:
+  !ms.
+  bir_env_lookup_type "f0" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f0" (BType_Imm Bit64)))  /\
+  bir_env_lookup_type "f1" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f1" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f2" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f2" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f3" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f3" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f4" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f4" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f5" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f5" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f6" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f6" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f7" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f7" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f8" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f8" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f9" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f9" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f10" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f10" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f11" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f11" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f12" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f12" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f13" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f13" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f14" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f14" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f15" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f15" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f16" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f16" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f17" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f17" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f18" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f18" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f19" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f19" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f20" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f20" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f21" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f21" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f22" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f22" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f23" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f23" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f24" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f24" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f25" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f25" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f26" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f26" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f27" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f27" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f28" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f28" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f29" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f29" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f30" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f30" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "f31" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "f31" (BType_Imm Bit64)))
+Proof
+  rw [default_riscv_bir_state_def,
+      default_riscv_bir_env_GPRS_def,
+      default_riscv_bir_env_FPRS_def,
+      bir_env_oldTheory.bir_env_var_is_declared_def,
+      bir_envTheory.bir_var_name_def,
+      bir_envTheory.bir_env_read_UPDATE,
+      bir_envTheory.bir_var_name_def,
+      bir_envTheory.bir_env_lookup_UPDATE,
+      bir_envTheory.bir_var_type_def,
+      bir_envTheory.bir_env_lookup_type_def,
+      bir_valuesTheory.type_of_bir_val_def,
+     type_of_bir_imm_def]
+QED
+
+Theorem default_riscv_bir_state_FPRS_lookup_type_tmp[local]:
+  !ms.
+  bir_env_lookup_type "tmp_f0" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f0" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f1" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f1" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f2" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f2" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f3" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f3" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f4" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f4" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f5" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f5" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f6" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f6" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f7" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f7" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f8" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f8" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f9" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f9" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f10" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f10" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f11" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f11" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f12" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f12" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f13" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f13" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f14" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f14" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f15" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f15" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f16" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f16" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f17" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f17" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f18" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f18" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f19" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f19" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f20" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f20" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f21" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f21" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f22" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f22" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f23" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f23" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f24" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f24" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f25" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f25" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f26" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f26" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f27" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f27" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f28" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f28" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f29" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f29" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f30" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f30" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_f31" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_f31" (BType_Imm Bit64)))
+Proof
+  rw [default_riscv_bir_state_def,
+      default_riscv_bir_env_GPRS_def,
+      default_riscv_bir_env_FPRS_def,
+      bir_env_oldTheory.bir_env_var_is_declared_def,
+      bir_envTheory.bir_var_name_def,
+      bir_envTheory.bir_env_read_UPDATE,
+      bir_envTheory.bir_var_name_def,
+      bir_envTheory.bir_env_lookup_UPDATE,
+      bir_envTheory.bir_var_type_def,
+      bir_envTheory.bir_env_lookup_type_def,
+      bir_valuesTheory.type_of_bir_val_def,
+     type_of_bir_imm_def]
+QED
+
+Theorem default_riscv_bir_state_basic_env_read[local]:
+ !ms.
+ bir_env_read (BVar "MEM8" (BType_Mem Bit64 Bit8)) (default_riscv_bir_state ms).bst_environ =
+   SOME (BVal_Mem Bit64 Bit8 (bir_mmap_w_w2n (bir_mf2mm ms.MEM8)))
+Proof
+  rw [default_riscv_bir_state_def,
+      default_riscv_bir_env_GPRS_def,
+      default_riscv_bir_env_FPRS_def,
+      default_riscv_bir_env_basic_def,
+      bir_envTheory.bir_env_read_UPDATE,
+      bir_envTheory.bir_var_name_def,
+      bir_envTheory.bir_env_lookup_UPDATE,
+      bir_envTheory.bir_var_type_def,
+      bir_valuesTheory.type_of_bir_val_def,
+      type_of_bir_imm_def,
+      bir_immTheory.type_of_bool2b]
+QED
+
+Theorem default_riscv_bir_state_basic_lookup_type[local]:
+ !ms.
+  bir_env_lookup_type "tmp_MEM8" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_MEM8" (BType_Mem Bit64 Bit8))) /\
+  bir_env_lookup_type "tmp_PC" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_PC" (BType_Imm Bit64))) /\
+  bir_env_lookup_type "tmp_COND" (default_riscv_bir_state ms).bst_environ =
+   SOME (bir_var_type (BVar "tmp_COND" (BType_Imm Bit1)))
+Proof
+  rw [default_riscv_bir_state_def,
+      default_riscv_bir_env_GPRS_def,
+      default_riscv_bir_env_FPRS_def,
+      default_riscv_bir_env_basic_def,
+      bir_env_oldTheory.bir_env_var_is_declared_def,
+      bir_envTheory.bir_var_name_def,
+      bir_envTheory.bir_env_read_UPDATE,
+      bir_envTheory.bir_var_name_def,
+      bir_envTheory.bir_env_lookup_UPDATE,
+      bir_envTheory.bir_var_type_def,
+      bir_envTheory.bir_env_lookup_type_def,
+      bir_valuesTheory.type_of_bir_val_def,
+     type_of_bir_imm_def]
+QED
 
 Theorem default_riscv_bir_state_satisfies_rel_thm[local]:
  !ms. riscv_bmr.bmr_extra ms ==>
    bmr_rel riscv_bmr (default_riscv_bir_state ms) ms
 Proof
-FULL_SIMP_TAC std_ss [default_riscv_bir_state_def,
-  bir_lifting_machinesTheory.riscv_bmr_rel_EVAL,
-  bir_env_oldTheory.bir_env_var_is_declared_def,
-  bir_envTheory.bir_var_name_def] >>
-FULL_SIMP_TAC (srw_ss()) [
-              bir_envTheory.bir_env_read_UPDATE,
-              bir_envTheory.bir_var_name_def,
-              bir_envTheory.bir_env_lookup_UPDATE,
-              bir_envTheory.bir_var_type_def,
-              bir_envTheory.bir_env_lookup_type_def] >>
-FULL_SIMP_TAC std_ss [bir_valuesTheory.type_of_bir_val_def,
-                      type_of_bir_imm_def,
-                      bir_immTheory.type_of_bool2b] >>
-FULL_SIMP_TAC std_ss [bir_lifting_machinesTheory.bmr_extra_RISCV] >>
+strip_tac >> strip_tac >>
+FULL_SIMP_TAC std_ss [bir_lifting_machinesTheory.riscv_bmr_rel_EVAL,
+ bir_env_oldTheory.bir_env_var_is_declared_def,bir_envTheory.bir_var_name_def] >>
+fs [
+  default_riscv_bir_state_GPRS_read,
+  default_riscv_bir_state_GPRS_read_tmp,
+  default_riscv_bir_state_GPRS_lookup_type,
+  default_riscv_bir_state_GPRS_lookup_type_tmp,
+  default_riscv_bir_state_FPRS_read,
+  default_riscv_bir_state_FPRS_read_tmp,
+  default_riscv_bir_state_FPRS_lookup_type,
+  default_riscv_bir_state_FPRS_lookup_type_tmp,
+  default_riscv_bir_state_basic_env_read,
+  default_riscv_bir_state_basic_lookup_type
+ ] >>
+FULL_SIMP_TAC std_ss [default_riscv_bir_state_def,bir_lifting_machinesTheory.bmr_extra_RISCV] >>
 FULL_SIMP_TAC (srw_ss()) [bir_exp_liftingTheory.bir_load_w2n_mf_simp_thm] >>
 METIS_TAC []
 QED
 
-bir_env_read (BVar "f28" (BType_Imm Bit64)) (default_riscv_bir_state ms) =
-SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 28w)))
-
-*)
-
 (*
-
-val default_arm8_bir_state_satisfies_rel_thm = prove(
-  ``!ms.
-    arm8_bmr.bmr_extra ms ==>
-    bmr_rel arm8_bmr (default_arm8_bir_state ms) ms``,
-
-REPEAT STRIP_TAC >>
-FULL_SIMP_TAC std_ss [default_arm8_bir_state_def,
-  bir_lifting_machinesTheory.arm8_bmr_rel_EVAL,
-  bir_env_oldTheory.bir_env_var_is_declared_def,
-  bir_envTheory.bir_var_name_def] >>
-FULL_SIMP_TAC (srw_ss()) [
-              bir_envTheory.bir_env_read_UPDATE,
-              bir_envTheory.bir_var_name_def,
-              bir_envTheory.bir_env_lookup_UPDATE,
-              bir_envTheory.bir_var_type_def,
-              bir_envTheory.bir_env_lookup_type_def] >>
-FULL_SIMP_TAC std_ss [bir_valuesTheory.type_of_bir_val_def,
-                      type_of_bir_imm_def,
-                      bir_immTheory.type_of_bool2b] >>
-FULL_SIMP_TAC std_ss [bir_lifting_machinesTheory.bmr_extra_ARM8] >>
-FULL_SIMP_TAC (srw_ss()) [bir_exp_liftingTheory.bir_load_w2n_mf_simp_thm] >>
-METIS_TAC []
-);
-
-
 val exist_bir_of_arm8_thm = prove(
   ``!ms vars.
     arm8_wf_varset vars ==>

--- a/src/theory/tools/backlifter/bir_riscv_backlifterScript.sml
+++ b/src/theory/tools/backlifter/bir_riscv_backlifterScript.sml
@@ -27,7 +27,7 @@ open m0_mod_stepLib;
 
 open bir_riscv_extrasTheory;
 
-open bir_backlifterTheory;
+open bir_arm8_backlifterTheory;
 
 val _ = new_theory "bir_riscv_backlifter";
 

--- a/src/theory/tools/backlifter/bir_riscv_backlifterScript.sml
+++ b/src/theory/tools/backlifter/bir_riscv_backlifterScript.sml
@@ -282,139 +282,149 @@ End
 Definition default_riscv_bir_env_FPRS_def:
  default_riscv_bir_env_FPRS ms env_map =
    ("f0"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 0w))))
-   (("tmp_f0"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 0w))))
    (("f1"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 1w))))
-   (("tmp_f1"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 1w))))
    (("f2"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 2w))))
-   (("tmp_f2"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 2w))))
    (("f3"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 3w))))
-   (("tmp_f3"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 3w))))
    (("f4"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 4w))))
-   (("tmp_f4"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 4w))))
    (("f5"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 5w))))
-   (("tmp_f5"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 5w))))
    (("f6"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 6w))))
-   (("tmp_f6"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 6w))))
    (("f7"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 7w))))
-   (("tmp_f7"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 7w))))
    (("f8"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 8w))))
-   (("tmp_f8"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 8w))))
    (("f9"       =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 9w))))
-   (("tmp_f9"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 9w))))
    (("f10"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 10w))))
-   (("tmp_f10"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 10w))))
    (("f11"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 11w))))
-   (("tmp_f11"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 11w))))
    (("f12"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 12w))))
-   (("tmp_f12"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 12w))))
    (("f13"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 13w))))
-   (("tmp_f13"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 13w))))
    (("f14"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 14w))))
-   (("tmp_f14"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 14w))))
    (("f15"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 15w))))
-   (("tmp_f15"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 15w))))
    (("f16"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 16w))))
-   (("tmp_f16"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 16w))))
    (("f17"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 17w))))
-   (("tmp_f17"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 17w))))
    (("f18"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 18w))))
-   (("tmp_f18"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 18w))))
    (("f19"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 19w))))
-   (("tmp_f19"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 19w))))
    (("f20"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 20w))))
-   (("tmp_f20"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 20w))))
    (("f21"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 21w))))
-   (("tmp_f21"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 21w))))
    (("f22"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 22w))))
-   (("tmp_f22"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 22w))))
    (("f23"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 23w))))
-   (("tmp_f23"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 23w))))
    (("f24"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 24w))))
-   (("tmp_f24"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 24w))))
    (("f25"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 25w))))
-   (("tmp_f25"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 25w))))
    (("f26"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 26w))))
-   (("tmp_f26"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 26w))))
    (("f27"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 27w))))
-   (("tmp_f27"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 27w))))
    (("f28"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 28w))))
-   (("tmp_f28"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 28w))))
    (("f29"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 29w))))
-   (("tmp_f29"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 29w))))
    (("f30"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 30w))))
-   (("tmp_f30"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 30w))))
    (("f31"      =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 31w))))
+   env_map)))))))))))))))))))))))))))))))
+End
+
+Definition default_riscv_bir_env_FPRS_tmp_def:
+ default_riscv_bir_env_FPRS_tmp ms env_map =
+   ("tmp_f0"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 0w))))
+   (("tmp_f1"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 1w))))
+   (("tmp_f2"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 2w))))
+   (("tmp_f3"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 3w))))
+   (("tmp_f4"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 4w))))
+   (("tmp_f5"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 5w))))
+   (("tmp_f6"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 6w))))
+   (("tmp_f7"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 7w))))
+   (("tmp_f8"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 8w))))
+   (("tmp_f9"   =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 9w))))
+   (("tmp_f10"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 10w))))
+   (("tmp_f11"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 11w))))
+   (("tmp_f12"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 12w))))
+   (("tmp_f13"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 13w))))
+   (("tmp_f14"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 14w))))
+   (("tmp_f15"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 15w))))
+   (("tmp_f16"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 16w))))
+   (("tmp_f17"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 17w))))
+   (("tmp_f18"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 18w))))
+   (("tmp_f19"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 19w))))
+   (("tmp_f20"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 20w))))
+   (("tmp_f21"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 21w))))
+   (("tmp_f22"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 22w))))
+   (("tmp_f23"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 23w))))
+   (("tmp_f24"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 24w))))
+   (("tmp_f25"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 25w))))
+   (("tmp_f26"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 26w))))
+   (("tmp_f27"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 27w))))
+   (("tmp_f28"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 28w))))
+   (("tmp_f29"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 29w))))
+   (("tmp_f30"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 30w))))
    (("tmp_f31"  =+ SOME (BVal_Imm (Imm64 (ms.c_fpr ms.procID 31w))))
-   env_map)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+   env_map)))))))))))))))))))))))))))))))
 End
 
 Definition default_riscv_bir_env_GPRS_def:
  default_riscv_bir_env_GPRS ms env_map =
   ("x0"        =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 0w))))
-  (("tmp_x0"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 0w))))
   (("x1"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 1w))))
-  (("tmp_x1"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 1w))))
   (("x2"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 2w))))
-  (("tmp_x2"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 2w))))
   (("x3"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 3w))))
-  (("tmp_x3"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 3w))))
   (("x4"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 4w))))
-  (("tmp_x4"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 4w))))
   (("x5"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 5w))))
-  (("tmp_x5"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 5w))))
   (("x6"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 6w))))
-  (("tmp_x6"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 6w))))
   (("x7"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 7w))))
-  (("tmp_x7"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 7w))))
   (("x8"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 8w))))
-  (("tmp_x8"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 8w))))
   (("x9"       =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 9w))))
-  (("tmp_x9"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 9w))))
   (("x10"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 10w))))
-  (("tmp_x10"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 10w))))
   (("x11"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 11w))))
-  (("tmp_x11"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 11w))))
   (("x12"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 12w))))
-  (("tmp_x12"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 12w))))
   (("x13"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 13w))))
-  (("tmp_x13"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 13w))))
   (("x14"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 14w))))
-  (("tmp_x14"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 14w))))
   (("x15"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 15w))))
-  (("tmp_x15"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 15w))))
   (("x16"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 16w))))
-  (("tmp_x16"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 16w))))
   (("x17"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 17w))))
-  (("tmp_x17"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 17w))))
   (("x18"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 18w))))
-  (("tmp_x18"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 18w))))
   (("x19"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 19w))))
-  (("tmp_x19"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 19w))))
   (("x20"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 20w))))
-  (("tmp_x20"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 20w))))
   (("x21"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 21w))))
-  (("tmp_x21"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 21w))))
   (("x22"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 22w))))
-  (("tmp_x22"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 22w))))
   (("x23"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 23w))))
-  (("tmp_x23"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 23w))))
   (("x24"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 24w))))
-  (("tmp_x24"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 24w))))
   (("x25"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 25w))))
-  (("tmp_x25"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 25w))))
   (("x26"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 26w))))
-  (("tmp_x26"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 26w))))
   (("x27"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 27w))))
-  (("tmp_x27"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 27w))))
   (("x28"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 28w))))
-  (("tmp_x28"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 28w))))
   (("x29"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 29w))))
-  (("tmp_x29"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 29w))))
   (("x30"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 30w))))
-  (("tmp_x30"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 30w))))
   (("x31"      =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 31w))))
+  env_map)))))))))))))))))))))))))))))))
+End
+
+Definition default_riscv_bir_env_GPRS_tmp_def:
+ default_riscv_bir_env_GPRS_tmp ms env_map =
+  ("tmp_x0"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 0w))))
+  (("tmp_x1"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 1w))))
+  (("tmp_x2"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 2w))))
+  (("tmp_x3"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 3w))))
+  (("tmp_x4"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 4w))))
+  (("tmp_x5"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 5w))))
+  (("tmp_x6"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 6w))))
+  (("tmp_x7"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 7w))))
+  (("tmp_x8"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 8w))))
+  (("tmp_x9"   =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 9w))))
+  (("tmp_x10"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 10w))))
+  (("tmp_x11"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 11w))))
+  (("tmp_x12"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 12w))))
+  (("tmp_x13"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 13w))))
+  (("tmp_x14"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 14w))))
+  (("tmp_x15"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 15w))))
+  (("tmp_x16"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 16w))))
+  (("tmp_x17"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 17w))))
+  (("tmp_x18"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 18w))))
+  (("tmp_x19"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 19w))))
+  (("tmp_x20"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 20w))))
+  (("tmp_x21"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 21w))))
+  (("tmp_x22"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 22w))))
+  (("tmp_x23"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 23w))))
+  (("tmp_x24"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 24w))))
+  (("tmp_x25"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 25w))))
+  (("tmp_x26"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 26w))))
+  (("tmp_x27"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 27w))))
+  (("tmp_x28"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 28w))))
+  (("tmp_x29"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 29w))))
+  (("tmp_x30"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 30w))))
   (("tmp_x31"  =+ SOME (BVal_Imm (Imm64 (ms.c_gpr ms.procID 31w))))
-  env_map)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+  env_map)))))))))))))))))))))))))))))))
 End
 
 Definition default_riscv_bir_state_def:
@@ -422,8 +432,10 @@ Definition default_riscv_bir_state_def:
   <| bst_pc := bir_block_pc (BL_Address (Imm64 (ms.c_PC ms.procID))) ;
      bst_environ := BEnv
        (default_riscv_bir_env_GPRS ms
-        (default_riscv_bir_env_FPRS ms
-         (default_riscv_bir_env_basic ms bir_env_map_empty)));
+        (default_riscv_bir_env_GPRS_tmp ms
+         (default_riscv_bir_env_FPRS ms
+          (default_riscv_bir_env_FPRS_tmp ms
+           (default_riscv_bir_env_basic ms bir_env_map_empty)))));
      bst_status := BST_Running
    |>
 End
@@ -575,6 +587,7 @@ Theorem default_riscv_bir_state_GPRS_read_tmp[local]:
 Proof
   rw [default_riscv_bir_state_def,
       default_riscv_bir_env_GPRS_def,
+      default_riscv_bir_env_GPRS_tmp_def,
       bir_envTheory.bir_env_read_UPDATE,
       bir_envTheory.bir_var_name_def,
       bir_envTheory.bir_env_lookup_UPDATE,
@@ -733,6 +746,7 @@ Theorem default_riscv_bir_state_GPRS_lookup_type_tmp[local]:
 Proof
   rw [default_riscv_bir_state_def,
       default_riscv_bir_env_GPRS_def,
+      default_riscv_bir_env_GPRS_tmp_def,
       bir_env_oldTheory.bir_env_var_is_declared_def,
       bir_envTheory.bir_var_name_def,
       bir_envTheory.bir_env_read_UPDATE,
@@ -813,6 +827,7 @@ Theorem default_riscv_bir_state_FPRS_read[local]:
 Proof
   rw [default_riscv_bir_state_def,
       default_riscv_bir_env_GPRS_def,
+      default_riscv_bir_env_GPRS_tmp_def,
       default_riscv_bir_env_FPRS_def,
       bir_envTheory.bir_env_read_UPDATE,
       bir_envTheory.bir_var_name_def,
@@ -892,7 +907,9 @@ Theorem default_riscv_bir_state_FPRS_read_tmp[local]:
 Proof
   rw [default_riscv_bir_state_def,
       default_riscv_bir_env_GPRS_def,
+      default_riscv_bir_env_GPRS_tmp_def,
       default_riscv_bir_env_FPRS_def,
+      default_riscv_bir_env_FPRS_tmp_def,
       bir_envTheory.bir_env_read_UPDATE,
       bir_envTheory.bir_var_name_def,
       bir_envTheory.bir_env_lookup_UPDATE,
@@ -971,6 +988,7 @@ Theorem default_riscv_bir_state_FPRS_lookup_type[local]:
 Proof
   rw [default_riscv_bir_state_def,
       default_riscv_bir_env_GPRS_def,
+      default_riscv_bir_env_GPRS_tmp_def,
       default_riscv_bir_env_FPRS_def,
       bir_env_oldTheory.bir_env_var_is_declared_def,
       bir_envTheory.bir_var_name_def,
@@ -1052,7 +1070,9 @@ Theorem default_riscv_bir_state_FPRS_lookup_type_tmp[local]:
 Proof
   rw [default_riscv_bir_state_def,
       default_riscv_bir_env_GPRS_def,
+      default_riscv_bir_env_GPRS_tmp_def,
       default_riscv_bir_env_FPRS_def,
+      default_riscv_bir_env_FPRS_tmp_def,
       bir_env_oldTheory.bir_env_var_is_declared_def,
       bir_envTheory.bir_var_name_def,
       bir_envTheory.bir_env_read_UPDATE,
@@ -1071,7 +1091,9 @@ Theorem default_riscv_bir_state_basic_env_read[local]:
 Proof
   rw [default_riscv_bir_state_def,
       default_riscv_bir_env_GPRS_def,
+      default_riscv_bir_env_GPRS_tmp_def,
       default_riscv_bir_env_FPRS_def,
+      default_riscv_bir_env_FPRS_tmp_def,
       default_riscv_bir_env_basic_def,
       bir_envTheory.bir_env_read_UPDATE,
       bir_envTheory.bir_var_name_def,
@@ -1093,7 +1115,9 @@ Theorem default_riscv_bir_state_basic_lookup_type[local]:
 Proof
   rw [default_riscv_bir_state_def,
       default_riscv_bir_env_GPRS_def,
+      default_riscv_bir_env_GPRS_tmp_def,
       default_riscv_bir_env_FPRS_def,
+      default_riscv_bir_env_FPRS_tmp_def,
       default_riscv_bir_env_basic_def,
       bir_env_oldTheory.bir_env_var_is_declared_def,
       bir_envTheory.bir_var_name_def,

--- a/src/theory/tools/lifter/bir_lifting_machinesScript.sml
+++ b/src/theory/tools/lifter/bir_lifting_machinesScript.sml
@@ -980,6 +980,15 @@ SIMP_TAC (list_ss++bmr_ss++stringSimps.STRING_ss++wordsLib.WORD_ss++holBACore_ss
           bmr_varnames_distinct_def]
 );
 
+val riscv_bmr_rel_EVAL = save_thm ("riscv_bmr_rel_EVAL",
+SIMP_CONV (list_ss++bmr_ss++holBACore_ss) [
+  bmr_rel_def, riscv_bmr_EVAL,
+  bir_machine_lifted_mem_def, bir_machine_lifted_imm_def,
+  bir_is_temp_var_name_def, BType_Bool_def, bir_temp_var_name_def,
+  bir_machine_lifted_pc_def, bir_temp_var_def,
+  GSYM CONJ_ASSOC]
+``bmr_rel riscv_bmr bs ms``);
+
 (**********************************************************************)
 (* 2. riscv_bmr_LIFTED                                                *)
 (**********************************************************************)

--- a/src/tools/backlifter/bir_backlifterLib.sml
+++ b/src/tools/backlifter/bir_backlifterLib.sml
@@ -37,7 +37,7 @@ open PPBackEnd Parse
 open bir_inst_liftingHelpersLib;
 (* ================================================ *)
 
-    open bir_backlifterTheory;
+    open bir_arm8_backlifterTheory;
     open bir_riscv_backlifterTheory;
     open bir_compositionLib;
   in
@@ -61,7 +61,7 @@ fun get_arm8_contract_sing bir_ct prog_bin arm8_pre arm8_post bir_prog_def bir_p
 	      (((el 2) o snd o strip_comb o concl) bir_is_lifted_prog_thm),
 	      arm8_pre, arm8_post,
 	      get_bir_cont_pre bir_ct,
-	      get_bir_cont_post bir_ct] lift_contract_thm;
+	      get_bir_cont_post bir_ct] arm8_lift_contract_thm;
 
     (* Prove the ARM triple by supplying the antecedents of lift_contract_thm *)
     val arm8_contract_thm = prove(

--- a/src/tools/backlifter/bir_backlifterLib.sml
+++ b/src/tools/backlifter/bir_backlifterLib.sml
@@ -126,12 +126,11 @@ fun get_arm8_contract_sing bir_ct prog_bin arm8_pre arm8_post bir_prog_def bir_p
 	      (((el 2) o snd o strip_comb o concl) bir_is_lifted_prog_thm),
 	      riscv_pre, riscv_post,
 	      get_bir_cont_pre bir_ct,
-	      get_bir_cont_post bir_ct] lift_contract_thm;
+	      get_bir_cont_post bir_ct] riscv_lift_contract_thm;
 
     (* Prove the ARM triple by supplying the antecedents of lift_contract_thm *)
     val riscv_contract_thm = prove(
-      ``riscv_cont ^prog_bin ^l ^ls ^riscv_pre
-		^riscv_post``,
+      ``riscv_cont ^prog_bin ^l ^ls ^riscv_pre ^riscv_post``,
 
     irule add_lift_thm >>
     REPEAT STRIP_TAC >| [
@@ -152,7 +151,7 @@ fun get_arm8_contract_sing bir_ct prog_bin arm8_pre arm8_post bir_prog_def bir_p
 
       (* 4. Provide translation of the RISC-V postcondition to BIR postcondition *)
       FULL_SIMP_TAC std_ss bir_post_defs >>
-      ASSUME_TAC (Q.SPEC `{BL_Address (Imm64 ml') | ml' IN ^ls}` riscv_post_imp_bir_post_thm) >>
+      ASSUME_TAC (Q.ISPEC `{BL_Address (Imm64 ml') | ml' IN ^ls}` riscv_post_imp_bir_post_thm) >>
       FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) [bir_post_bir_to_riscv_def] >>
       FULL_SIMP_TAC std_ss [],
 
@@ -161,7 +160,7 @@ fun get_arm8_contract_sing bir_ct prog_bin arm8_pre arm8_post bir_prog_def bir_p
 
       (* 6. Provide the BIR triple in the requisite format *)
       ASSUME_TAC bir_ct >>
-      `{BL_Address (Imm64 ml') | ml' IN {72w}} = {BL_Address (Imm64 72w)}` suffices_by (
+      `{BL_Address (Imm64 ml') | ml' IN {20w}} = {BL_Address (Imm64 20w)}` suffices_by (
               FULL_SIMP_TAC std_ss []
       ) >>
       FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) [pred_setTheory.EXTENSION]

--- a/src/tools/backlifter/bir_backlifterLib.sml
+++ b/src/tools/backlifter/bir_backlifterLib.sml
@@ -96,7 +96,7 @@ fun get_arm8_contract_sing bir_ct prog_bin arm8_pre arm8_post bir_prog_def bir_p
 
       (* 6. Provide the BIR triple in the requisite format *)
       ASSUME_TAC bir_ct >>
-      `{BL_Address (Imm64 ml') | ml' IN {72w}} = {BL_Address (Imm64 72w)}` suffices_by (
+      `{BL_Address (Imm64 ml') | ml' IN ^ls} = {BL_Address (Imm64 ^ls_sing)}` suffices_by (
               FULL_SIMP_TAC std_ss []
       ) >>
       FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) [pred_setTheory.EXTENSION]
@@ -150,8 +150,8 @@ fun get_arm8_contract_sing bir_ct prog_bin arm8_pre arm8_post bir_prog_def bir_p
       FULL_SIMP_TAC std_ss [bir_pre1_def, riscv_pre_imp_bir_pre_thm],
 
       (* 4. Provide translation of the RISC-V postcondition to BIR postcondition *)
-      FULL_SIMP_TAC std_ss bir_post_defs >>
       ASSUME_TAC (Q.ISPEC `{BL_Address (Imm64 ml') | ml' IN ^ls}` riscv_post_imp_bir_post_thm) >>
+      FULL_SIMP_TAC std_ss bir_post_defs >>
       FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) [bir_post_bir_to_riscv_def] >>
       FULL_SIMP_TAC std_ss [],
 
@@ -160,7 +160,7 @@ fun get_arm8_contract_sing bir_ct prog_bin arm8_pre arm8_post bir_prog_def bir_p
 
       (* 6. Provide the BIR triple in the requisite format *)
       ASSUME_TAC bir_ct >>
-      `{BL_Address (Imm64 ml') | ml' IN {20w}} = {BL_Address (Imm64 20w)}` suffices_by (
+      `{BL_Address (Imm64 ml') | ml' IN ^ls} = {BL_Address (Imm64 ^ls_sing)}` suffices_by (
               FULL_SIMP_TAC std_ss []
       ) >>
       FULL_SIMP_TAC (std_ss++pred_setLib.PRED_SET_ss) [pred_setTheory.EXTENSION]

--- a/src/tools/symbexec/examples/analysis/testfile.sml
+++ b/src/tools/symbexec/examples/analysis/testfile.sml
@@ -1,4 +1,4 @@
-"bir_backlifterTheory.bir_is_lifted_prog_MULTI_STEP_EXEC_compute"
+"bir_arm8_backlifterTheory.bir_is_lifted_prog_MULTI_STEP_EXEC_compute"
 
 
 bmr_rel r bs ms
@@ -6,8 +6,8 @@ bmr_rel r bs ms
 
 bir_lifting_machinesTheory.bmr_rel_def
 
-bir_backlifterTheory.bir_pre_arm8_to_bir_def
-bir_backlifterTheory.bir_post_bir_to_arm8_def
+bir_arm8_backlifterTheory.bir_pre_arm8_to_bir_def
+bir_arm8_backlifterTheory.bir_post_bir_to_arm8_def
 
 
 ***** number of addr label steps (c_addr_labels?), but n' is the number of bir steps??? *****
@@ -37,13 +37,13 @@ bir_program_terminationTheory???
 
 
 
-bir_backlifterTheory.arm8_triple_def
+bir_arm8_backlifterTheory.arm8_triple_def
 
 abstract_hoare_logicTheory.abstract_jgmt_def
 abstract_simp_hoare_logicTheory.abstract_simp_jgmt_def
 
-bir_backlifterTheory.arm_weak_model_def
-bir_backlifterTheory.arm_weak_trs_def
+bir_arm8_backlifterTheory.arm_weak_model_def
+bir_arm8_backlifterTheory.arm_weak_trs_def
 
 bir_wm_instTheory.bir_simp_jgmt_def
 bir_wm_instTheory.bir_etl_wm_def

--- a/src/tools/symbexec/examples/common/bir_program_transfScript.sml
+++ b/src/tools/symbexec/examples/common/bir_program_transfScript.sml
@@ -1116,9 +1116,9 @@ val m0_mod_triple_rel_def = Define `
 (* TODO: translate to pure Cortex-M0 property *)
 (* =================================================================================== *)
 (*
-bir_backlifterTheory.bir_post_bir_to_arm8_def
+bir_arm8_backlifterTheory.bir_post_bir_to_arm8_def
 lift_contract_thm
-src/tools/backlifter/bir_backlifterLib.sml
+src/tools/backlifter/bir_arm8_backlifterLib.sml
 
 get_arm8_contract_sing
 
@@ -1126,7 +1126,7 @@ examples/tutorial/7-composition/tutorial_backliftingScript.sml
 *)
 (* =================================================================================== *)
 
-(* TODO: stolen and adjusted/generalized from "bir_backlifterTheory.bir_is_lifted_prog_MULTI_STEP_EXEC_compute" *)
+(* TODO: stolen and adjusted/generalized from "bir_arm8_backlifterTheory.bir_is_lifted_prog_MULTI_STEP_EXEC_compute" *)
 (* =================================================================================== *)
 val bir_is_lifted_prog_MULTI_STEP_EXEC_compute_GEN_thm =
   prove(
@@ -1169,9 +1169,9 @@ val bir_is_lifted_prog_MULTI_STEP_EXEC_compute_32_8_thm =
 (*
 
 TODO: this is probably in precondition lifting
-"bir_backlifterTheory.exist_bir_of_arm8_thm"
-bir_backlifterTheory.bir_pre_arm8_to_bir_def
-bir_backlifterTheory.bir_post_bir_to_arm8_def
+"bir_arm8_backlifterTheory.exist_bir_of_arm8_thm"
+bir_arm8_backlifterTheory.bir_pre_arm8_to_bir_def
+bir_arm8_backlifterTheory.bir_post_bir_to_arm8_def
 ((
 !ms.
 ?bs.
@@ -1501,7 +1501,7 @@ REPEAT STRIP_TAC >>
 FULL_SIMP_TAC std_ss [pred_setTheory.GSPECIFICATION, bir_program_labelsTheory.IS_BL_Address_def, IMAGE_DEF]
 );
 
-(* TODO: copied and adjusted "bir_backlifterTheory.bir_exec_to_labels_TO_exec_to_addr_label_n" *)
+(* TODO: copied and adjusted "bir_arm8_backlifterTheory.bir_exec_to_labels_TO_exec_to_addr_label_n" *)
 val bir_exec_to_labels_TO_exec_to_addr_label_n_GEN =
   store_thm("bir_exec_to_labels_TO_exec_to_addr_label_n_GEN",
   ``!bs' ls p bs lo0 n n0.
@@ -1612,7 +1612,7 @@ REPEAT DISCH_TAC >>
   FULL_SIMP_TAC (std_ss++holBACore_ss) []
 );
 
-(* TODO: this is copied "bir_backlifterTheory.bir_arm8_inter_exec_notin_end_label_set" and adapted *)
+(* TODO: this is copied "bir_arm8_backlifterTheory.bir_arm8_inter_exec_notin_end_label_set" and adapted *)
 val bir_inter_exec_notin_end_label_set_GEN = prove(
   ``!mls p bs l n0 n' n'' lo lo' c_st c_st' bs' bs''.
     (bir_exec_to_labels (IMAGE (\l. BL_Address l) mls) p bs = BER_Ended l c_st n0 bs') ==>

--- a/src/tools/symbexec/examples/test-birs_transfer.sml
+++ b/src/tools/symbexec/examples/test-birs_transfer.sml
@@ -483,7 +483,7 @@ val bprog_bir_prop_thm = save_thm(
 
 (* TODO: translate to pure Cortex-M0 property *)
 (*
-bir_backlifterTheory.bir_post_bir_to_arm8_def
+bir_arm8_backlifterTheory.bir_post_bir_to_arm8_def
 lift_contract_thm
 src/tools/backlifter/bir_backlifterLib.sml
 


### PR DESCRIPTION
This PR contains:
- backlifting results for RISC-V, following those for ARMv8
- fixes to the backlifting proof generation for ARMv8 (and proper name for the theory)
- more RISC-V examples and results for those examples (testing backlifting)

Currently a draft because a final `cheat` in a test case needs to be addressed.
