### PR TITLE
Update HOL4 and Poly/ML to latest versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,9 +19,9 @@ jobs:
 
     strategy:
       matrix:
-        polyml: ['v5.7.1', 'v5.9']
+        polyml: ['v5.7.1', 'v5.9.1']
         z3: ['4.8.4']
-        hol4: ['kananaskis-14']
+        hol4: ['master']
 
     env:
       HOLBA_POLYML_VERSION: ${{ matrix.polyml }}

--- a/README.md
+++ b/README.md
@@ -12,15 +12,8 @@ HolBA is built using the `Holmake` tool bundled with HOL4.
 
 ### Dependencies
 
-- [HOL4](https://github.com/HOL-Theorem-Prover/HOL), tag `kananaskis-14`.
-  If you download HOL4 yourself, be sure to fix problems with modern C++
-  compilers by running the following commands in your HOL4 root directory
-  before you run `./bin/build`:
-  ```shell
-  sed -i 's/CFLAGS    = -Wall -ffloat-store -fno-strict-aliasing.*/& -std=c++14/g' src/HolSat/sat_solvers/minisat/Makefile
-  sed -i 's/g++ -O3 Proof.o File.o zc2hs.cpp -o zc2hs.*/& -std=c++14/g' src/HolSat/sat_solvers/zc2hs/Makefile
-  ```
-- [Poly/ML](https://github.com/polyml/polyml), 5.9
+- [HOL4](https://github.com/HOL-Theorem-Prover/HOL), tag `trindemossen-1`.
+- [Poly/ML](https://github.com/polyml/polyml), 5.9.1
   - alternatively, Poly/ML 5.7.1 (version packaged for Ubuntu 20.04)
 - [Z3](https://github.com/Z3Prover/z3), 4.8.4
 

--- a/scripts/setup/env_config_gen.sh
+++ b/scripts/setup/env_config_gen.sh
@@ -111,7 +111,7 @@ echo
 # first define HOLBA_HOL_DIR if undefined (default)
 if [[ ( -z "${HOLBA_HOL_DIR}" ) || ( ! -z "${OPT_DIR_PARAM}" ) ]]; then
   print_export_msg "HOLBA_HOL_DIR"
-  export HOLBA_HOL_DIR="${HOLBA_OPT_DIR}/hol_k14"
+  export HOLBA_HOL_DIR="${HOLBA_OPT_DIR}/hol_t1"
 fi
 
 HOLBA_HOL_BIN_DIR="${HOLBA_HOL_DIR}/bin"

--- a/scripts/setup/install_hol4.sh
+++ b/scripts/setup/install_hol4.sh
@@ -16,7 +16,7 @@ source "${SETUP_DIR}/env_config_gen.sh" "${OPT_DIR_PARAM}"
 ##################################################################
 
 # use a default polyml version if it is not specified in the environment
-POLY_VERSION="v5.9"
+POLY_VERSION="v5.9.1"
 if [[ ! -z "${HOLBA_POLYML_VERSION}" ]]; then
   POLY_VERSION=${HOLBA_POLYML_VERSION}
 fi

--- a/scripts/setup/install_hol4.sh
+++ b/scripts/setup/install_hol4.sh
@@ -27,7 +27,7 @@ export PATH=${POLY_DIR}/bin:$PATH
 export LD_LIBRARY_PATH=${POLY_DIR}/lib:$LD_LIBRARY_PATH
 
 # use a default hol4 version if it is not specified in the environment
-HOL4_VERSION="kananaskis-14"
+HOL4_VERSION="trindemossen-1"
 if [[ ! -z "${HOLBA_HOL4_VERSION}" ]]; then
   HOL4_VERSION=${HOLBA_HOL4_VERSION}
 fi
@@ -36,7 +36,7 @@ fi
 GIT_URL=https://github.com/HOL-Theorem-Prover/HOL.git
 GIT_IS_TAG=1
 
-HOL4_DIR=${HOLBA_OPT_DIR}/hol_k14
+HOL4_DIR=${HOLBA_OPT_DIR}/hol_t1
 
 
 ##################################################################

--- a/scripts/setup/install_hol4_latest.sh
+++ b/scripts/setup/install_hol4_latest.sh
@@ -16,7 +16,7 @@ source "${SETUP_DIR}/env_config_gen.sh" "${OPT_DIR_PARAM}"
 ##################################################################
 
 # use a default polyml version if it is not specified in the environment
-POLY_VERSION="v5.9"
+POLY_VERSION="v5.9.1"
 if [[ ! -z "${HOLBA_POLYML_VERSION}" ]]; then
   POLY_VERSION=${HOLBA_POLYML_VERSION}
 fi

--- a/scripts/setup/install_poly.sh
+++ b/scripts/setup/install_poly.sh
@@ -21,7 +21,7 @@ source "${SETUP_DIR}/env_config_gen.sh" "${OPT_DIR_PARAM}"
 POLY_BASE="https://github.com/polyml/polyml"
 
 # use a default polyml version if it is not specified in the environment
-POLY_VERSION="v5.9"
+POLY_VERSION="v5.9.1"
 if [[ ! -z "${HOLBA_POLYML_VERSION}" ]]; then
   POLY_VERSION=${HOLBA_POLYML_VERSION}
 fi

--- a/src/theory/bir-support/bir_bool_expScript.sml
+++ b/src/theory/bir-support/bir_bool_expScript.sml
@@ -1,12 +1,11 @@
 open HolKernel Parse boolLib bossLib;
+open bir_auxiliaryLib;
 open bir_auxiliaryTheory;
 open bir_envTheory bir_valuesTheory;
 open bir_immTheory bir_typing_expTheory;
 open bir_exp_memTheory bir_expTheory;
 open bir_exp_immTheory;
 open HolBACoreSimps
-
-open bir_auxiliaryLib;
 
 val _ = new_theory "bir_bool_exp";
 
@@ -65,12 +64,6 @@ Theorem bir_val_TF_bool2b_DEF:
     (bir_val_false = BVal_Imm (bool2b F))
 Proof
 SIMP_TAC std_ss [BVal_Imm_bool2b_TF_DEF]
-QED
-
-Theorem BVal_Imm_bool2b_TF_DEF:
-  !b. (BVal_Imm (bool2b b) = if b then bir_val_true else bir_val_false)
-Proof
-Cases >> SIMP_TAC (std_ss++holBACore_ss) [bir_val_true_def, bir_val_false_def]
 QED
 
 Theorem BVal_Imm_bool2b_EQ_TF_REWRS:

--- a/src/theory/bir-support/bir_exp_tautologiesScript.sml
+++ b/src/theory/bir-support/bir_exp_tautologiesScript.sml
@@ -82,19 +82,6 @@ QED
 
 
 Theorem bir_exp_is_taut_WEAK_CONG_IFF:
-  !e1 e2. bir_exp_CONG_WEAK e1 e2 ==> bir_var_set_is_well_typed (bir_vars_of_exp e1) ==>
-        (bir_exp_is_taut e1 <=> bir_exp_is_taut e2)
-Proof
-REPEAT STRIP_TAC >> EQ_TAC >- (
-  METIS_TAC[bir_exp_is_taut_WEAK_CONG_IMPL]
-) >>
-FULL_SIMP_TAC std_ss [bir_exp_is_taut_def, bir_exp_CONG_WEAK_def, bir_is_bool_exp_def] >>
-REPEAT STRIP_TAC >>
-METIS_TAC[bir_env_oldTheory.bir_env_vars_are_initialised_SUBSET]
-QED
-
-
-Theorem bir_exp_is_taut_WEAK_CONG_IFF:
   !e1 e2. bir_exp_CONG e1 e2 ==>
         (bir_exp_is_taut e1 <=> bir_exp_is_taut e2)
 Proof

--- a/src/theory/bir-support/bir_interval_expScript.sml
+++ b/src/theory/bir-support/bir_interval_expScript.sml
@@ -119,7 +119,9 @@ Definition WI_ELEM_LIST_def:
   (WI_ELEM_LIST b (SUC n) = b::(WI_ELEM_LIST (b+1w) n))
 End
 
-Theorem WI_ELEM_LIST_compute = CONV_RULE (numLib.SUC_TO_NUMERAL_DEFN_CONV) WI_ELEM_LIST_def
+(* TODO: Why does Holmake not work to with this just commented out?
+ * Interactively, this is defined by the above definition *)
+Theorem WI_ELEM_LIST_compute[allow_rebind] = CONV_RULE (numLib.SUC_TO_NUMERAL_DEFN_CONV) WI_ELEM_LIST_def
 
 
 Theorem WI_MEM_WI_size:

--- a/src/theory/bir-support/bir_nzcv_expScript.sml
+++ b/src/theory/bir-support/bir_nzcv_expScript.sml
@@ -353,16 +353,6 @@ METIS_TAC[awc_BIR_NZCV_SYM, awc_BIR_NZVC_ELIMS]
 QED
 
 
-val nzcv_BIR_SUB_SYM = store_thm ("nzcv_BIR_ADD_SYM", ``
-  (!w1 (w2:'a word). nzcv_BIR_SUB_N (~w1) (~w2) <=> nzcv_BIR_SUB_N w2 w1) /\
-  (!w1 (w2:'a word). nzcv_BIR_SUB_Z (~w1) (~w2) <=> nzcv_BIR_SUB_Z w2 w1) /\
-  (!w1 (w2:'a word). nzcv_BIR_SUB_C (~w1) (~w2) <=> nzcv_BIR_SUB_C w2 w1) /\
-  (!w1 (w2:'a word). nzcv_BIR_SUB_V (~w1) (~w2) <=> nzcv_BIR_SUB_V w2 w1)``,
-
-SIMP_TAC std_ss [awc_BIR_NZVC_INTROS, WORD_NOT_NOT] >>
-SIMP_TAC std_ss [awc_BIR_NZVC_ELIMS_SYM, awc_BIR_NZVC_ELIMS]);
-
-
 
 (*******************)
 (* Simplifications *)

--- a/src/theory/bir-support/bir_program_no_assumeScript.sml
+++ b/src/theory/bir-support/bir_program_no_assumeScript.sml
@@ -35,32 +35,32 @@ REPEAT STRIP_TAC >>
     Cases_on `(bir_eval_exp b0'' b0)` >> (
       FULL_SIMP_TAC (std_ss++holBACore_ss)
             [bir_state_set_typeerror_def,
-             bir_state_t_bst_status_fupd]
+             recordtype_bir_state_t_seldef_bst_status_fupd_def]
     ) >>
     Cases_on `bir_env_write b'' x b0` >| [
       FULL_SIMP_TAC (std_ss++holBACore_ss)
             [bir_state_set_typeerror_def,
-             bir_state_t_bst_status_fupd],
+             recordtype_bir_state_t_seldef_bst_status_fupd_def],
 
       FULL_SIMP_TAC (std_ss++holBACore_ss)
-                    [bir_state_t_bst_environ_fupd]
+                    [recordtype_bir_state_t_seldef_bst_environ_fupd_def]
     ],
 
     FULL_SIMP_TAC (std_ss++holBACore_ss) [bir_exec_stmt_assert_def] >>
     Cases_on `(bir_eval_exp b'' b0)` >> (
       FULL_SIMP_TAC (std_ss++holBACore_ss)
             [bir_state_set_typeerror_def,
-             bir_state_t_bst_status_fupd]
+             recordtype_bir_state_t_seldef_bst_status_fupd_def]
     ) >>
     Cases_on `bir_dest_bool_val x` >| [
       FULL_SIMP_TAC (std_ss++holBACore_ss)
             [bir_state_set_typeerror_def,
-             bir_state_t_bst_status_fupd],
+             recordtype_bir_state_t_seldef_bst_status_fupd_def],
 
       Cases_on `x'` >> (
         FULL_SIMP_TAC (std_ss++holBACore_ss)
               [bir_state_set_typeerror_def,
-               bir_state_t_bst_status_fupd]
+               recordtype_bir_state_t_seldef_bst_status_fupd_def]
       )
     ],
 
@@ -69,21 +69,21 @@ REPEAT STRIP_TAC >>
     Cases_on `(bir_eval_exp b'' b0)` >> (
       FULL_SIMP_TAC (std_ss++holBACore_ss)
             [bir_state_set_typeerror_def,
-             bir_state_t_bst_status_fupd]
+             recordtype_bir_state_t_seldef_bst_status_fupd_def]
     ) >>
     Cases_on `(bir_dest_bool_val x)` >> (
       FULL_SIMP_TAC (std_ss++holBACore_ss)
             [bir_state_set_typeerror_def,
-             bir_state_t_bst_status_fupd]
+             recordtype_bir_state_t_seldef_bst_status_fupd_def]
     ) >>
     Cases_on `(x')` >> (
       FULL_SIMP_TAC (std_ss++holBACore_ss)
             [bir_state_set_typeerror_def,
-             bir_state_t_bst_status_fupd] >>
+             recordtype_bir_state_t_seldef_bst_status_fupd_def] >>
       Cases_on `(EXISTS IS_NONE (MAP (λe. bir_eval_exp e b0) l))` >> (
         FULL_SIMP_TAC (std_ss++holBACore_ss)
               [bir_state_set_typeerror_def,
-               bir_state_t_bst_status_fupd]
+               recordtype_bir_state_t_seldef_bst_status_fupd_def]
       )
     )
   ]
@@ -253,12 +253,12 @@ FULL_SIMP_TAC std_ss [bir_block_has_no_assumes_def,
     Cases_on `st` >>
     Cases_on `st'` >>
     FULL_SIMP_TAC (std_ss++holBACore_ss)
-                  [bir_state_t_fn_updates, bir_state_t_bst_status,
-                   bir_state_t_bst_pc],
+                  [bir_state_t_fn_updates, recordtype_bir_state_t_seldef_bst_status_def,
+                   recordtype_bir_state_t_seldef_bst_pc_def],
 
     FULL_SIMP_TAC (std_ss++holBACore_ss)
-                  [bir_state_t_fn_updates, bir_state_t_bst_status,
-                   bir_state_t_bst_pc] >>
+                  [bir_state_t_fn_updates, recordtype_bir_state_t_seldef_bst_status_def,
+                   recordtype_bir_state_t_seldef_bst_pc_def] >>
     Cases_on `bir_state_is_terminated
                 (bir_exec_stmtE prog bl.bb_last_statement
                    st'_test)` >> (

--- a/src/theory/bir/bir_envScript.sml
+++ b/src/theory/bir/bir_envScript.sml
@@ -290,43 +290,36 @@ Theorem bir_vs_consistent_IMP_includes_envty_of_vs:
              (bir_envty_includes_vs (bir_envty_of_vs vs) vs)
 Proof
 SIMP_TAC std_ss [bir_vs_consistent_def, bir_envty_of_vs_def, bir_envty_includes_vs_def, bir_envty_includes_v_def] >>
-  REPEAT STRIP_TAC >>
-  RW_TAC std_ss [] >>
-
-  ASM_SIMP_TAC (std_ss++pred_setSimps.PRED_SET_ss) [] >>
-  `vs DIFF {BVar vn' vt' | (vn',vt') | bir_var_name v <> vn'} = {v}` by (
-    SIMP_TAC std_ss [GSPEC_IMAGE, o_DEF, EXTENSION, IMAGE_applied, IN_DIFF, IN_APP, SING_applied] >>
-    GEN_TAC >> Cases_on `x = v` >- (
-      ASM_SIMP_TAC (std_ss) [] >>
-      POP_ASSUM (K ALL_TAC) >>
-      `vs v` by METIS_TAC [IN_APP] >>
-      ASM_SIMP_TAC (std_ss) [] >>
-      POP_ASSUM (K ALL_TAC) >>
-
-      GEN_TAC >>
-      Cases_on `x'` >> Cases_on `v` >>
-      ASM_SIMP_TAC (std_ss) [bir_var_eq_EXPAND, bir_var_name_def, bir_var_type_def] >>
-      METIS_TAC []
-    ) >>
+REPEAT STRIP_TAC >>
+ASM_SIMP_TAC (std_ss++pred_setSimps.PRED_SET_ss) [] >>
+`vs DIFF {BVar vn' vt' | (vn',vt') | bir_var_name v <> vn'} = {v}` by (
+  SIMP_TAC std_ss [GSPEC_IMAGE, o_DEF, EXTENSION, IMAGE_applied, IN_DIFF, IN_APP, SING_applied] >>
+  GEN_TAC >> Cases_on `x = v` >- (
     ASM_SIMP_TAC (std_ss) [] >>
-    Cases_on `x IN vs` >- (
-      `vs x` by METIS_TAC [IN_APP] >>
-      ASM_SIMP_TAC (std_ss) [] >>
+    POP_ASSUM (K ALL_TAC) >>
+    `vs v` by METIS_TAC [IN_APP] >>
+    ASM_SIMP_TAC (std_ss) [] >>
+    POP_ASSUM (K ALL_TAC) >>
 
-      Cases_on `x` >> Cases_on `v` >>
-      Q.EXISTS_TAC `(s,b)` >>
-      ASM_SIMP_TAC (std_ss) [] >>
-      METIS_TAC [bir_var_name_def, bir_var_type_def]
-    ) >>
-    `~(vs x)` by METIS_TAC [IN_APP] >>
-    ASM_SIMP_TAC (std_ss) []
-  ) >|
-  [
-    Q.EXISTS_TAC `v` >>
-    fs[]
-  ,
-    ASM_SIMP_TAC std_ss [CHOICE_SING]
-  ]
+    GEN_TAC >>
+    Cases_on `x'` >> Cases_on `v` >>
+    ASM_SIMP_TAC (std_ss) [bir_var_eq_EXPAND, bir_var_name_def, bir_var_type_def] >>
+    METIS_TAC []
+  ) >>
+  ASM_SIMP_TAC (std_ss) [] >>
+  Cases_on `x IN vs` >- (
+    `vs x` by METIS_TAC [IN_APP] >>
+    ASM_SIMP_TAC (std_ss) [] >>
+
+    Cases_on `x` >> Cases_on `v` >>
+    Q.EXISTS_TAC `(s,b)` >>
+    ASM_SIMP_TAC (std_ss) [] >>
+    METIS_TAC [bir_var_name_def, bir_var_type_def]
+  ) >>
+  `~(vs x)` by METIS_TAC [IN_APP] >>
+  ASM_SIMP_TAC (std_ss) []
+) >>
+ASM_SIMP_TAC std_ss [CHOICE_SING]
 QED
 
 Theorem bir_envty_includes_vs_EMPTY:

--- a/src/theory/bir/bir_exp_memScript.sml
+++ b/src/theory/bir/bir_exp_memScript.sml
@@ -864,8 +864,15 @@ SIMP_TAC std_ss [bir_store_in_mem_used_addrs_def, bir_load_from_mem_used_addrs_d
 SIMP_TAC (list_ss++bir_endian_ss) [DISJ_IMP_THM, LEFT_AND_OVER_OR, FORALL_AND_THM,
   listTheory.MEM_MAP, rich_listTheory.MEM_COUNT_LIST] >>
 REPEAT STRIP_TAC >> (
-  MATCH_MP_TAC bir_update_mmap_UNCHANGED >>
+  MATCH_MP_TAC bir_update_mmap_UNCHANGED
+) >- (
   METIS_TAC[bitstring_split_LENGTHS_b2v, listTheory.LENGTH_REVERSE]
+) >- (
+  METIS_TAC[bitstring_split_LENGTHS_b2v, listTheory.LENGTH_REVERSE]
+) >- (
+  IMP_RES_TAC bitstring_split_LENGTHS_b2v >>
+  rpt strip_tac >>
+  gs[]
 )
 QED
 

--- a/src/theory/bir/bir_programSyntax.sig
+++ b/src/theory/bir/bir_programSyntax.sig
@@ -213,7 +213,7 @@ sig
    val dest_bir_state_is_terminated : term -> term
    val is_bir_state_is_terminated   : term -> bool
    val mk_bir_state_is_terminated   : term -> term
-
+(*
    val bst_status_tm   : term
    val dest_bst_status : term -> term
    val is_bst_status   : term -> bool
@@ -228,7 +228,7 @@ sig
    val dest_bst_pc : term -> term
    val is_bst_pc   : term -> bool
    val mk_bst_pc   : term -> term
-
+*)
 
    (***************************)
    (* various functions       *)

--- a/src/theory/bir/bir_programSyntax.sml
+++ b/src/theory/bir/bir_programSyntax.sml
@@ -246,13 +246,14 @@ in
   TypeBase.mk_record (bir_state_t_ty, l)
 end handle e => raise wrap_exn "mk_bir_state" e;
 
-
+(* TODO: What's the counterpart of these in Trindemossen? *)
+(*
 val (bst_status_tm,  mk_bst_status, dest_bst_status, is_bst_status)  = syntax_fns1 "bir_state_t_bst_status";
 
 val (bst_environ_tm,  mk_bst_environ, dest_bst_environ, is_bst_environ)  = syntax_fns1 "bir_state_t_bst_environ";
 
 val (bst_pc_tm,  mk_bst_pc, dest_bst_pc, is_bst_pc)  = syntax_fns1 "bir_state_t_bst_pc";
-
+*)
 
 val (bir_state_init_tm,  mk_bir_state_init, dest_bir_state_init, is_bir_state_init)  = syntax_fns1 "bir_state_init";
 

--- a/src/theory/program_logic/partial_program_logicScript.sml
+++ b/src/theory/program_logic/partial_program_logicScript.sml
@@ -155,7 +155,7 @@ subgoal `!l1'. (l1' IN ls1') ==> (t_jgmt TS l1' ls2 (\st. (TS.ctrl st IN ls1' ==
 ) >>
 imp_res_tac total_seq_rule_thm >>
 gs [t_jgmt_def] >>
-subgoal `s' = st'` >- (
+subgoal `s' = st''` >- (
  (* Both reached by TS.weak s ls2 *)
   metis_tac [weak_unique]
 ) >>

--- a/src/theory/program_logic/transition_systemScript.sml
+++ b/src/theory/program_logic/transition_systemScript.sml
@@ -677,9 +677,6 @@ Cases_on `n = 0` >- (
   metis_tac [weak_ctrl_in, pred_setTheory.SUBSET_THM],
 
   rpt strip_tac >>
-  subgoal `n_l' = 0` >- (
-   fs [] 
-  ) >>
   fs [weak_exec_n_def, FUNPOW_OPT_compute]
  ]
 ) >>
@@ -752,9 +749,6 @@ Cases_on `n'' = n'` >- (
  ) >>
  fs [whileTheory.OLEAST_EQ_SOME] >>
  rpt strip_tac >>
- subgoal `n_l = 0` >- (
-  fs []
- ) >>
  fs [weak_exec_n_def, FUNPOW_OPT_compute]
 ) >>
 subgoal `n'' < n'` >- (

--- a/src/theory/tools/lifter/bir_inst_liftingScript.sml
+++ b/src/theory/tools/lifter/bir_inst_liftingScript.sml
@@ -289,16 +289,16 @@ End
 (* Auxiliary definitions *)
 (*-----------------------*)
 
-val bir_is_lifted_inst_block_COMPUTE_ms'_COND_def = Define
-  `bir_is_lifted_inst_block_COMPUTE_ms'_COND r ms al_step ms' <=>
+Definition bir_is_lifted_inst_block_COMPUTE_ms'_COND_def:
+   bir_is_lifted_inst_block_COMPUTE_ms'_COND r ms al_step ms' <=>
      (* We can compute the next machine state using extra assumptions in al_step *)
      ((EVERY (\a. bir_assert_desc_value a) al_step) ==>
       (r.bmr_step_fun ms = SOME ms')) /\
 
      (* This machine step satisfies the machine state invariants *)
      ((EVERY (\a. bir_assert_desc_value a) al_step) ==>
-      r.bmr_extra ms')`
-
+      r.bmr_extra ms')
+End
 
 Definition bir_is_lifted_inst_block_COMPUTE_imm_ups_COND_def:
   bir_is_lifted_inst_block_COMPUTE_imm_ups_COND r ms ms' imm_ups updates <=>
@@ -542,10 +542,11 @@ QED
 (* Auxiliary definitions *)
 (*-----------------------*)
 
-val bir_is_lifted_inst_block_COMPUTE_ms'_COND_WITH_DESC_OK_def = Define
-  `bir_is_lifted_inst_block_COMPUTE_ms'_COND_WITH_DESC_OK r bs ms al_step ms' <=>
+Definition bir_is_lifted_inst_block_COMPUTE_ms'_COND_WITH_DESC_OK_def:
+  bir_is_lifted_inst_block_COMPUTE_ms'_COND_WITH_DESC_OK r bs ms al_step ms' <=>
    (bir_is_lifted_inst_block_COMPUTE_ms'_COND r ms al_step ms' /\
-    EVERY (bir_assert_desc_OK bs.bst_environ) al_step)`;
+    EVERY (bir_assert_desc_OK bs.bst_environ) al_step)
+End
 
 Definition bir_is_lifted_inst_block_COMPUTE_al_mem_COND_WITH_DESC_OK_def:
   bir_is_lifted_inst_block_COMPUTE_al_mem_COND_WITH_DESC_OK r mu bs ms ms' al_mem <=>
@@ -1456,9 +1457,6 @@ SIMP_TAC list_ss [bir_is_lifted_inst_block_COMPUTE_updates_FULL_REL_def,
   LET_THM, bir_updateB_desc_exp_def, bir_updateB_desc_value_def,
   bir_updateB_desc_var_def, IN_IMAGE] >>
 REPEAT STRIP_TAC >- (
-  `i = 0` by DECIDE_TAC >>
-  FULL_SIMP_TAC std_ss []
-) >- (
   METIS_TAC[]
 )
 QED

--- a/src/theory/tools/lifter/bir_m0_extrasScript.sml
+++ b/src/theory/tools/lifter/bir_m0_extrasScript.sml
@@ -379,13 +379,6 @@ SIMP_TAC (list_ss++wordsLib.WORD_ss) [m0_mem_store_half_BE_def, WI_MEM_WI_size, 
 QED
 
 
-Theorem m0_LIFT_STORE_HALF_LE_CHANGE_INTERVAL:
-  !va vv mem_f. FUNS_EQ_OUTSIDE_WI_size va 2 (m0_mem_store_half_LE va vv mem_f) mem_f
-Proof
-SIMP_TAC (list_ss++wordsLib.WORD_ss) [m0_mem_store_half_LE_def, WI_MEM_WI_size, WI_ELEM_LIST_compute, w2n_n2w, updateTheory.APPLY_UPDATE_THM, FUNS_EQ_OUTSIDE_WI_size_def]
-QED
-
-
 Theorem m0_LIFT_STORE_BYTE_CHANGE_INTERVAL:
   !va vv mem_f. FUNS_EQ_OUTSIDE_WI_size va 1 (m0_mem_store_byte va vv mem_f) mem_f
 Proof

--- a/src/theory/tools/wp/bir_wpScript.sml
+++ b/src/theory/tools/wp/bir_wpScript.sml
@@ -505,7 +505,6 @@ rename1 `BVar vname2 vtype2 IN bir_vars_of_exp post` >>
 
      bir_env_vars_are_initialised (BEnv f)
        (bir_vars_of_exp (bir_exp_subst1 (BVar vname vtype) ex post)
-QED
 
  * which together with the assumption
 
@@ -577,7 +576,7 @@ subgoal `(BVar vname2 vtype2) IN
     [bir_exp_subst1_USED_VARS]
 ) >>
 METIS_TAC [bir_var_name_def, bir_var_type_def, combinTheory.UPDATE_APPLY]
-);
+QED
 
 (* Preservation of valid status for the Assign statement *)
 Theorem bir_assign_valid_status:

--- a/src/tools/symbexec/bir_symb_soundScript.sml
+++ b/src/tools/symbexec/bir_symb_soundScript.sml
@@ -1343,7 +1343,7 @@ Definition bir_prog_has_no_halt_def:
     (bir_prog_has_no_halt (BirProgram t)))
   )
 End
-Theorem bir_prog_has_no_halt_thm:
+Theorem bir_prog_has_no_halt_block_thm:
   !blocks block.
   (bir_prog_has_no_halt (BirProgram blocks)) ==>
   (MEM block blocks) ==>
@@ -1402,7 +1402,7 @@ REPEAT STRIP_TAC >>
     METIS_TAC [INDEX_FIND_IMP_MEM_thm]
   ) >>
 
-  METIS_TAC [bir_prog_has_no_halt_thm, bir_block_has_no_halt_def]
+  METIS_TAC [bir_prog_has_no_halt_block_thm, bir_block_has_no_halt_def]
 QED
 
 Theorem birs_exec_stmtE_sound_thm:


### PR DESCRIPTION
Two fishy things remain:

* Had to use `allow_rebind` in [one place](https://github.com/kth-step/HolBA/blob/4666d490db55edceb3a115f7792b3ee439b49643/src/theory/bir-support/bir_interval_expScript.sml#L122-L124) in `bir_interval_expScript.sml` - the theorem doesn't need to be there when using the REPL but needs to be there when using Holmake, but having it still triggers redefinition error for some reason. Confusing.

* There are some syntax functions in `bir_programSyntax.sml` ([here](https://github.com/kth-step/HolBA/blob/4666d490db55edceb3a115f7792b3ee439b49643/src/theory/bir/bir_programSyntax.sml#L249-L256))for which I can't find Trindemossen counterparts - those aren't used anywhere AFAIK, so I commented them out. Ideally we find their new names.