### PR TITLE
Heapless build option for riscv-symbexec branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,19 +19,20 @@ jobs:
 
     strategy:
       matrix:
-        polyml: ['v5.7.1', 'v5.9.1']
+        polyml: [{version: 'v5.7.1'}, {version: 'v5.9.1', heapless: '1'}]
         z3: ['4.8.4']
         hol4: ['trindemossen-1']
 
     env:
-      HOLBA_POLYML_VERSION: ${{ matrix.polyml }}
+      HOLBA_POLYML_VERSION: ${{ matrix.polyml.version }}
+      HOLBA_POLYML_HEAPLESS: ${{ matrix.polyml.heapless }}
       HOLBA_Z3_VERSION: ${{ matrix.z3 }}
       HOLBA_Z3_ASSET_SUFFIX: '.d6df51951f4c-x64-debian-8.11.zip'
       HOLBA_HOL4_VERSION: ${{ matrix.hol4 }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
         id: cache-deps

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,7 @@ jobs:
           ./scripts/ci/run_holmake.sh
 
       - name: Run tests
-        timeout-minutes: 35
+        timeout-minutes: 40
         run: |
           ./scripts/ci/run_make.sh tests
 

--- a/examples/riscv/README.md
+++ b/examples/riscv/README.md
@@ -33,7 +33,7 @@ See the [general README](https://github.com/kth-step/HolBA/blob/master/README.md
 
 ### 0. RISC-V program
 
-- RISC-V programs must be given in `.da` format for RV64
+- RISC-V programs must be given in `.da` format for RV64G
 - C programs should ideally be compiled with `-O1` before disassembly (fewer instructions, close correspondence)
 
 Example C function that increments an unsigned 64-bit integer:
@@ -71,8 +71,8 @@ Disassembly of section .text:
 
 - requires manual specification of code area addresses, for all code included in the binary program
 - the lifting stores HOL4 constants for the BIR program, the original binary program, and a lifting theorem for use in backlifting
-- **automatic** once arguments (program memory boundaries) are given inside HOL4
-- Notice: the code area addresses have to be accurate, i.e., the end boundary is the address of the last instruction plus 4 in case of RISC-V with 32-bit instructions
+- **automatic** once arguments (names and code area boundaries) are given inside HOL4
+- the code area addresses have to be accurate, i.e., the end boundary is the address of the last instruction plus 4 in case of 32-bit instructions as in RV64G
 
 Example:
 
@@ -277,7 +277,7 @@ Example:
 
 ```sml
 Theorem riscv_incr_contract_thm:
- riscv_cont bir_foo_progbin incr_init_addr {incr_end_addr}
+ riscv_cont bir_incr_progbin incr_init_addr {incr_end_addr}
   (riscv_incr_pre pre_x10) (riscv_incr_post pre_x10)
 Proof
 (* application of backlifting automation *)

--- a/examples/riscv/aes-unopt/Holmakefile
+++ b/examples/riscv/aes-unopt/Holmakefile
@@ -24,6 +24,7 @@ all: $(DEFAULT_TARGETS)
 .PHONY: all
 
 ifdef POLY
-HOLHEAP = $(HOLBADIR)/examples/riscv/common/examples-riscv-common-heap
+ifndef HOLBA_POLYML_HEAPLESS
+HOLHEAP = $(HOLBADIR)/examples/riscv/common/holba-riscv-heap
 endif
-
+endif

--- a/examples/riscv/aes/Holmakefile
+++ b/examples/riscv/aes/Holmakefile
@@ -24,6 +24,7 @@ all: $(DEFAULT_TARGETS)
 .PHONY: all
 
 ifdef POLY
-HOLHEAP = $(HOLBADIR)/examples/riscv/common/examples-riscv-common-heap
+ifndef HOLBA_POLYML_HEAPLESS
+HOLHEAP = $(HOLBADIR)/examples/riscv/common/holba-riscv-heap
 endif
-
+endif

--- a/examples/riscv/common/Holmakefile
+++ b/examples/riscv/common/Holmakefile
@@ -11,17 +11,15 @@ all: $(DEFAULT_TARGETS)
 .PHONY: all
 
 ifdef POLY
-all: examples-riscv-common-heap
+all: holba-riscv-heap
 
 HEAPINC = $(HOLBADIR)/src/tools/lifter/bir_lifter_interfaceLib.uo \
           $(HOLBADIR)/src/tools/backlifter/bir_backlifterLib.uo \
           $(HOLBADIR)/src/shared/HolSmt/HolBA_HolSmtLib.uo \
           $(HOLBADIR)/src/tools/symbexec/birs_auxLib.uo
-# \
-#          distribute_generic_stuffLib.uo #\
-#          bir_symbLib.uo
 
-examples-riscv-common-heap: $(HEAPINC) Holmakefile
+holba-riscv-heap: $(HEAPINC)
 	$(HOLDIR)/bin/buildheap -o $@ $(patsubst %.uo,-f %.uo,$(HEAPINC))
-endif
 
+EXTRA_CLEANS = holba-riscv-heap
+endif

--- a/examples/riscv/common/Holmakefile
+++ b/examples/riscv/common/Holmakefile
@@ -11,15 +11,15 @@ all: $(DEFAULT_TARGETS)
 .PHONY: all
 
 ifdef POLY
-all: holba-riscv-heap
+HEAP = holba-riscv-heap
+DEPS = $(HOLBADIR)/src/tools/lifter/bir_lifter_interfaceLib.uo \
+       $(HOLBADIR)/src/tools/backlifter/bir_backlifterLib.uo \
+       $(HOLBADIR)/src/shared/HolSmt/HolBA_HolSmtLib.uo \
+       $(HOLBADIR)/src/tools/symbexec/birs_auxLib.uo
+EXTRA_CLEANS += $(HEAP)
 
-HEAPINC = $(HOLBADIR)/src/tools/lifter/bir_lifter_interfaceLib.uo \
-          $(HOLBADIR)/src/tools/backlifter/bir_backlifterLib.uo \
-          $(HOLBADIR)/src/shared/HolSmt/HolBA_HolSmtLib.uo \
-          $(HOLBADIR)/src/tools/symbexec/birs_auxLib.uo
+all: $(HEAP)
 
-holba-riscv-heap: $(HEAPINC)
-	$(HOLDIR)/bin/buildheap -o $@ $(patsubst %.uo,-f %.uo,$(HEAPINC))
-
-EXTRA_CLEANS = holba-riscv-heap
+$(HEAP): $(DEPS)
+	$(HOLDIR)/bin/buildheap -o $@ $(patsubst %.uo,-f %.uo,$(DEPS))
 endif

--- a/examples/riscv/incr-mem/Holmakefile
+++ b/examples/riscv/incr-mem/Holmakefile
@@ -24,6 +24,8 @@ all: $(DEFAULT_TARGETS)
 .PHONY: all
 
 ifdef POLY
-HOLHEAP = $(HOLBADIR)/examples/riscv/common/examples-riscv-common-heap
+ifndef HOLBA_POLYML_HEAPLESS
+HOLHEAP = $(HOLBADIR)/examples/riscv/common/holba-riscv-heap
+endif
 endif
 

--- a/examples/riscv/incr/Holmakefile
+++ b/examples/riscv/incr/Holmakefile
@@ -24,6 +24,7 @@ all: $(DEFAULT_TARGETS)
 .PHONY: all
 
 ifdef POLY
-HOLHEAP = $(HOLBADIR)/examples/riscv/common/examples-riscv-common-heap
+ifndef HOLBA_POLYML_HEAPLESS
+HOLHEAP = $(HOLBADIR)/examples/riscv/common/holba-riscv-heap
 endif
-
+endif

--- a/examples/riscv/isqrt/Holmakefile
+++ b/examples/riscv/isqrt/Holmakefile
@@ -25,6 +25,7 @@ all: $(DEFAULT_TARGETS)
 .PHONY: all
 
 ifdef POLY
-HOLHEAP = $(HOLBADIR)/examples/riscv/common/examples-riscv-common-heap
+ifndef HOLBA_POLYML_HEAPLESS
+HOLHEAP = $(HOLBADIR)/examples/riscv/common/holba-riscv-heap
 endif
-
+endif

--- a/examples/riscv/mod2-mem/Holmakefile
+++ b/examples/riscv/mod2-mem/Holmakefile
@@ -24,6 +24,7 @@ all: $(DEFAULT_TARGETS)
 .PHONY: all
 
 ifdef POLY
-HOLHEAP = $(HOLBADIR)/examples/riscv/common/examples-riscv-common-heap
+ifndef HOLBA_POLYML_HEAPLESS
+HOLHEAP = $(HOLBADIR)/examples/riscv/common/holba-riscv-heap
 endif
-
+endif

--- a/examples/riscv/mod2/Holmakefile
+++ b/examples/riscv/mod2/Holmakefile
@@ -25,6 +25,7 @@ all: $(DEFAULT_TARGETS)
 .PHONY: all
 
 ifdef POLY
-HOLHEAP = $(HOLBADIR)/examples/riscv/common/examples-riscv-common-heap
+ifndef HOLBA_POLYML_HEAPLESS
+HOLHEAP = $(HOLBADIR)/examples/riscv/common/holba-riscv-heap
 endif
-
+endif

--- a/examples/riscv/modexp/Holmakefile
+++ b/examples/riscv/modexp/Holmakefile
@@ -24,6 +24,7 @@ all: $(DEFAULT_TARGETS)
 .PHONY: all
 
 ifdef POLY
-HOLHEAP = $(HOLBADIR)/examples/riscv/common/examples-riscv-common-heap
+ifndef HOLBA_POLYML_HEAPLESS
+HOLHEAP = $(HOLBADIR)/examples/riscv/common/holba-riscv-heap
 endif
-
+endif

--- a/examples/riscv/motor/Holmakefile
+++ b/examples/riscv/motor/Holmakefile
@@ -24,6 +24,7 @@ all: $(DEFAULT_TARGETS)
 .PHONY: all
 
 ifdef POLY
-HOLHEAP = $(HOLBADIR)/examples/riscv/common/examples-riscv-common-heap
+ifndef HOLBA_POLYML_HEAPLESS
+HOLHEAP = $(HOLBADIR)/examples/riscv/common/holba-riscv-heap
 endif
-
+endif

--- a/examples/riscv/perftest/Holmakefile
+++ b/examples/riscv/perftest/Holmakefile
@@ -24,6 +24,7 @@ all: $(DEFAULT_TARGETS)
 .PHONY: all
 
 ifdef POLY
-HOLHEAP = $(HOLBADIR)/examples/riscv/common/examples-riscv-common-heap
+ifndef HOLBA_POLYML_HEAPLESS
+HOLHEAP = $(HOLBADIR)/examples/riscv/common/holba-riscv-heap
 endif
-
+endif

--- a/examples/riscv/swap/Holmakefile
+++ b/examples/riscv/swap/Holmakefile
@@ -23,6 +23,7 @@ all: $(DEFAULT_TARGETS)
 .PHONY: all
 
 ifdef POLY
-HOLHEAP = $(HOLBADIR)/examples/riscv/common/examples-riscv-common-heap
+ifndef HOLBA_POLYML_HEAPLESS
+HOLHEAP = $(HOLBADIR)/examples/riscv/common/holba-riscv-heap
 endif
-
+endif

--- a/examples/riscv/symbexectests/Holmakefile
+++ b/examples/riscv/symbexectests/Holmakefile
@@ -24,6 +24,8 @@ all: $(DEFAULT_TARGETS)
 .PHONY: all
 
 ifdef POLY
-HOLHEAP = $(HOLBADIR)/examples/riscv/common/examples-riscv-common-heap
+ifndef HOLBA_POLYML_HEAPLESS
+HOLHEAP = $(HOLBADIR)/examples/riscv/common/holba-riscv-heap
+endif
 endif
 


### PR DESCRIPTION
Using environment variable `HOLBA_POLYML_HEAPLESS`.